### PR TITLE
fix: preserve sidebar state when entering worktrees

### DIFF
--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -525,7 +525,7 @@ class DashboardViewController: NSViewController {
         overviewView.commandMenuProvider = commandMenuProvider
     }
 
-    /// Drill into a specific worktree: select it, then flip to worktree mode.
+    /// Drill into a specific worktree without changing the chrome sidebar state.
     /// Clicking a row is what sets the overview's selection highlight.
     func enterWorktree(byWorktreePath path: String) {
         selectSailor(byWorktreePath: path)
@@ -536,7 +536,6 @@ class DashboardViewController: NSViewController {
             overviewView.selectedId = overviewSelectedId
             overviewView.update(agents)
         }
-        setViewMode(.terminal)
     }
 
     var isLeftColumnCollapsedState: Bool { isLeftColumnCollapsed }

--- a/Tests/DashboardViewControllerClickTests.swift
+++ b/Tests/DashboardViewControllerClickTests.swift
@@ -3,6 +3,38 @@ import XCTest
 
 final class DashboardViewControllerClickTests: XCTestCase {
 
+    // MARK: - Worktree entry
+
+    func testEnteringWorktreeKeepsExpandedSidebarExpanded() {
+        let vc = DashboardViewController()
+        vc.loadViewIfNeeded()
+        vc.updateSailors([makeSailor(id: "agent-a", worktreePath: "/repo/a")])
+        vc.adoptChromeCollapse(false, activePane: .firstMate)
+        var requestedCollapse: Bool?
+        vc.onRequestSetChromeCollapsed = { requestedCollapse = $0 }
+        XCTAssertFalse(vc.isLeftColumnCollapsedState)
+
+        vc.enterWorktree(byWorktreePath: "/repo/a")
+
+        XCTAssertNil(requestedCollapse)
+        XCTAssertFalse(vc.isLeftColumnCollapsedState)
+    }
+
+    func testEnteringWorktreeKeepsCollapsedSidebarCollapsed() {
+        let vc = DashboardViewController()
+        vc.loadViewIfNeeded()
+        vc.updateSailors([makeSailor(id: "agent-a", worktreePath: "/repo/a")])
+        vc.adoptChromeCollapse(true, activePane: .firstMate)
+        var requestedCollapse: Bool?
+        vc.onRequestSetChromeCollapsed = { requestedCollapse = $0 }
+        XCTAssertTrue(vc.isLeftColumnCollapsedState)
+
+        vc.enterWorktree(byWorktreePath: "/repo/a")
+
+        XCTAssertNil(requestedCollapse)
+        XCTAssertTrue(vc.isLeftColumnCollapsedState)
+    }
+
     // MARK: - Row click
 
     func testRowClickOnUnknownPathDoesNotCallSelectProject() {


### PR DESCRIPTION
## Summary

- preserve the current left-sidebar state when entering terminal mode
- apply the behavior consistently to Island, dashboard, notification, and other worktree navigation paths
- add regression coverage for both expanded and collapsed sidebar states

## Validation

- Passed: Swift syntax parsing for the changed source and test files
- Passed: git diff --check
- Blocked: focused XCTest and Debug build cannot link because the existing cached Ghostty archive is missing _ghostty_* symbols; the same failure occurs on the unchanged baseline before this patch
