### PR TITLE
fix: per-terminal state leaks, EPIPE crash, test-host hangs

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -8,7 +8,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// How often to clean up orphan zmx sessions (5 minutes).
     private let orphanCleanupInterval: TimeInterval = 300
 
+    /// True when the process is hosting XCTest. The unit tests exercise types
+    /// directly and never need the real app (window, Ghostty, git discovery,
+    /// hook installers). Skipping bootstrap keeps them hermetic and prevents the
+    /// test runner from hanging when git on an external volume stalls at launch.
+    static var isRunningUnitTests: Bool {
+        NSClassFromString("XCTestCase") != nil
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
+        guard !Self.isRunningUnitTests else { return }
         // Register bundled JetBrains Mono before any view builds its fonts.
         AppFont.registerBundledFonts()
 

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -780,6 +780,10 @@ class TabCoordinator {
     // MARK: - Worktree Lifecycle
 
     func worktreeDidDelete(_ info: WorktreeInfo) {
+        // Idempotent surface teardown: every current caller already removed the
+        // tree, but destroying here too means a future call path can't leak the
+        // worktree's stations (removeTree on a missing path is a no-op).
+        _ = terminalCoordinator.stationManager.removeTree(forPath: info.path)
         let repoPath = worktreeRepoCache[info.path]
         allWorktrees.removeAll { $0.info.path == info.path }
         worktreeRepoCache.removeValue(forKey: info.path)
@@ -788,9 +792,13 @@ class TabCoordinator {
             let remaining = workspaceManager.tabs[tabIndex].worktrees.filter { $0.path != info.path }
             workspaceManager.updateWorktrees(at: tabIndex, worktrees: remaining)
         }
-        if let agent = ShipLog.shared.sailor(forWorktree: info.path) {
-            ShipLog.shared.unregister(terminalID: agent.id)
+        // Unregister EVERY pane of the worktree (split worktrees have N agents;
+        // taking just the first leaked the rest for the app's lifetime).
+        for terminalID in ShipLog.shared.terminalIDs(forWorktree: info.path) {
+            ShipLog.shared.unregister(terminalID: terminalID)
         }
+        WorktreeTitleCache.shared.evict(worktreePath: info.path)
+        WorktreeGitStatsCache.shared.evict(worktreePath: info.path)
         dashboardVC?.invalidateSplitContainer(forPath: info.path)
         dashboardVC?.updateSailors(buildSailorDisplayInfos())
         statusPublisher.updateSurfaces(terminalCoordinator.stationManager.all)
@@ -809,11 +817,15 @@ class TabCoordinator {
             let primaryStation = terminalCoordinator.stationManager.primaryStation(forPath: worktree.path)
             terminalCoordinator.stationManager.removeTree(forPath: worktree.path)
 
-            if let agent = ShipLog.shared.sailor(forWorktree: worktree.path) {
-                ShipLog.shared.unregister(terminalID: agent.id)
-            } else if let primaryStation {
+            // Unregister EVERY pane of the worktree, not just the first sailor.
+            let ids = ShipLog.shared.terminalIDs(forWorktree: worktree.path)
+            if ids.isEmpty, let primaryStation {
                 ShipLog.shared.unregister(terminalID: primaryStation.id)
+            } else {
+                for id in ids { ShipLog.shared.unregister(terminalID: id) }
             }
+            WorktreeTitleCache.shared.evict(worktreePath: worktree.path)
+            WorktreeGitStatsCache.shared.evict(worktreePath: worktree.path)
             if runtimeBackend != "local" {
                 let sessionName = SessionManager.persistentSessionName(for: worktree.path)
                 SessionManager.killSession(sessionName, backend: runtimeBackend)

--- a/Sources/App/TerminalCoordinator.swift
+++ b/Sources/App/TerminalCoordinator.swift
@@ -237,6 +237,7 @@ class TerminalCoordinator {
             station.destroy()
         }
         StationRegistry.shared.unregister(closed.stationId)
+        ShipLog.shared.unregister(terminalID: closed.stationId)
         container.surfaceViews.removeValue(forKey: closed.stationId)
         container.layoutTree()
 

--- a/Sources/Core/ShipLog.swift
+++ b/Sources/Core/ShipLog.swift
@@ -120,6 +120,9 @@ class ShipLog {
         agents.removeValue(forKey: terminalID)
         channels.removeValue(forKey: terminalID)
         orderedIDs.removeAll { $0 == terminalID }
+        statusEnteredAt.removeValue(forKey: terminalID)
+        hookRunningSince.removeValue(forKey: terminalID)
+        eventLog.removeValue(forKey: terminalID)
     }
 
     // MARK: - Worktree Index (1:N)

--- a/Sources/Core/WorktreeTitleCache.swift
+++ b/Sources/Core/WorktreeTitleCache.swift
@@ -17,6 +17,12 @@ final class WorktreeTitleCache {
         return entries[worktreePath]?.title
     }
 
+    /// Drop the entry for a deleted worktree so churn doesn't grow the cache unbounded.
+    func evict(worktreePath: String) {
+        lock.lock(); defer { lock.unlock() }
+        entries.removeValue(forKey: worktreePath)
+    }
+
     /// Resolves the title, serving a fresh cache entry without disk access or
     /// resolving off the main thread on a miss/stale. `completion` runs on main.
     func title(worktreePath: String, lastUserPrompt: String, branch: String,

--- a/Sources/Git/WorktreeGitStats.swift
+++ b/Sources/Git/WorktreeGitStats.swift
@@ -98,6 +98,12 @@ final class WorktreeGitStatsCache {
         return entries[worktreePath]?.stats
     }
 
+    /// Drop the entry for a deleted worktree so churn doesn't grow the cache unbounded.
+    func evict(worktreePath: String) {
+        lock.lock(); defer { lock.unlock() }
+        entries.removeValue(forKey: worktreePath)
+    }
+
     /// Serves a fresh cache entry without disk access, or resolves off-main on a
     /// miss/stale. `completion` runs on main with the resolved stats.
     func refresh(worktreePath: String, completion: @escaping (WorktreeGitStats) -> Void = { _ in }) {

--- a/Sources/Status/StatusPublisher.swift
+++ b/Sources/Status/StatusPublisher.swift
@@ -94,9 +94,21 @@ class StatusPublisher {
         timer = nil
     }
 
+    /// Drop all per-terminal state for a dead pane. Caller must hold `lock`.
+    private func removeTerminalStateLocked(_ terminalID: String) {
+        trackers.removeValue(forKey: terminalID)
+        lastMessages.removeValue(forKey: terminalID)
+        runningStartTimes.removeValue(forKey: terminalID)
+        lastViewportHashes.removeValue(forKey: terminalID)
+        probedTypes.removeValue(forKey: terminalID)
+        probedAtCycle.removeValue(forKey: terminalID)
+    }
+
     func updateSurfaces(_ trees: [String: SplitTree]) {
         let inputWorktreePaths = Array(trees.keys)
         lock.lock()
+        let oldSurfaceIDs = Set(self.surfaces.keys)
+        let oldPaths = self.worktreePaths
         self.surfaces = [:]
         self.worktreePaths = [:]
         for (worktreePath, tree) in trees {
@@ -113,7 +125,19 @@ class StatusPublisher {
                 trackers[terminalID] = DebouncedStatusTracker()
             }
         }
+        // Self-healing: drop per-terminal state for panes that disappeared
+        // (pane closed, worktree deleted). Without this, trackers/hashes/probe
+        // caches grow for the app's lifetime.
+        let goneIDs = oldSurfaceIDs.subtracting(self.surfaces.keys)
+        for id in goneIDs { removeTerminalStateLocked(id) }
         lock.unlock()
+
+        // Aggregator is main-queue only; updateSurfaces is called from main.
+        for id in goneIDs {
+            if let path = oldPaths[id] {
+                aggregator?.unregisterTerminal(id, worktreePath: path)
+            }
+        }
 
         for (worktreePath, tree) in trees {
             let leaves = tree.allLeaves

--- a/Sources/Status/WorktreeStatusAggregator.swift
+++ b/Sources/Status/WorktreeStatusAggregator.swift
@@ -55,6 +55,7 @@ class WorktreeStatusAggregator {
         if worktreeTerminals[worktreePath]?.isEmpty == true {
             worktreeTerminals.removeValue(forKey: worktreePath)
             worktreeStatuses.removeValue(forKey: worktreePath)
+            lastActivityAt.removeValue(forKey: worktreePath)
         }
     }
 

--- a/Sources/Terminal/Station.swift
+++ b/Sources/Terminal/Station.swift
@@ -208,9 +208,11 @@ class Station {
 
     /// Check if the process has exited
     var processExited: Bool {
-        guard let surface else { return true }
+        // Read `surface` inside the lock: destroy() frees it under the same
+        // lock, so a pointer captured before locking could dangle.
         ghosttyLock.lock()
         defer { ghosttyLock.unlock() }
+        guard let surface else { return true }
         return ghostty_surface_process_exited(surface)
     }
 
@@ -247,14 +249,17 @@ class Station {
     }
 
     func readViewportText() -> String? {
-        guard let surface else { return nil }
-
         // Hold ghosttyLock only for the C calls plus a raw byte copy. Building
         // the String (UTF-8 validation + allocation over a full viewport) used
         // to happen inside the lock, stalling main-thread input that contends
-        // for it during every background status poll.
+        // for it during every background status poll. `surface` must be read
+        // inside the lock — destroy() frees it under the same lock.
         var bytes: [UInt8]?
         ghosttyLock.lock()
+        guard let surface else {
+            ghosttyLock.unlock()
+            return nil
+        }
         let size = ghostty_surface_size(surface)
         if size.rows > 0, size.columns > 0 {
             var selection = ghostty_selection_s()
@@ -312,9 +317,9 @@ class Station {
 
     /// Get the process status for status detection
     var processStatus: ProcessStatus {
-        guard let surface else { return .unknown }
         ghosttyLock.lock()
         defer { ghosttyLock.unlock() }
+        guard let surface else { return .unknown }
         if ghostty_surface_process_exited(surface) {
             // We don't have the exit code from ghostty, so assume exited
             return .exited
@@ -377,11 +382,17 @@ class Station {
     func destroy() {
         recoveryTimer?.cancel()
         recoveryTimer = nil
-        if let surface {
-            ghostty_surface_request_close(surface)
-        }
+        view?.surface = nil
         view?.removeFromSuperview()
+        // Free under ghosttyLock so the background status poll can't be mid-read
+        // on this surface. Freeing (not just request_close) is what tears down
+        // the PTY and renderer — request_close only fires the host callback.
+        ghosttyLock.lock()
+        if let surface {
+            ghostty_surface_free(surface)
+        }
         surface = nil
+        ghosttyLock.unlock()
         view = nil
         containerView = nil
     }

--- a/Sources/Usage/CodexUsageSummaryProvider.swift
+++ b/Sources/Usage/CodexUsageSummaryProvider.swift
@@ -87,8 +87,12 @@ struct CodexAppServerRateLimitClient {
                 #"{"method":"initialized"}"#,
                 #"{"id":2,"method":"account/rateLimits/read"}"#
             ].joined(separator: "\n") + "\n"
-            stdin.fileHandleForWriting.write(Data(input.utf8))
-            stdin.fileHandleForWriting.closeFile()
+            // write(contentsOf:) throws a Swift error on EPIPE; the legacy
+            // write(_:) raises an ObjC NSFileHandleOperationException that no
+            // Swift catch can intercept — it crashed the app when the codex
+            // process exited before reading stdin.
+            try stdin.fileHandleForWriting.write(contentsOf: Data(input.utf8))
+            try stdin.fileHandleForWriting.close()
 
             guard waitUntilExit(process, timeout: timeout) else {
                 terminate(process)

--- a/Tests/WorktreeStatusAggregatorTests.swift
+++ b/Tests/WorktreeStatusAggregatorTests.swift
@@ -50,8 +50,10 @@ final class WorktreeStatusAggregatorTests: XCTestCase {
         let ws = mockDelegate.lastUpdatedStatus!
         XCTAssertEqual(ws.panes.count, 2)
         XCTAssertEqual(ws.statuses, [.running, .idle])
-        XCTAssertEqual(ws.mostRecentMessage, "done")
-        XCTAssertEqual(ws.mostRecentPaneIndex, 2)
+        // Representative pane = highest rollup rank (running t1 beats idle t2),
+        // so status/message/index all describe that pane.
+        XCTAssertEqual(ws.mostRecentMessage, "building")
+        XCTAssertEqual(ws.mostRecentPaneIndex, 1)
     }
 
     func testStatusChangeFiresPaneCallback() {


### PR DESCRIPTION
## Summary

### Leak fixes
Closing a pane / deleting a worktree / closing a repo now fully cleans up per-terminal state across all three status components:

- **ShipLog.unregister** also clears `statusEnteredAt` / `hookRunningSince` / `eventLog`
- **StatusPublisher.updateSurfaces** prunes per-terminal state for panes that disappeared (trackers, message / running-time / viewport-hash / probe caches) and finally wires `aggregator.unregisterTerminal` — previously defined but never called
- **Aggregator** drops `lastActivityAt` when a worktree's last pane goes away
- **worktreeDidDelete / performCloseRepo** unregister *every* pane of a worktree instead of only the first sailor; `worktreeDidDelete` gains an idempotent `removeTree` so no call path can leak stations
- **WorktreeTitleCache / WorktreeGitStatsCache** gain `evict(worktreePath:)`, called on worktree deletion

### Crash fix
Codex rate-limit client wrote to the app-server's stdin with legacy `FileHandle.write(_:)`, which raises an uncatchable ObjC exception on EPIPE and **crashed the whole app** whenever the codex process exited before reading stdin. Switched to `write(contentsOf:)` so the failure lands in the existing catch and degrades to a log line.

### Test reliability
- `AppDelegate` skips the full app bootstrap under XCTest — unit tests no longer hang the runner when launch-time git discovery stalls
- Updated stale `testMultiPaneUpdate` to the representative-pane (rollupRank) semantics

### Thread safety (from concurrent session)
`Station` surface-pointer reads moved inside `ghosttyLock` (`destroy()` frees under the same lock; a pointer captured before locking could dangle).

## Test plan
- [x] `xcodebuild build` clean
- [x] 38 tests green: ShipLog suites, WorktreeStatusAggregator, SessionTitleLookup
- [x] EPIPE path verified: crash → graceful log

🤖 Generated with [Claude Code](https://claude.com/claude-code)