### PR TITLE
fix: bundle terminal typography defaults

### DIFF
--- a/Resources/ghostty.conf
+++ b/Resources/ghostty.conf
@@ -1,0 +1,7 @@
+# Seahelm terminal defaults. User overrides in
+# ~/.config/seahelm/ghostty.conf are loaded after this file.
+font-family = ""
+font-family-bold = ""
+font-family-italic = ""
+font-family-bold-italic = ""
+font-family = JetBrains Mono

--- a/Sources/Terminal/GhosttyBridge.swift
+++ b/Sources/Terminal/GhosttyBridge.swift
@@ -80,7 +80,14 @@ class GhosttyBridge {
         }
         ghostty_config_load_default_files(config)
 
-        // Load seahelm-specific overrides (e.g. copy-on-select = false)
+        // Keep terminal typography consistent with the rest of Seahelm. The
+        // bundled config resets any font families inherited from Ghostty's
+        // global config before selecting the JetBrains Mono faces registered
+        // by AppFont at launch.
+        Self.loadBundledTerminalDefaults(into: config)
+
+        // Load Seahelm-specific user overrides last so users can still adjust
+        // the bundled terminal defaults (e.g. font size or copy-on-select).
         let seahelmConfigPath = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/seahelm/ghostty.conf").path
         if FileManager.default.fileExists(atPath: seahelmConfigPath) {
@@ -255,6 +262,7 @@ class GhosttyBridge {
     private static func buildConfig() -> ghostty_config_t? {
         guard let config = ghostty_config_new() else { return nil }
         ghostty_config_load_default_files(config)
+        loadBundledTerminalDefaults(into: config)
         let seahelmConfigPath = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/seahelm/ghostty.conf").path
         if FileManager.default.fileExists(atPath: seahelmConfigPath) {
@@ -265,6 +273,12 @@ class GhosttyBridge {
         }
         ghostty_config_finalize(config)
         return config
+    }
+
+    private static func loadBundledTerminalDefaults(into config: ghostty_config_t) {
+        if let path = Bundle.main.path(forResource: "ghostty", ofType: "conf") {
+            ghostty_config_load_file(config, path)
+        }
     }
 
     /// `GHOSTTY_RESOURCES_DIR` → `Bundle/.../Resources/ghostty` (contains `themes/`).

--- a/project.yml
+++ b/project.yml
@@ -64,6 +64,7 @@ targets:
       - path: Sources
         type: group
       - path: Resources/Fonts
+      - path: Resources/ghostty.conf
       - path: Assets.xcassets
       - path: Resources/licenses
         type: folder

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -132,6 +132,24 @@ if [[ ! -d "$APP_PATH" ]]; then
   exit 1
 fi
 
+# Terminal typography must be self-contained. A fresh install cannot depend on
+# fonts or Ghostty configuration already present on the user's Mac.
+echo "==> Verifying bundled terminal typography"
+for RESOURCE in \
+  "ghostty.conf" \
+  "JetBrainsMono-Regular.ttf" \
+  "JetBrainsMono-Medium.ttf" \
+  "JetBrainsMono-Bold.ttf"; do
+  if [[ ! -f "$APP_PATH/Contents/Resources/$RESOURCE" ]]; then
+    echo "Missing required terminal typography resource: $RESOURCE" >&2
+    exit 1
+  fi
+done
+if ! grep -Fqx "font-family = JetBrains Mono" "$APP_PATH/Contents/Resources/ghostty.conf"; then
+  echo "Bundled ghostty.conf does not select JetBrains Mono" >&2
+  exit 1
+fi
+
 # The x86_64 slice is cross-compiled on Apple Silicon, where a stray
 # ONLY_ACTIVE_ARCH=YES would silently yield an arm64 binary in a zip labelled
 # x86_64. Fail loudly instead of shipping the wrong architecture.

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		3A5FD6063BF092FB51DC280A /* WorktreeGitStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8BB5725BBA721E41CF23CF /* WorktreeGitStats.swift */; };
 		3BB046CB910F5735999EAF2F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 23B112FAA14CF6135A4F7202 /* Assets.xcassets */; };
 		3BE5AE4B30540C9F80527B7F /* ChromeDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4AD78048C5DC1D7D1D5E3F /* ChromeDividerView.swift */; };
+		A1424D5B7D8F491EB5A3C621 /* ghostty.conf in Resources */ = {isa = PBXBuildFile; fileRef = A1424D5B7D8F491EB5A3C620 /* ghostty.conf */; };
 		3C498141117B2348743A7A3E /* SettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DFC7C439D7D5CB85100DB4D /* SettingsPage.swift */; };
 		3D646290FE05FFC7FE24794B /* StatusBarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176DD9C40844C7ECA03950E6 /* StatusBarViewTests.swift */; };
 		426F95A44B1C856837684FCF /* IslandPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2761438177A32EEF5CCFE031 /* IslandPanelController.swift */; };
@@ -590,6 +591,7 @@
 		A6F12DC83A838ABCF3346194 /* Keymap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keymap.swift; sourceTree = "<group>"; };
 		A93CAFA62124025DCEA0F97A /* SailorReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SailorReducerTests.swift; sourceTree = "<group>"; };
 		A94DAD757D9F452B11283244 /* Manifests */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Manifests; path = Resources/Manifests; sourceTree = SOURCE_ROOT; };
+		A1424D5B7D8F491EB5A3C620 /* ghostty.conf */ = {isa = PBXFileReference; lastKnownFileType = text; path = Resources/ghostty.conf; sourceTree = SOURCE_ROOT; };
 		AA151402CD4A6E95C947C0AB /* ExternalChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalChannel.swift; sourceTree = "<group>"; };
 		AA3A8892B1DC42E27FCD2A98 /* CodexUsageSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageSummaryProvider.swift; sourceTree = "<group>"; };
 		AB8C0AA934FBBE1D3F9E6831 /* AgentManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentManifest.swift; sourceTree = "<group>"; };
@@ -1204,6 +1206,7 @@
 			children = (
 				23B112FAA14CF6135A4F7202 /* Assets.xcassets */,
 				3C22FD399E95F8A453F40C3A /* ghostty */,
+				A1424D5B7D8F491EB5A3C620 /* ghostty.conf */,
 				E02B47C1F399F29F6BDC084B /* ghostty.h */,
 				36D5F3B1BC616505486ACBA0 /* licenses */,
 				A94DAD757D9F452B11283244 /* Manifests */,
@@ -1416,6 +1419,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3BB046CB910F5735999EAF2F /* Assets.xcassets in Resources */,
+				A1424D5B7D8F491EB5A3C621 /* ghostty.conf in Resources */,
 				89C41D7167472A785EA66D4F /* JetBrainsMono-Bold.ttf in Resources */,
 				756AC63650FCD59FB6D44243 /* JetBrainsMono-Medium.ttf in Resources */,
 				346BF50E3F02C947F8D62DB5 /* JetBrainsMono-Regular.ttf in Resources */,


### PR DESCRIPTION
## Summary
- bundle a Seahelm Ghostty config that selects JetBrains Mono
- load bundled defaults before user-specific Seahelm overrides
- fail release packaging when terminal font resources are missing

## Validation
- `git diff --check`
- `bash -n scripts/package_release.sh`
- confirmed `ghostty.conf` is copied into the built app resources
- `xcodebuild ... build` reaches Swift compilation and resource copy, but final linking is blocked by the current GhosttyKit archive missing Ghostty C API exports

## UI impact
Codex and other embedded terminal sessions now use the same bundled JetBrains Mono typography on fresh installations.