### PR TITLE
feat: pane-precise hook routing + AskUserQuestion cards

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -1594,6 +1594,13 @@ extension MainWindowController {
                 branch: order.action.branch,
                 deleteBranch: deleteBranch,
                 force: force)
+        } else if order.action.payload == "ask-user-question" {
+            // AskUserQuestion TUI selects by digit; typing the label text would
+            // land in the free-form field instead. Send the option's number —
+            // sendCommand follows with a Return that confirms the selection.
+            if let idx = order.action.options?.firstIndex(of: optionText) {
+                ShipLog.shared.sendCommand(to: order.action.terminalID, command: "\(idx + 1)")
+            }
         } else {
             ShipLog.shared.sendCommand(to: order.action.terminalID, command: optionText)
         }

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -586,7 +586,7 @@ class TabCoordinator {
                             // stash the agent's final message so the suggestion card can show it.
                             sessionBlockedAt[turnKey] = Date()
                             if let msg = event.data?["last_assistant_message"] as? String {
-                                ShipLog.shared.noteAssistantMessage(cwd: event.cwd, message: msg)
+                                ShipLog.shared.noteAssistantMessage(cwd: event.cwd, paneId: event.paneId, message: msg)
                             }
                             return block
                         }

--- a/Sources/Core/FirstMate.swift
+++ b/Sources/Core/FirstMate.swift
@@ -57,6 +57,19 @@ enum FirstMate {
     static func evaluate(_ outcome: IngestOutcome, config: FirstMateConfig) -> [FirstMateAction] {
         guard config.enabled else { return [] }
 
+        if case .question(let prompt, let options) = outcome.event.kind {
+            guard !options.isEmpty else { return [] }
+            let i = outcome.info
+            // AskUserQuestion card: the question itself is the summary, and the
+            // payload marks the tap handler to answer by option NUMBER (the TUI
+            // selects by digit), not by typing the label text.
+            return [FirstMateAction(kind: .suggestNextOrder, zone: .red,
+                                    worktreePath: i.worktreePath, branch: i.branch,
+                                    project: i.project, terminalID: i.id,
+                                    message: String(prompt.prefix(200)),
+                                    payload: "ask-user-question", options: options)]
+        }
+
         if case .suggest(let options) = outcome.event.kind {
             guard !options.isEmpty else { return [] }
             let i = outcome.info

--- a/Sources/Core/ShipLog.swift
+++ b/Sources/Core/ShipLog.swift
@@ -266,6 +266,11 @@ class ShipLog {
             next.hookStatus = .waiting
             hookRunningSince[event.terminalID] = nil
             message = text
+        case .question(let prompt, _):
+            // Agent is blocked on an AskUserQuestion choice — same as awaiting input.
+            next.hookStatus = .waiting
+            hookRunningSince[event.terminalID] = nil
+            message = prompt
         case .agentStopped(let success):
             next.hookStatus = success ? .idle : .error
             hookRunningSince[event.terminalID] = nil
@@ -458,12 +463,15 @@ class ShipLog {
 
     /// Record the agent's final prose (Stop hook `last_assistant_message`) for a worktree
     /// WITHOUT changing status — used to give suggestion cards a summary line. Resolves
-    /// cwd → terminal the same way `handleWebhookEvent` does.
-    func noteAssistantMessage(cwd: String, message: String) {
+    /// pane → terminal the same way `handleWebhookEvent` does: the exact pane wins,
+    /// cwd's first pane is the fallback.
+    func noteAssistantMessage(cwd: String, paneId: String? = nil, message: String) {
         let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        let paneTid = paneId.flatMap { StationRegistry.shared.station(forSessionName: $0)?.id }
         lock.lock()
-        let tid = worktreeIndex.first { cwd == $0.key || cwd.hasPrefix($0.key + "/") }?.value.first
+        let tid = (paneTid.flatMap { agents[$0] != nil ? $0 : nil })
+            ?? worktreeIndex.first { cwd == $0.key || cwd.hasPrefix($0.key + "/") }?.value.first
         guard let tid, var info = agents[tid] else { lock.unlock(); return }
         info.lastMessage = trimmed
         info.lastAssistantMessage = trimmed  // preserved for suggestion-card summary
@@ -554,14 +562,23 @@ class ShipLog {
         return channels[terminalID]
     }
 
-    /// Route a webhook event to the appropriate HooksChannel based on cwd matching
+    /// Route a webhook event to the appropriate HooksChannel. The exact pane the
+    /// hook ran under (SEAHELM_PANE_ID → station session name) wins; cwd matching
+    /// is the fallback. Resolving by cwd alone always picked the worktree's FIRST
+    /// pane, so a suggestion raised in a split pane was attributed to — and its
+    /// picked option sent into — a sibling pane.
     func handleWebhookEvent(_ event: WebhookEvent) {
+        let paneTid = event.paneId.flatMap { StationRegistry.shared.station(forSessionName: $0)?.id }
         lock.lock()
         // Find the agent whose worktree path matches the event's cwd
         let matchingTIDs = worktreeIndex.first { (worktreePath, _) in
             event.cwd == worktreePath || event.cwd.hasPrefix(worktreePath + "/")
         }?.value
-        guard let tid = matchingTIDs?.first else {
+        let resolvedTid: String? = {
+            if let paneTid, agents[paneTid] != nil { return paneTid }
+            return matchingTIDs?.first
+        }()
+        guard let tid = resolvedTid else {
             let known = Array(worktreeIndex.keys)
             lock.unlock()
             if event.event == .suggest {

--- a/Sources/Status/HookDecoder.swift
+++ b/Sources/Status/HookDecoder.swift
@@ -69,6 +69,13 @@ struct HookDecoder: SignalDecoder {
         case .userPrompt:
             return .userPrompt(event.data?["message"] as? String ?? "Processing prompt")
         case .toolUseStart, .toolUseEnd, .toolUseFailed:
+            // AskUserQuestion blocks the agent on a choice — surface it as a
+            // First Mate question card instead of a generic tool-use activity.
+            if event.event == .toolUseStart,
+               event.data?["tool_name"] as? String == "AskUserQuestion",
+               let q = firstQuestion(from: event) {
+                return .question(prompt: q.prompt, options: q.options)
+            }
             return .toolUse(ActivityEventExtractor.extract(from: event))
         case .prompt:
             return .awaitingInput(event.data?["message"] as? String ?? "Waiting for input")
@@ -89,5 +96,22 @@ struct HookDecoder: SignalDecoder {
             // A subagent finishing must not drive the main station's status.
             return nil
         }
+    }
+
+    /// Extract the first question (text + option labels) from an AskUserQuestion
+    /// tool_input payload. Returns nil when the payload doesn't parse — the event
+    /// then degrades to a normal tool-use activity.
+    static func firstQuestion(from event: WebhookEvent) -> (prompt: String, options: [String])? {
+        guard let input = event.data?["tool_input"] as? [String: Any],
+              let questions = input["questions"] as? [[String: Any]],
+              let first = questions.first,
+              let prompt = first["question"] as? String, !prompt.isEmpty,
+              let rawOptions = first["options"] as? [[String: Any]] else { return nil }
+        let labels = rawOptions.compactMap { $0["label"] as? String }.filter { !$0.isEmpty }
+        guard !labels.isEmpty else { return nil }
+        // Multi-question flows answer one question at a time in the TUI; the card
+        // shows the first, tagged with the total so the user knows more follow.
+        let tagged = questions.count > 1 ? "\(prompt) (1/\(questions.count))" : prompt
+        return (tagged, labels)
     }
 }

--- a/Sources/Status/NormalizedEvent.swift
+++ b/Sources/Status/NormalizedEvent.swift
@@ -19,6 +19,7 @@ enum NormalizedEventKind {
     case notification(level: String, text: String)  // notification / error(level:"error")
     case taskUpdate([TaskItem])               // future (MCP / derived)
     case suggest(options: [String])           // agent-authored candidate orders
+    case question(prompt: String, options: [String])  // AskUserQuestion tool — agent blocked on a choice
     case screenObserved(status: SailorStatus,
                         message: String,
                         activity: [ActivityEvent],

--- a/Tests/FirstMateEvaluateOutcomeTests.swift
+++ b/Tests/FirstMateEvaluateOutcomeTests.swift
@@ -29,6 +29,22 @@ final class FirstMateEvaluateOutcomeTests: XCTestCase {
         XCTAssertTrue(acts.isEmpty)
     }
 
+    func testQuestionEventEmitsCardWithPromptAndPayloadMarker() {
+        let acts = FirstMate.evaluate(
+            outcome(kind: .question(prompt: "Pick one?", options: ["A", "B"])), config: .default)
+        XCTAssertEqual(acts.map(\.kind), [.suggestNextOrder])
+        XCTAssertEqual(acts.first?.zone, .red)
+        XCTAssertEqual(acts.first?.message, "Pick one?")
+        XCTAssertEqual(acts.first?.options, ["A", "B"])
+        XCTAssertEqual(acts.first?.payload, "ask-user-question")
+    }
+
+    func testEmptyQuestionOptionsEmitsNothing() {
+        let acts = FirstMate.evaluate(
+            outcome(kind: .question(prompt: "Pick?", options: [])), config: .default)
+        XCTAssertTrue(acts.isEmpty)
+    }
+
     func testStatusTransitionRoutedThroughOutcomeEntry() {
         let acts = FirstMate.evaluate(outcome(kind: .agentStopped(success: false),
                                               changed: true, newStatus: .error), config: .default)

--- a/Tests/HookDecoderTests.swift
+++ b/Tests/HookDecoderTests.swift
@@ -39,6 +39,43 @@ final class HookDecoderTests: XCTestCase {
         XCTAssertEqual(ae.tool, "Bash")
     }
 
+    func testAskUserQuestionMapsToQuestion() {
+        let event = makeEvent(type: .toolUseStart, data: [
+            "tool_name": "AskUserQuestion",
+            "tool_input": [
+                "questions": [[
+                    "question": "Where should daily check-in happen?",
+                    "options": [["label": "Gate face scan"], ["label": "Front desk kiosk"]],
+                ]],
+            ],
+        ])
+        let normalized = HookDecoder(terminalID: "t1", event: event).decode()
+        guard case .question(let prompt, let options)? = normalized?.kind else { return XCTFail("wrong kind") }
+        XCTAssertEqual(prompt, "Where should daily check-in happen?")
+        XCTAssertEqual(options, ["Gate face scan", "Front desk kiosk"])
+    }
+
+    func testAskUserQuestionMultiQuestionTagsCount() {
+        let event = makeEvent(type: .toolUseStart, data: [
+            "tool_name": "AskUserQuestion",
+            "tool_input": [
+                "questions": [
+                    ["question": "Q1?", "options": [["label": "A"], ["label": "B"]]],
+                    ["question": "Q2?", "options": [["label": "C"]]],
+                ],
+            ],
+        ])
+        let normalized = HookDecoder(terminalID: "t1", event: event).decode()
+        guard case .question(let prompt, _)? = normalized?.kind else { return XCTFail("wrong kind") }
+        XCTAssertEqual(prompt, "Q1? (1/2)")
+    }
+
+    func testAskUserQuestionWithBadPayloadDegradesToToolUse() {
+        let event = makeEvent(type: .toolUseStart, data: ["tool_name": "AskUserQuestion"])
+        let normalized = HookDecoder(terminalID: "t1", event: event).decode()
+        guard case .toolUse? = normalized?.kind else { return XCTFail("wrong kind") }
+    }
+
     func testPromptMapsToAwaitingInput() {
         let event = makeEvent(type: .prompt, data: ["message": "Continue?"])
         let normalized = HookDecoder(terminalID: "t1", event: event).decode()


### PR DESCRIPTION
## Summary
- **Pane-precise hook routing**: resolve hook/suggest events by `SEAHELM_PANE_ID` → station session name, falling back to cwd. Fixes suggestions from a split pane being attributed to (and answered into) the worktree's first pane. `noteAssistantMessage` gets the same treatment.
- **AskUserQuestion → First Mate cards**: `PreToolUse(AskUserQuestion)` becomes a `.question` event → red-zone card with the question as title and option labels as buttons; agent shows as waiting. Tapping sends the option number + Return (TUI selects by digit). Multi-question flows tagged `(1/N)`; malformed payloads degrade to tool-use activity.

## Test plan
- [x] Build clean
- [x] 24 tests green (HookDecoder incl. 3 new AskUserQuestion cases, FirstMateEvaluateOutcome incl. 2 new question-card cases, ShipLogIngest, FirstMateCoordinatorOutcome)

🤖 Generated with [Claude Code](https://claude.com/claude-code)