### PR TITLE
feat: add First Mate worktree grouping

### DIFF
--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -380,6 +380,7 @@ class TabCoordinator {
                 tasks: agent.tasks,
                 activityEvents: agent.activityEvents,
                 lastActivityAge: lastActivityAge,
+                lastActivityAt: lastActivity,
                 gitStats: gitStats,
                 currentPaneTitle: currentPaneTitle,
                 currentPaneRunTime: currentPaneRunTime

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -247,7 +247,9 @@ class DashboardViewController: NSViewController {
             self?.syncOverviewFocusCounts()
         }
         overviewView.onGroupingChanged = { [weak self] in
-            self?.syncOverviewFocusCounts()
+            guard let self else { return }
+            overviewSelectedId = overviewView.selectedId
+            syncOverviewFocusCounts()
         }
     }
 
@@ -2180,6 +2182,16 @@ final class DashboardOverviewView: NSView {
         let sailorsByPath = Dictionary(sailors.map { ($0.worktreePath, $0) }, uniquingKeysWith: { first, _ in first })
         let groupingItems = sailors.map { $0.groupingItem(creationDate: Self.creationDate($0.worktreePath)) }
         let groups = WorktreeGrouping.groups(groupingItems, mode: groupingMode, now: now())
+
+        // A mode switch is an explicit navigation action. If its previous
+        // identity is stale, land on the first row in the new ordering before
+        // constructing rows so the resolved selection is highlighted and can be
+        // revealed. Ordinary data refreshes intentionally preserve stale/empty
+        // selection without moving the user's focus.
+        if revealSelection, !selectedId.isEmpty,
+           !groups.contains(where: { group in group.items.contains(where: { $0.id == selectedId }) }) {
+            selectedId = groups.first?.items.first?.id ?? ""
+        }
 
         for (groupIndex, group) in groups.enumerated() {
             renderedGroupTitles.append(group.title)

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -246,6 +246,9 @@ class DashboardViewController: NSViewController {
         overviewView.onOrdersChanged = { [weak self] in
             self?.syncOverviewFocusCounts()
         }
+        overviewView.onGroupingChanged = { [weak self] in
+            self?.syncOverviewFocusCounts()
+        }
     }
 
     // MARK: - `?` keyboard help overlay
@@ -1586,7 +1589,7 @@ private final class NonFirstResponderScrollView: NSScrollView {
 
 // MARK: - Dashboard overview (spread First Mate fleet page)
 
-/// Full-width fleet overview: every worktree as a row grouped by status, a
+/// Full-width fleet overview: every worktree as a row grouped by the chosen mode, a
 /// horizontal ORDERS carousel, and a command composer. This is the landing
 /// surface (the "spread First Mate"); clicking a row drills into that worktree.
 extension Array {
@@ -1597,6 +1600,7 @@ final class DashboardOverviewView: NSView {
     var onSelectWorktree: ((String) -> Void)?
     var onDeleteWorktree: ((String) -> Void)?
     var onSubmitCommand: ((String) -> Void)?
+    var onGroupingChanged: (() -> Void)?
     /// A card's primary/secondary button was tapped. `optionText` is the chosen
     /// option label (or "" for a plain approve).
     var onOrderAction: ((PendingOrder, String) -> Void)?
@@ -1669,6 +1673,8 @@ final class DashboardOverviewView: NSView {
 
     private let headerTitle = NSTextField(labelWithString: "First mate")
     private let headerSub = NSTextField(labelWithString: "")
+    private let groupingButton = NSButton()
+    private let groupingMenu = NSMenu()
     private let headerLine = NSView()
     private let scroll = NonFirstResponderScrollView()
     private let stack = FlippedStackView()
@@ -1698,11 +1704,39 @@ final class DashboardOverviewView: NSView {
     /// labels) dismiss the slash menu even when the field stays first responder.
     private var menuClickMonitor: Any?
 
+    private let groupingPreference: WorktreeGroupingPreference
+    private let now: () -> Date
+    private var groupingMode: WorktreeGroupingMode
+    private var latestSailors: [SailorDisplayInfo] = []
+    private var rowViewsByID: [String: RowView] = [:]
+    private var renderedGroupTitles: [String] = []
+    private var revealedRowID: String?
+
     override init(frame frameRect: NSRect) {
+        let preference = WorktreeGroupingPreference(defaults: .standard)
+        groupingPreference = preference
+        now = Date.init
+        groupingMode = preference.load()
         super.init(frame: frameRect)
         setup()
     }
-    required init?(coder: NSCoder) { super.init(coder: coder); setup() }
+    required init?(coder: NSCoder) {
+        let preference = WorktreeGroupingPreference(defaults: .standard)
+        groupingPreference = preference
+        now = Date.init
+        groupingMode = preference.load()
+        super.init(coder: coder)
+        setup()
+    }
+
+    init(frame frameRect: NSRect, defaults: UserDefaults, now: @escaping () -> Date) {
+        let preference = WorktreeGroupingPreference(defaults: defaults)
+        groupingPreference = preference
+        self.now = now
+        groupingMode = preference.load()
+        super.init(frame: frameRect)
+        setup()
+    }
 
     deinit {
         stopMenuClickMonitor()
@@ -1723,10 +1757,14 @@ final class DashboardOverviewView: NSView {
         headerTitle.textColor = Self.ink
         headerSub.font = AppFont.mono(size: 11)
         headerSub.textColor = Self.inkFaint
-        let headerRow = NSStackView(views: [headerIcon, headerTitle, headerSub])
+        configureGroupingMenu()
+        let spacer = NSView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        let headerRow = NSStackView(views: [headerIcon, headerTitle, headerSub, spacer, groupingButton])
         headerRow.orientation = .horizontal
         headerRow.spacing = 10
-        headerRow.alignment = .firstBaseline
+        headerRow.alignment = .centerY
         headerRow.translatesAutoresizingMaskIntoConstraints = false
         addSubview(headerRow)
         headerLine.wantsLayer = true
@@ -1756,7 +1794,7 @@ final class DashboardOverviewView: NSView {
         NSLayoutConstraint.activate([
             headerRow.topAnchor.constraint(equalTo: topAnchor, constant: 13),
             headerRow.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 15),
-            headerRow.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -15),
+            headerRow.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -15),
 
             headerLine.topAnchor.constraint(equalTo: headerRow.bottomAnchor, constant: 11),
             headerLine.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -1780,6 +1818,70 @@ final class DashboardOverviewView: NSView {
         ])
         ordersZoneHeight = ordersZone.heightAnchor.constraint(equalToConstant: 0)
         ordersZoneHeight?.isActive = true
+    }
+
+    private func configureGroupingMenu() {
+        groupingButton.isBordered = false
+        let groupingImage = NSImage(systemSymbolName: "rectangle.3.group", accessibilityDescription: nil)
+        groupingButton.image = groupingImage?.withSymbolConfiguration(.init(pointSize: 13, weight: .medium))
+        groupingButton.contentTintColor = Self.inkDim
+        if groupingButton.image == nil {
+            groupingButton.title = "☷"
+            groupingButton.font = AppFont.mono(size: 13)
+        } else {
+            groupingButton.title = ""
+            groupingButton.imagePosition = .imageOnly
+        }
+        groupingButton.refusesFirstResponder = true
+        groupingButton.target = self
+        groupingButton.action = #selector(showGroupingMenu(_:))
+
+        let entries: [(WorktreeGroupingMode, String)] = [
+            (.repository, "Group by Repository"),
+            (.status, "Group by Status"),
+            (.activityTime, "Group by Time"),
+        ]
+        for (mode, title) in entries {
+            let item = NSMenuItem(title: title, action: #selector(selectGroupingMode(_:)), keyEquivalent: "")
+            item.target = self
+            item.representedObject = mode.rawValue
+            groupingMenu.addItem(item)
+        }
+        refreshGroupingMenuPresentation()
+    }
+
+    @objc private func showGroupingMenu(_ sender: NSButton) {
+        groupingMenu.popUp(positioning: nil,
+                           at: NSPoint(x: 0, y: sender.bounds.maxY + 4),
+                           in: sender)
+    }
+
+    @objc private func selectGroupingMode(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let mode = WorktreeGroupingMode(rawValue: rawValue) else { return }
+        applyGroupingMode(mode)
+    }
+
+    private func applyGroupingMode(_ mode: WorktreeGroupingMode) {
+        groupingMode = mode
+        groupingPreference.save(mode)
+        refreshGroupingMenuPresentation()
+        render(latestSailors, revealSelection: true)
+        onGroupingChanged?()
+    }
+
+    private func refreshGroupingMenuPresentation() {
+        for item in groupingMenu.items {
+            item.state = (item.representedObject as? String) == groupingMode.rawValue ? .on : .off
+        }
+        let description: String
+        switch groupingMode {
+        case .repository: description = "Group worktrees by repository"
+        case .status: description = "Group worktrees by status"
+        case .activityTime: description = "Group worktrees by time"
+        }
+        groupingButton.toolTip = description
+        groupingButton.setAccessibilityLabel(description)
     }
 
     private func setupOrdersZone() {
@@ -2052,15 +2154,6 @@ final class DashboardOverviewView: NSView {
         }
     }
 
-    private static func primaryStatus(_ s: SailorDisplayInfo) -> SailorStatus {
-        let ps = s.paneStatuses
-        if ps.contains(.waiting) { return .waiting }
-        if ps.contains(.running) { return .running }
-        if ps.contains(.error) { return .error }
-        if ps.contains(.idle) { return .idle }
-        return ps.first ?? .unknown
-    }
-
     /// Focus the command input with a prefilled command (e.g. "/new ").
     func focusCommand(prefill: String) {
         commandInput.setTextAndFocusEnd(prefill)
@@ -2070,28 +2163,27 @@ final class DashboardOverviewView: NSView {
     private(set) var orderedRows: [(id: String, path: String)] = []
 
     func update(_ sailors: [SailorDisplayInfo]) {
-        let running = sailors.filter { Self.primaryStatus($0) == .running }.count
+        latestSailors = sailors
+        render(sailors, revealSelection: false)
+    }
+
+    private func render(_ sailors: [SailorDisplayInfo], revealSelection: Bool) {
+        let running = sailors.filter { SailorStatus.highestPriority($0.paneStatuses) == .running }.count
         headerSub.stringValue = "\(sailors.count) worktrees · \(running) running"
 
         stack.arrangedSubviews.forEach { $0.removeFromSuperview() }
         orderedRows = []
+        rowViewsByID = [:]
+        renderedGroupTitles = []
+        revealedRowID = nil
 
-        // Group by repo, in first-seen order (which follows the configured
-        // card/workspace order). Within a repo: main worktree first, then the
-        // linked worktrees by creation time (oldest first).
-        var repoOrder: [String] = []
-        var grouped: [String: [SailorDisplayInfo]] = [:]
-        for sailor in sailors {
-            if grouped[sailor.project] == nil { repoOrder.append(sailor.project) }
-            grouped[sailor.project, default: []].append(sailor)
-        }
-        for (gi, repo) in repoOrder.enumerated() {
-            let items = (grouped[repo] ?? []).sorted { a, b in
-                if a.isMainWorktree != b.isMainWorktree { return a.isMainWorktree }
-                return Self.creationDate(a.worktreePath) < Self.creationDate(b.worktreePath)
-            }
-            guard !items.isEmpty else { continue }
-            let header = makeGroupHeader(repo: repo, topGap: gi == 0 ? 0 : 13)
+        let sailorsByPath = Dictionary(sailors.map { ($0.worktreePath, $0) }, uniquingKeysWith: { first, _ in first })
+        let groupingItems = sailors.map { $0.groupingItem(creationDate: Self.creationDate($0.worktreePath)) }
+        let groups = WorktreeGrouping.groups(groupingItems, mode: groupingMode, now: now())
+
+        for (groupIndex, group) in groups.enumerated() {
+            renderedGroupTitles.append(group.title)
+            let header = makeGroupHeader(group: group, topGap: groupIndex == 0 ? 0 : 13)
             stack.addArrangedSubview(header)
             pin(header)
             let rowsBox = NSStackView()
@@ -2099,18 +2191,27 @@ final class DashboardOverviewView: NSView {
             rowsBox.spacing = 4
             rowsBox.alignment = .leading
             rowsBox.translatesAutoresizingMaskIntoConstraints = false
-            for item in items {
-                let status = Self.primaryStatus(item)
-                let row = RowView(sailor: item, status: status,
-                                  selected: item.id == self.selectedId)
+            for groupedItem in group.items {
+                guard let sailor = sailorsByPath[groupedItem.path] else { continue }
+                let row = RowView(sailor: sailor,
+                                  status: groupedItem.status,
+                                  selected: groupedItem.id == selectedId,
+                                  showsRepository: groupingMode != .repository)
                 row.onTap = { [weak self] path in self?.onSelectWorktree?(path) }
                 row.onDelete = { [weak self] path in self?.onDeleteWorktree?(path) }
                 rowsBox.addArrangedSubview(row)
                 row.widthAnchor.constraint(equalTo: rowsBox.widthAnchor).isActive = true
-                orderedRows.append((item.id, item.worktreePath))
+                orderedRows.append((groupedItem.id, groupedItem.path))
+                rowViewsByID[groupedItem.id] = row
             }
             stack.addArrangedSubview(rowsBox)
             pin(rowsBox)
+        }
+
+        if revealSelection, let selectedRow = rowViewsByID[selectedId] {
+            layoutSubtreeIfNeeded()
+            selectedRow.scrollToVisible(selectedRow.bounds)
+            revealedRowID = selectedId
         }
     }
 
@@ -2127,6 +2228,24 @@ final class DashboardOverviewView: NSView {
 
     /// Selected worktree id, so the fleet can mark the current row (accent border).
     var selectedId: String = ""
+
+    // Focused AppKit contract exposed to unit tests without leaking mutable UI.
+    var groupingModeForTesting: WorktreeGroupingMode { groupingMode }
+    var groupingMenuTitlesForTesting: [String] { groupingMenu.items.map(\.title) }
+    var groupingMenuKeyEquivalentsForTesting: [String] { groupingMenu.items.map(\.keyEquivalent) }
+    var checkedGroupingModesForTesting: [WorktreeGroupingMode] {
+        groupingMenu.items.compactMap { item in
+            guard item.state == .on, let rawValue = item.representedObject as? String else { return nil }
+            return WorktreeGroupingMode(rawValue: rawValue)
+        }
+    }
+    var renderedGroupTitlesForTesting: [String] { renderedGroupTitles }
+    var renderedSelectedRowIDForTesting: String? { rowViewsByID[selectedId] == nil ? nil : selectedId }
+    var revealedRowIDForTesting: String? { revealedRowID }
+    var groupingButtonToolTipForTesting: String? { groupingButton.toolTip }
+    var groupingButtonAccessibilityLabelForTesting: String? { groupingButton.accessibilityLabel() }
+    var groupingButtonRefusesFirstResponderForTesting: Bool { groupingButton.refusesFirstResponder }
+    func selectGroupingModeForTesting(_ mode: WorktreeGroupingMode) { applyGroupingMode(mode) }
 
     /// Cards in carousel order + each card's worktree path, for keyboard nav.
     private(set) var orderCards: [OrderCardView] = []
@@ -2187,15 +2306,36 @@ final class DashboardOverviewView: NSView {
         v.trailingAnchor.constraint(equalTo: stack.trailingAnchor, constant: -15).isActive = true
     }
 
-    /// Repo name only — worktrees under this header share the project.
-    private func makeGroupHeader(repo: String, topGap: CGFloat) -> NSView {
-        let label = NSTextField(labelWithString: repo)
-        label.font = AppFont.mono(size: 11, weight: .semibold)
-        label.textColor = Self.inkDim
-        label.lineBreakMode = .byTruncatingTail
+    private func makeGroupHeader(group: WorktreeGroup, topGap: CGFloat) -> NSView {
+        var views: [NSView] = []
+        if let status = group.status {
+            let meta = Self.groupMeta(status)
+            let glyph = NSTextField(labelWithString: meta.glyph)
+            glyph.font = AppFont.mono(size: 8)
+            glyph.textColor = meta.color
+            views.append(glyph)
 
-        let row = NSStackView(views: [label])
+            let title = NSTextField(labelWithString: meta.label)
+            title.font = AppFont.mono(size: 11)
+            title.textColor = meta.color
+            title.lineBreakMode = .byTruncatingTail
+            views.append(title)
+
+            let count = NSTextField(labelWithString: "\(group.items.count)")
+            count.font = AppFont.mono(size: 11)
+            count.textColor = Self.inkFaint
+            views.append(count)
+        } else {
+            let title = NSTextField(labelWithString: group.title)
+            title.font = AppFont.mono(size: 11, weight: .semibold)
+            title.textColor = Self.inkDim
+            title.lineBreakMode = .byTruncatingTail
+            views.append(title)
+        }
+
+        let row = NSStackView(views: views)
         row.orientation = .horizontal
+        row.spacing = 7
         row.alignment = .centerY
         row.edgeInsets = NSEdgeInsets(top: topGap, left: 0, bottom: 7, right: 0)
         return row
@@ -2243,7 +2383,8 @@ final class DashboardOverviewView: NSView {
             return v
         }
 
-        init(sailor: SailorDisplayInfo, status: SailorStatus, selected: Bool) {
+        init(sailor: SailorDisplayInfo, status: SailorStatus, selected: Bool,
+             showsRepository: Bool) {
             self.path = sailor.worktreePath
             self.selected = selected
             super.init(frame: .zero)
@@ -2299,6 +2440,13 @@ final class DashboardOverviewView: NSView {
             line2.alignment = .firstBaseline
             line2.spacing = 8
             line2.translatesAutoresizingMaskIntoConstraints = false
+            if showsRepository {
+                let repository = Self.label(sailor.project.isEmpty ? "Unknown repository" : sailor.project,
+                                            RepoColor.color(for: sailor.project), 10, weight: .semibold)
+                repository.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+                repository.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+                line2.addArrangedSubview(repository)
+            }
             line2.addArrangedSubview(branchLabel)
             line2.addArrangedSubview(git)
             line2.addArrangedSubview(Self.spacer())

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -36,6 +36,7 @@ struct SailorDisplayInfo {
     let tasks: [TaskItem]              // webhook-tracked task items
     let activityEvents: [ActivityEvent]
     let lastActivityAge: String        // "3m"/"2h" since last real activity ("" if unknown)
+    let lastActivityAt: Date?
     let gitStats: WorktreeGitStats?    // diff size + ahead/behind (nil until first resolve)
     /// Focused (last-selected) pane title for First Mate fleet rows.
     let currentPaneTitle: String

--- a/Sources/UI/Dashboard/WorktreeGrouping.swift
+++ b/Sources/UI/Dashboard/WorktreeGrouping.swift
@@ -30,6 +30,20 @@ struct WorktreeGroupingItem: Equatable {
     let creationDate: Date
 }
 
+extension SailorDisplayInfo {
+    func groupingItem(creationDate: Date) -> WorktreeGroupingItem {
+        WorktreeGroupingItem(
+            id: id,
+            path: worktreePath,
+            repository: project,
+            status: SailorStatus.highestPriority(paneStatuses),
+            lastActivityAt: lastActivityAt,
+            isMainWorktree: isMainWorktree,
+            creationDate: creationDate
+        )
+    }
+}
+
 struct WorktreeGroup: Equatable {
     let id: WorktreeGroupID
     let title: String

--- a/Sources/UI/Dashboard/WorktreeGrouping.swift
+++ b/Sources/UI/Dashboard/WorktreeGrouping.swift
@@ -1,0 +1,194 @@
+import Foundation
+
+enum WorktreeGroupingMode: String, CaseIterable {
+    case repository
+    case status
+    case activityTime
+}
+
+enum WorktreeActivityBucket: String, CaseIterable {
+    case recentHour
+    case today
+    case recentSevenDays
+    case earlier
+    case noActivity
+}
+
+enum WorktreeGroupID: Hashable {
+    case repository(String)
+    case status(SailorStatus)
+    case activity(WorktreeActivityBucket)
+}
+
+struct WorktreeGroupingItem: Equatable {
+    let id: String
+    let path: String
+    let repository: String
+    let status: SailorStatus
+    let lastActivityAt: Date?
+    let isMainWorktree: Bool
+    let creationDate: Date
+}
+
+struct WorktreeGroup: Equatable {
+    let id: WorktreeGroupID
+    let title: String
+    let status: SailorStatus?
+    let items: [WorktreeGroupingItem]
+}
+
+enum WorktreeGrouping {
+    static func groups(
+        _ items: [WorktreeGroupingItem],
+        mode: WorktreeGroupingMode,
+        now: Date,
+        calendar: Calendar = .current
+    ) -> [WorktreeGroup] {
+        switch mode {
+        case .repository:
+            return repositoryGroups(items)
+        case .status:
+            return statusGroups(items)
+        case .activityTime:
+            return activityGroups(items, now: now, calendar: calendar)
+        }
+    }
+
+    private static func repositoryGroups(_ items: [WorktreeGroupingItem]) -> [WorktreeGroup] {
+        var repositoryOrder: [String] = []
+        var groupedItems: [String: [WorktreeGroupingItem]] = [:]
+
+        for item in items {
+            let repository = item.repository.isEmpty ? "Unknown repository" : item.repository
+            if groupedItems[repository] == nil {
+                repositoryOrder.append(repository)
+            }
+            groupedItems[repository, default: []].append(item)
+        }
+
+        return repositoryOrder.map { repository in
+            WorktreeGroup(
+                id: .repository(repository),
+                title: repository,
+                status: nil,
+                items: groupedItems[repository, default: []].sorted(by: repositoryRowComesFirst)
+            )
+        }
+    }
+
+    private static func statusGroups(_ items: [WorktreeGroupingItem]) -> [WorktreeGroup] {
+        let statuses: [(status: SailorStatus, title: String)] = [
+            (.waiting, "Needs input"),
+            (.running, "Running"),
+            (.idle, "Idle"),
+            (.error, "Error"),
+            (.exited, "Dormant"),
+            (.unknown, "Unknown"),
+        ]
+
+        return statuses.compactMap { status, title in
+            let matchingItems = items.filter { $0.status == status }
+            guard !matchingItems.isEmpty else { return nil }
+            return WorktreeGroup(
+                id: .status(status),
+                title: title,
+                status: status,
+                items: matchingItems.sorted(by: activityRowComesFirst)
+            )
+        }
+    }
+
+    private static func activityGroups(
+        _ items: [WorktreeGroupingItem],
+        now: Date,
+        calendar: Calendar
+    ) -> [WorktreeGroup] {
+        let buckets: [(bucket: WorktreeActivityBucket, title: String)] = [
+            (.recentHour, "Recent hour"),
+            (.today, "Today"),
+            (.recentSevenDays, "Recent 7 days"),
+            (.earlier, "Earlier"),
+            (.noActivity, "No activity"),
+        ]
+        var groupedItems: [WorktreeActivityBucket: [WorktreeGroupingItem]] = [:]
+
+        for item in items {
+            let bucket = activityBucket(for: item.lastActivityAt, now: now, calendar: calendar)
+            groupedItems[bucket, default: []].append(item)
+        }
+
+        return buckets.compactMap { bucket, title in
+            guard let matchingItems = groupedItems[bucket], !matchingItems.isEmpty else { return nil }
+            return WorktreeGroup(
+                id: .activity(bucket),
+                title: title,
+                status: nil,
+                items: matchingItems.sorted(by: activityRowComesFirst)
+            )
+        }
+    }
+
+    private static func activityBucket(
+        for activity: Date?,
+        now: Date,
+        calendar: Calendar
+    ) -> WorktreeActivityBucket {
+        guard let activity else { return .noActivity }
+        let age = max(0, now.timeIntervalSince(activity))
+        if age < 3_600 { return .recentHour }
+        if calendar.isDate(activity, inSameDayAs: now) { return .today }
+        if age < 7 * 86_400 { return .recentSevenDays }
+        return .earlier
+    }
+
+    private static func repositoryRowComesFirst(
+        _ lhs: WorktreeGroupingItem,
+        _ rhs: WorktreeGroupingItem
+    ) -> Bool {
+        if lhs.isMainWorktree != rhs.isMainWorktree {
+            return lhs.isMainWorktree
+        }
+        if lhs.creationDate != rhs.creationDate {
+            return lhs.creationDate < rhs.creationDate
+        }
+        return lhs.path < rhs.path
+    }
+
+    private static func activityRowComesFirst(
+        _ lhs: WorktreeGroupingItem,
+        _ rhs: WorktreeGroupingItem
+    ) -> Bool {
+        switch (lhs.lastActivityAt, rhs.lastActivityAt) {
+        case let (left?, right?) where left != right:
+            return left > right
+        case (.some, .none):
+            return true
+        case (.none, .some):
+            return false
+        default:
+            return lhs.path < rhs.path
+        }
+    }
+}
+
+struct WorktreeGroupingPreference {
+    static let key = "seahelm.dashboard.worktreeGroupingMode"
+
+    let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func load() -> WorktreeGroupingMode {
+        guard let rawValue = defaults.string(forKey: Self.key),
+              let mode = WorktreeGroupingMode(rawValue: rawValue) else {
+            return .repository
+        }
+        return mode
+    }
+
+    func save(_ mode: WorktreeGroupingMode) {
+        defaults.set(mode.rawValue, forKey: Self.key)
+    }
+}

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import seahelm
+
+final class DashboardOverviewGroupingTests: XCTestCase {
+    func testGroupingItemCarriesIdentityRepositoryStatusAndActivityDate() {
+        let lastActivityAt = Date(timeIntervalSince1970: 1_721_234_567)
+        let creationDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let sailor = makeSailor(
+            id: "station-42",
+            project: "seahelm",
+            worktreePath: "/tmp/seahelm-feature",
+            paneStatuses: [.running, .error],
+            isMainWorktree: true,
+            lastActivityAt: lastActivityAt
+        )
+
+        let item = sailor.groupingItem(creationDate: creationDate)
+
+        XCTAssertEqual(item.id, "station-42")
+        XCTAssertEqual(item.path, "/tmp/seahelm-feature")
+        XCTAssertEqual(item.repository, "seahelm")
+        XCTAssertEqual(item.status, .error)
+        XCTAssertEqual(item.lastActivityAt, lastActivityAt)
+        XCTAssertTrue(item.isMainWorktree)
+        XCTAssertEqual(item.creationDate, creationDate)
+    }
+}
+
+private func makeSailor(
+    id: String,
+    project: String,
+    worktreePath: String,
+    paneStatuses: [SailorStatus],
+    isMainWorktree: Bool,
+    lastActivityAt: Date?
+) -> SailorDisplayInfo {
+    let surface = Station()
+    return SailorDisplayInfo(
+        id: id,
+        name: id,
+        project: project,
+        thread: "feature",
+        paneStatuses: paneStatuses,
+        mostRecentMessage: "Working",
+        lastUserPrompt: "Implement grouping",
+        mostRecentPaneIndex: 0,
+        totalDuration: "00:01:00",
+        roundDuration: "00:00:30",
+        station: surface,
+        worktreePath: worktreePath,
+        paneCount: paneStatuses.count,
+        paneStations: [surface],
+        isMainWorktree: isMainWorktree,
+        tasks: [],
+        activityEvents: [],
+        lastActivityAge: "1m",
+        lastActivityAt: lastActivityAt,
+        gitStats: nil,
+        currentPaneTitle: id,
+        currentPaneRunTime: "30s"
+    )
+}

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -1,7 +1,10 @@
+import AppKit
 import XCTest
 @testable import seahelm
 
 final class DashboardOverviewGroupingTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 2_000_000)
+
     func testGroupingItemCarriesIdentityRepositoryStatusAndActivityDate() {
         let lastActivityAt = Date(timeIntervalSince1970: 1_721_234_567)
         let creationDate = Date(timeIntervalSince1970: 1_700_000_000)
@@ -23,6 +26,98 @@ final class DashboardOverviewGroupingTests: XCTestCase {
         XCTAssertEqual(item.lastActivityAt, lastActivityAt)
         XCTAssertTrue(item.isMainWorktree)
         XCTAssertEqual(item.creationDate, creationDate)
+    }
+
+    func testGroupingMenuUsesApprovedTitlesAndHasNoKeyboardShortcuts() {
+        withDefaults { defaults in
+            let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
+                                             defaults: defaults,
+                                             now: { self.now })
+
+            XCTAssertEqual(view.groupingMenuTitlesForTesting, [
+                "Group by Repository", "Group by Status", "Group by Time",
+            ])
+            XCTAssertEqual(view.groupingMenuKeyEquivalentsForTesting, ["", "", ""])
+            XCTAssertTrue(view.groupingButtonRefusesFirstResponderForTesting)
+        }
+    }
+
+    func testStoredStatusLoadsAsTheOnlyCheckedMode() {
+        withDefaults { defaults in
+            defaults.set("status", forKey: WorktreeGroupingPreference.key)
+
+            let view = DashboardOverviewView(frame: .zero, defaults: defaults, now: { self.now })
+
+            XCTAssertEqual(view.groupingModeForTesting, .status)
+            XCTAssertEqual(view.checkedGroupingModesForTesting, [.status])
+        }
+    }
+
+    func testInvalidStoredModeFallsBackToRepository() {
+        withDefaults { defaults in
+            defaults.set("not-a-mode", forKey: WorktreeGroupingPreference.key)
+
+            let view = DashboardOverviewView(frame: .zero, defaults: defaults, now: { self.now })
+
+            XCTAssertEqual(view.groupingModeForTesting, .repository)
+            XCTAssertEqual(view.checkedGroupingModesForTesting, [.repository])
+        }
+    }
+
+    func testChoosingStatusPersistsRendersAndRevealsSelectedRow() {
+        withDefaults { defaults in
+            let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
+                                             defaults: defaults,
+                                             now: { self.now })
+            view.selectedId = "run"
+            view.update([
+                makeSailor(id: "idle", project: "charlie", worktreePath: "/idle",
+                           paneStatuses: [.idle], isMainWorktree: false,
+                           lastActivityAt: now.addingTimeInterval(-300)),
+                makeSailor(id: "wait", project: "alpha", worktreePath: "/wait",
+                           paneStatuses: [.waiting], isMainWorktree: false,
+                           lastActivityAt: now.addingTimeInterval(-100)),
+                makeSailor(id: "run", project: "bravo", worktreePath: "/run",
+                           paneStatuses: [.running], isMainWorktree: false,
+                           lastActivityAt: now.addingTimeInterval(-200)),
+            ])
+            var callbackCount = 0
+            view.onGroupingChanged = { callbackCount += 1 }
+
+            view.selectGroupingModeForTesting(.status)
+
+            XCTAssertEqual(defaults.string(forKey: WorktreeGroupingPreference.key), "status")
+            XCTAssertEqual(view.renderedGroupTitlesForTesting, ["Needs input", "Running", "Idle"])
+            XCTAssertEqual(view.orderedRows.map(\.id), ["wait", "run", "idle"])
+            XCTAssertEqual(view.selectedId, "run")
+            XCTAssertEqual(view.renderedSelectedRowIDForTesting, "run")
+            XCTAssertEqual(view.revealedRowIDForTesting, "run")
+            XCTAssertEqual(callbackCount, 1)
+        }
+    }
+
+    func testGroupingButtonDescriptionReflectsCurrentMode() {
+        withDefaults { defaults in
+            let view = DashboardOverviewView(frame: .zero, defaults: defaults, now: { self.now })
+
+            XCTAssertEqual(view.groupingButtonToolTipForTesting, "Group worktrees by repository")
+            XCTAssertEqual(view.groupingButtonAccessibilityLabelForTesting,
+                           "Group worktrees by repository")
+
+            view.selectGroupingModeForTesting(.activityTime)
+
+            XCTAssertEqual(view.groupingButtonToolTipForTesting, "Group worktrees by time")
+            XCTAssertEqual(view.groupingButtonAccessibilityLabelForTesting,
+                           "Group worktrees by time")
+        }
+    }
+
+    private func withDefaults(_ body: (UserDefaults) -> Void) {
+        let suite = "DashboardOverviewGroupingTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        body(defaults)
     }
 }
 

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -96,6 +96,33 @@ final class DashboardOverviewGroupingTests: XCTestCase {
         }
     }
 
+    func testGroupingModeSwitchFallsBackFromStaleSelectionToFirstRow() {
+        withDefaults { defaults in
+            let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
+                                             defaults: defaults,
+                                             now: { self.now })
+            view.selectedId = "removed"
+            view.update([
+                makeSailor(id: "idle", project: "charlie", worktreePath: "/idle",
+                           paneStatuses: [.idle], isMainWorktree: false,
+                           lastActivityAt: now.addingTimeInterval(-300)),
+                makeSailor(id: "wait", project: "alpha", worktreePath: "/wait",
+                           paneStatuses: [.waiting], isMainWorktree: false,
+                           lastActivityAt: now.addingTimeInterval(-100)),
+                makeSailor(id: "run", project: "bravo", worktreePath: "/run",
+                           paneStatuses: [.running], isMainWorktree: false,
+                           lastActivityAt: now.addingTimeInterval(-200)),
+            ])
+
+            view.selectGroupingModeForTesting(.status)
+
+            XCTAssertEqual(view.orderedRows.map(\.id), ["wait", "run", "idle"])
+            XCTAssertEqual(view.selectedId, "wait")
+            XCTAssertEqual(view.renderedSelectedRowIDForTesting, "wait")
+            XCTAssertEqual(view.revealedRowIDForTesting, "wait")
+        }
+    }
+
     func testGroupingButtonDescriptionReflectsCurrentMode() {
         withDefaults { defaults in
             let view = DashboardOverviewView(frame: .zero, defaults: defaults, now: { self.now })

--- a/Tests/DashboardViewControllerClickTests.swift
+++ b/Tests/DashboardViewControllerClickTests.swift
@@ -51,6 +51,7 @@ private func makeSailor(id: String, worktreePath: String) -> SailorDisplayInfo {
         tasks: [],
         activityEvents: [],
         lastActivityAge: "",
+        lastActivityAt: nil,
         gitStats: nil,
         currentPaneTitle: id,
         currentPaneRunTime: ""

--- a/Tests/WorktreeGroupingTests.swift
+++ b/Tests/WorktreeGroupingTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+@testable import seahelm
+
+final class WorktreeGroupingTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 2_000_000)
+
+    private var utcCalendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+
+    private func item(
+        _ path: String,
+        repo: String,
+        status: SailorStatus = .idle,
+        activity: Date? = nil,
+        main: Bool = false,
+        created: Date = .distantPast
+    ) -> WorktreeGroupingItem {
+        WorktreeGroupingItem(
+            id: path,
+            path: path,
+            repository: repo,
+            status: status,
+            lastActivityAt: activity,
+            isMainWorktree: main,
+            creationDate: created
+        )
+    }
+
+    func testRepositoryGroupsRemainInFirstSeenOrderAndNormalizeEmptyName() {
+        let groups = WorktreeGrouping.groups([
+            item("/beta/linked", repo: "beta"),
+            item("/unknown", repo: ""),
+            item("/alpha", repo: "alpha"),
+            item("/beta/main", repo: "beta", main: true),
+        ], mode: .repository, now: now)
+
+        XCTAssertEqual(groups.map(\.title), ["beta", "Unknown repository", "alpha"])
+        XCTAssertEqual(groups.map(\.id), [
+            .repository("beta"),
+            .repository("Unknown repository"),
+            .repository("alpha"),
+        ])
+    }
+
+    func testRepositoryRowsSortMainFirstThenCreationDateThenPath() {
+        let old = Date(timeIntervalSince1970: 10)
+        let new = Date(timeIntervalSince1970: 20)
+        let groups = WorktreeGrouping.groups([
+            item("/repo/z-new", repo: "repo", created: new),
+            item("/repo/z-old", repo: "repo", created: old),
+            item("/repo/main", repo: "repo", main: true, created: new),
+            item("/repo/a-old", repo: "repo", created: old),
+        ], mode: .repository, now: now)
+
+        XCTAssertEqual(groups[0].items.map(\.path), [
+            "/repo/main", "/repo/a-old", "/repo/z-old", "/repo/z-new",
+        ])
+    }
+
+    func testStatusGroupsUseApprovedOrderAndTitles() {
+        let groups = WorktreeGrouping.groups([
+            item("/unknown", repo: "repo", status: .unknown),
+            item("/dormant", repo: "repo", status: .exited),
+            item("/error", repo: "repo", status: .error),
+            item("/idle", repo: "repo", status: .idle),
+            item("/running", repo: "repo", status: .running),
+            item("/waiting", repo: "repo", status: .waiting),
+        ], mode: .status, now: now)
+
+        XCTAssertEqual(groups.map(\.title), [
+            "Needs input", "Running", "Idle", "Error", "Dormant", "Unknown",
+        ])
+        XCTAssertEqual(groups.compactMap(\.status), [
+            .waiting, .running, .idle, .error, .exited, .unknown,
+        ])
+    }
+
+    func testStatusRowsSortByLatestActivityThenPath() {
+        let recent = now.addingTimeInterval(-10)
+        let old = now.addingTimeInterval(-30)
+        let groups = WorktreeGrouping.groups([
+            item("/none-z", repo: "repo", status: .running),
+            item("/old", repo: "repo", status: .running, activity: old),
+            item("/recent-z", repo: "repo", status: .running, activity: recent),
+            item("/recent-a", repo: "repo", status: .running, activity: recent),
+            item("/none-a", repo: "repo", status: .running),
+        ], mode: .status, now: now)
+
+        XCTAssertEqual(groups[0].items.map(\.path), [
+            "/recent-a", "/recent-z", "/old", "/none-a", "/none-z",
+        ])
+    }
+
+    func testActivityTimeBucketsUseUTCNowAndClampFutureActivity() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-07-20T12:00:00Z"))
+        let groups = WorktreeGrouping.groups([
+            item("/future", repo: "repo", activity: now.addingTimeInterval(60)),
+            item("/hour", repo: "repo", activity: now.addingTimeInterval(-3_599)),
+            item("/today", repo: "repo", activity: now.addingTimeInterval(-7_200)),
+            item("/recent-seven", repo: "repo", activity: now.addingTimeInterval(-2 * 86_400)),
+            item("/earlier", repo: "repo", activity: now.addingTimeInterval(-8 * 86_400)),
+            item("/none", repo: "repo"),
+        ], mode: .activityTime, now: now, calendar: utcCalendar)
+
+        XCTAssertEqual(groups.map(\.title), [
+            "Recent hour", "Today", "Recent 7 days", "Earlier", "No activity",
+        ])
+        XCTAssertEqual(groups[0].items.map(\.path), ["/future", "/hour"])
+    }
+
+    func testActivityTimeBucketsHonorExactHourAndSevenDayBoundaries() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-07-20T12:00:00Z"))
+        let groups = WorktreeGrouping.groups([
+            item("/exact-hour", repo: "repo", activity: now.addingTimeInterval(-3_600)),
+            item("/under-seven", repo: "repo", activity: now.addingTimeInterval(-(7 * 86_400 - 1))),
+            item("/exact-seven", repo: "repo", activity: now.addingTimeInterval(-7 * 86_400)),
+        ], mode: .activityTime, now: now, calendar: utcCalendar)
+
+        XCTAssertEqual(groups.map(\.id), [
+            .activity(.today), .activity(.recentSevenDays), .activity(.earlier),
+        ])
+        XCTAssertEqual(groups.map { $0.items.map(\.path) }, [
+            ["/exact-hour"], ["/under-seven"], ["/exact-seven"],
+        ])
+    }
+
+    func testActivityRowsSortByLatestActivityThenPath() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-07-20T12:00:00Z"))
+        let tied = now.addingTimeInterval(-7_200)
+        let groups = WorktreeGrouping.groups([
+            item("/today-z", repo: "repo", activity: tied),
+            item("/today-old", repo: "repo", activity: tied.addingTimeInterval(-60)),
+            item("/today-a", repo: "repo", activity: tied),
+            item("/none-z", repo: "repo"),
+            item("/none-a", repo: "repo"),
+        ], mode: .activityTime, now: now, calendar: utcCalendar)
+
+        XCTAssertEqual(groups[0].items.map(\.path), ["/today-a", "/today-z", "/today-old"])
+        XCTAssertEqual(groups[1].items.map(\.path), ["/none-a", "/none-z"])
+    }
+
+    func testPreferenceRoundTripsAndInvalidOrMissingValueFallsBack() {
+        let suite = "WorktreeGroupingTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let preference = WorktreeGroupingPreference(defaults: defaults)
+
+        XCTAssertEqual(preference.load(), .repository)
+        preference.save(.activityTime)
+        XCTAssertEqual(preference.load(), .activityTime)
+        XCTAssertEqual(defaults.string(forKey: WorktreeGroupingPreference.key), "activityTime")
+
+        defaults.set("broken", forKey: WorktreeGroupingPreference.key)
+        XCTAssertEqual(preference.load(), .repository)
+    }
+}

--- a/docs/superpowers/plans/2026-07-20-worktree-grouping-mode.md
+++ b/docs/superpowers/plans/2026-07-20-worktree-grouping-mode.md
@@ -1,0 +1,412 @@
+# Worktree Grouping Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent First Mate header menu that groups worktrees by repository, status, or last activity time.
+
+**Architecture:** Put grouping and preference decoding in a pure model. `DashboardOverviewView` translates `SailorDisplayInfo` values into grouping items, renders the resulting sections with its existing stack/row views, and continues deriving keyboard order from `orderedRows`.
+
+**Tech Stack:** Swift 5.10, AppKit, XCTest, UserDefaults, XcodeGen
+
+---
+
+## Preparation
+
+The approved spec is on a local `main` that is behind `origin/main`. Start from the latest remote code in an isolated worktree:
+
+```bash
+git fetch origin
+git worktree add ../seahelm-worktree-grouping -b feat/worktree-grouping origin/main
+cd ../seahelm-worktree-grouping
+git cherry-pick 1e38dcd
+```
+
+If `GhosttyKit.xcframework` is absent, run `scripts/setup.sh` with Zig 0.15.2 available. Never commit Ghostty build artifacts.
+
+## File Structure
+
+- Create `Sources/UI/Dashboard/WorktreeGrouping.swift` for pure grouping values, algorithms, and preference persistence.
+- Create `Tests/WorktreeGroupingTests.swift` for group order, time boundaries, stable sorting, and persistence.
+- Modify `Sources/UI/Dashboard/DashboardViewController.swift` for `lastActivityAt`, the header menu, model-driven rendering, and focus notification.
+- Modify `Sources/App/TabCoordinator.swift` to pass the authoritative activity date.
+- Modify `Tests/DashboardViewControllerClickTests.swift` to update its `SailorDisplayInfo` fixture.
+- Create `Tests/DashboardOverviewGroupingTests.swift` for AppKit menu, persistence, row order, and selection coverage.
+
+### Task 1: Pure Grouping And Preference Model
+
+**Files:**
+- Create: `Tests/WorktreeGroupingTests.swift`
+- Create: `Sources/UI/Dashboard/WorktreeGrouping.swift`
+
+- [ ] **Step 1: Write failing repository and status tests**
+
+Create `Tests/WorktreeGroupingTests.swift`:
+
+```swift
+import XCTest
+@testable import seahelm
+
+final class WorktreeGroupingTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 2_000_000)
+
+    private func item(_ path: String, repo: String, status: SailorStatus = .idle,
+                      activity: Date? = nil, main: Bool = false,
+                      created: Date = .distantPast) -> WorktreeGroupingItem {
+        WorktreeGroupingItem(id: path, path: path, repository: repo, status: status,
+                             lastActivityAt: activity, isMainWorktree: main,
+                             creationDate: created)
+    }
+
+    func testRepositoryGroupingKeepsCurrentOrdering() {
+        let old = Date(timeIntervalSince1970: 10)
+        let new = Date(timeIntervalSince1970: 20)
+        let groups = WorktreeGrouping.groups([
+            item("/b/new", repo: "beta", created: new),
+            item("/a/linked", repo: "alpha", created: old),
+            item("/b/main", repo: "beta", main: true, created: new),
+            item("/b/old", repo: "beta", created: old),
+        ], mode: .repository, now: now)
+        XCTAssertEqual(groups.map(\.title), ["beta", "alpha"])
+        XCTAssertEqual(groups[0].items.map(\.path), ["/b/main", "/b/old", "/b/new"])
+    }
+
+    func testRepositoryUsesPathAsCreationTimeTieBreaker() {
+        let groups = WorktreeGrouping.groups([
+            item("/repo/z", repo: "repo"), item("/repo/a", repo: "repo"),
+        ], mode: .repository, now: now)
+        XCTAssertEqual(groups[0].items.map(\.path), ["/repo/a", "/repo/z"])
+    }
+
+    func testStatusGroupingUsesApprovedOrderAndRecency() {
+        let groups = WorktreeGrouping.groups([
+            item("/idle", repo: "r", status: .idle, activity: now.addingTimeInterval(-5)),
+            item("/run-old", repo: "r", status: .running, activity: now.addingTimeInterval(-30)),
+            item("/wait", repo: "r", status: .waiting, activity: now),
+            item("/run-new", repo: "r", status: .running, activity: now.addingTimeInterval(-10)),
+            item("/error", repo: "r", status: .error, activity: now),
+            item("/exited", repo: "r", status: .exited, activity: now),
+        ], mode: .status, now: now)
+        XCTAssertEqual(groups.map(\.title), ["Needs input", "Running", "Idle", "Error", "Dormant"])
+        XCTAssertEqual(groups[1].items.map(\.path), ["/run-new", "/run-old"])
+    }
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug test \
+  -only-testing:seahelmTests/WorktreeGroupingTests \
+  -skipPackagePluginValidation -skipMacroValidation
+```
+
+Expected: compilation fails because the grouping types do not exist.
+
+- [ ] **Step 3: Implement repository/status grouping**
+
+Create `Sources/UI/Dashboard/WorktreeGrouping.swift` with these exact module-level types:
+
+```swift
+import Foundation
+
+enum WorktreeGroupingMode: String, CaseIterable { case repository, status, activityTime }
+enum WorktreeActivityBucket: String, CaseIterable {
+    case recentHour, today, recentSevenDays, earlier, noActivity
+}
+enum WorktreeGroupID: Hashable {
+    case repository(String), status(SailorStatus), activity(WorktreeActivityBucket)
+}
+struct WorktreeGroupingItem: Equatable {
+    let id: String
+    let path: String
+    let repository: String
+    let status: SailorStatus
+    let lastActivityAt: Date?
+    let isMainWorktree: Bool
+    let creationDate: Date
+}
+struct WorktreeGroup: Equatable {
+    let id: WorktreeGroupID
+    let title: String
+    let status: SailorStatus?
+    let items: [WorktreeGroupingItem]
+}
+```
+
+Implement `WorktreeGrouping.groups(_:mode:now:calendar:)`. Repository mode records keys in first-seen order, converts an empty name to `Unknown repository`, and sorts main first, creation date ascending, then path. Status mode iterates `[.waiting, .running, .idle, .error, .exited, .unknown]`, uses titles `Needs input`, `Running`, `Idle`, `Error`, `Dormant`, `Unknown`, and sorts activity descending with path as the final tie-breaker. Return `[]` temporarily for activity mode.
+
+- [ ] **Step 4: Run GREEN**
+
+Run the Step 2 command. Expected: three tests pass.
+
+- [ ] **Step 5: Add failing time and preference tests**
+
+Append:
+
+```swift
+func testActivityBucketsHonorExactBoundaries() {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    let now = ISO8601DateFormatter().date(from: "2026-07-20T12:00:00Z")!
+    let groups = WorktreeGrouping.groups([
+        item("/future", repo: "r", activity: now.addingTimeInterval(60)),
+        item("/hour", repo: "r", activity: now.addingTimeInterval(-3_599)),
+        item("/today", repo: "r", activity: now.addingTimeInterval(-3_600)),
+        item("/week", repo: "r", activity: now.addingTimeInterval(-6 * 86_400)),
+        item("/earlier", repo: "r", activity: now.addingTimeInterval(-7 * 86_400)),
+        item("/none", repo: "r", activity: nil),
+    ], mode: .activityTime, now: now, calendar: calendar)
+    XCTAssertEqual(groups.map(\.title),
+                   ["Recent hour", "Today", "Recent 7 days", "Earlier", "No activity"])
+    XCTAssertEqual(groups[0].items.map(\.path), ["/future", "/hour"])
+}
+
+func testPreferenceRoundTripsAndInvalidValueFallsBack() {
+    let suite = "WorktreeGroupingTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    defer { defaults.removePersistentDomain(forName: suite) }
+    let preference = WorktreeGroupingPreference(defaults: defaults)
+    preference.save(.activityTime)
+    XCTAssertEqual(preference.load(), .activityTime)
+    defaults.set("broken", forKey: WorktreeGroupingPreference.key)
+    XCTAssertEqual(preference.load(), .repository)
+}
+```
+
+- [ ] **Step 6: Run RED, then implement activity buckets and persistence**
+
+Run Step 2; expect the activity assertion and missing preference type to fail. Then add:
+
+```swift
+struct WorktreeGroupingPreference {
+    static let key = "seahelm.dashboard.worktreeGroupingMode"
+    let defaults: UserDefaults
+    init(defaults: UserDefaults = .standard) { self.defaults = defaults }
+    func load() -> WorktreeGroupingMode {
+        guard let raw = defaults.string(forKey: Self.key),
+              let mode = WorktreeGroupingMode(rawValue: raw) else { return .repository }
+        return mode
+    }
+    func save(_ mode: WorktreeGroupingMode) { defaults.set(mode.rawValue, forKey: Self.key) }
+}
+```
+
+Bucket by clamped age: `< 3_600` is Recent hour; otherwise same calendar day is Today; otherwise `< 7 * 86_400` is Recent 7 days; known older dates are Earlier; nil is No activity. Iterate buckets in that order and sort every bucket by activity descending, then path.
+
+- [ ] **Step 7: Run GREEN and commit**
+
+Run Step 2; expect all tests to pass.
+
+```bash
+git add Sources/UI/Dashboard/WorktreeGrouping.swift Tests/WorktreeGroupingTests.swift
+git commit -m "feat: model worktree grouping modes"
+```
+
+### Task 2: Carry Raw Activity Dates Into Grouping
+
+**Files:**
+- Modify: `Sources/UI/Dashboard/DashboardViewController.swift:15-55`
+- Modify: `Sources/UI/Dashboard/WorktreeGrouping.swift`
+- Modify: `Sources/App/TabCoordinator.swift:335-385`
+- Modify: `Tests/DashboardViewControllerClickTests.swift:30-65`
+- Create: `Tests/DashboardOverviewGroupingTests.swift`
+
+- [ ] **Step 1: Write a failing adapter test**
+
+Create `Tests/DashboardOverviewGroupingTests.swift` with a `makeSailor` helper based on `DashboardViewControllerClickTests`, and add:
+
+```swift
+func testGroupingItemUsesHighestStatusAndRawActivityDate() {
+    let activity = Date(timeIntervalSince1970: 1234)
+    let sailor = makeSailor(id: "agent", path: "/repo/feature", project: "repo",
+                            statuses: [.running, .error], lastActivityAt: activity)
+    let item = sailor.groupingItem(creationDate: Date(timeIntervalSince1970: 10))
+    XCTAssertEqual(item.status, .error)
+    XCTAssertEqual(item.lastActivityAt, activity)
+    XCTAssertEqual(item.repository, "repo")
+}
+```
+
+The helper supplies the latest `currentPaneTitle` and `currentPaneRunTime` initializer fields from `origin/main`.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug test \
+  -only-testing:seahelmTests/DashboardOverviewGroupingTests \
+  -skipPackagePluginValidation -skipMacroValidation
+```
+
+Expected: compilation fails because `lastActivityAt` and `groupingItem` are missing.
+
+- [ ] **Step 3: Add the field, adapter, and producer value**
+
+Add `let lastActivityAt: Date?` beside `lastActivityAge` in `SailorDisplayInfo`. In `WorktreeGrouping.swift`, add:
+
+```swift
+extension SailorDisplayInfo {
+    func groupingItem(creationDate: Date) -> WorktreeGroupingItem {
+        WorktreeGroupingItem(id: id, path: worktreePath, repository: project,
+            status: SailorStatus.highestPriority(paneStatuses),
+            lastActivityAt: lastActivityAt, isMainWorktree: isMainWorktree,
+            creationDate: creationDate)
+    }
+}
+```
+
+In `TabCoordinator`, pass the existing `lastActivity` local as `lastActivityAt: lastActivity`. Add `lastActivityAt: nil` to `DashboardViewControllerClickTests` and the supplied date to the new fixture.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug test \
+  -only-testing:seahelmTests/DashboardOverviewGroupingTests \
+  -only-testing:seahelmTests/DashboardViewControllerClickTests \
+  -skipPackagePluginValidation -skipMacroValidation
+git add Sources/UI/Dashboard/DashboardViewController.swift Sources/UI/Dashboard/WorktreeGrouping.swift \
+  Sources/App/TabCoordinator.swift Tests/DashboardViewControllerClickTests.swift \
+  Tests/DashboardOverviewGroupingTests.swift
+git commit -m "refactor: expose worktree activity dates to dashboard"
+```
+
+Expected: both test classes pass before committing.
+
+### Task 3: Add The Header Menu And Model-Driven Rendering
+
+**Files:**
+- Modify: `Sources/UI/Dashboard/DashboardViewController.swift:1595-2225`
+- Modify: `Tests/DashboardOverviewGroupingTests.swift`
+
+- [ ] **Step 1: Write failing AppKit tests**
+
+Use an isolated `UserDefaults` suite and injected fixed clock:
+
+```swift
+func testMenuLoadsAllModesAndChecksStoredMode() {
+    let context = makeView(storedMode: .status)
+    defer { context.defaults.removePersistentDomain(forName: context.suite) }
+    XCTAssertEqual(context.view.groupingMenuTitlesForTesting,
+                   ["Group by Repository", "Group by Status", "Group by Time"])
+    XCTAssertEqual(context.view.checkedGroupingModeForTesting, .status)
+}
+
+func testChoosingStatusPersistsRegroupsAndKeepsSelection() {
+    let context = makeView(storedMode: .repository)
+    defer { context.defaults.removePersistentDomain(forName: context.suite) }
+    let view = context.view
+    view.selectedId = "run"
+    view.update([
+        makeSailor(id: "idle", path: "/a/idle", project: "a", statuses: [.idle]),
+        makeSailor(id: "run", path: "/b/run", project: "b", statuses: [.running]),
+        makeSailor(id: "wait", path: "/a/wait", project: "a", statuses: [.waiting]),
+    ])
+    view.selectGroupingModeForTesting(.status)
+    XCTAssertEqual(view.renderedGroupTitlesForTesting, ["Needs input", "Running", "Idle"])
+    XCTAssertEqual(view.orderedRows.map(\.id), ["wait", "run", "idle"])
+    XCTAssertEqual(context.defaults.string(forKey: WorktreeGroupingPreference.key), "status")
+    XCTAssertEqual(view.selectedRowIDForTesting, "run")
+}
+
+func testInvalidStoredModeStartsInRepositoryMode() {
+    let context = makeView(rawStoredMode: "broken")
+    defer { context.defaults.removePersistentDomain(forName: context.suite) }
+    XCTAssertEqual(context.view.groupingModeForTesting, .repository)
+}
+```
+
+- [ ] **Step 2: Run RED**
+
+Run the Task 2 focused command. Expected: compilation fails because the injectable initializer and testing accessors are missing.
+
+- [ ] **Step 3: Add the button, native menu, and preference injection**
+
+In `DashboardOverviewView`:
+
+- Store `latestSailors`, an injected `() -> Date`, `WorktreeGroupingPreference`, and its loaded mode.
+- Keep `override init(frame:)` and `required init?(coder:)` on standard defaults; add an internal `init(frame:defaults:now:)` for tests.
+- Create an unbordered `NSButton` using `rectangle.3.group`, falling back to `☷`.
+- Add a flexible spacer and the button after `headerSub`; constrain the header row to both 15-point horizontal insets.
+- Build a native `NSMenu` with `Group by Repository`, `Group by Status`, and `Group by Time`; store each raw mode in `representedObject`, check only the active item, and assign no key equivalents.
+- On selection, save the mode, update checks plus tooltip/accessibility text, render `latestSailors`, reveal the selected row, and call a new `onGroupingChanged` closure.
+
+- [ ] **Step 4: Replace inline repo grouping with the pure model**
+
+In the renderer, build and group items exactly once:
+
+```swift
+let sailorsByPath = Dictionary(uniqueKeysWithValues: sailors.map { ($0.worktreePath, $0) })
+let items = sailors.map { $0.groupingItem(creationDate: Self.creationDate($0.worktreePath)) }
+let groups = WorktreeGrouping.groups(items, mode: groupingMode, now: now())
+```
+
+For each model group, render a header and existing `RowView`, then append `(id, path)` to `orderedRows`. Repository/time headers use neutral `inkDim`; status headers reuse `groupMeta` glyph/color/label. Track row views by ID so only a mode-triggered render calls `scrollToVisible` for the selected row. Expose internal read-only testing accessors used above.
+
+- [ ] **Step 5: Re-anchor keyboard focus after regrouping**
+
+During `DashboardViewController` setup, add:
+
+```swift
+overviewView.onGroupingChanged = { [weak self] in self?.syncOverviewFocusCounts() }
+```
+
+This reuses the controller's existing ID/path anchor instead of introducing another focus model.
+
+- [ ] **Step 6: Run GREEN and commit**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug test \
+  -only-testing:seahelmTests/WorktreeGroupingTests \
+  -only-testing:seahelmTests/DashboardOverviewGroupingTests \
+  -only-testing:seahelmTests/OverviewFocusModelTests \
+  -skipPackagePluginValidation -skipMacroValidation
+git add Sources/UI/Dashboard/DashboardViewController.swift Tests/DashboardOverviewGroupingTests.swift
+git commit -m "feat: switch First Mate worktree grouping"
+```
+
+Expected: all three focused test classes pass before committing.
+
+### Task 4: Regression And Visual Verification
+
+**Files:**
+- Modify only `seahelm.xcodeproj/project.pbxproj` if XcodeGen registers new files.
+
+- [ ] **Step 1: Regenerate and inspect project membership**
+
+```bash
+xcodegen generate
+git status --short
+```
+
+Expected: successful generation. Keep a project-file change only when it registers the new source/test files.
+
+- [ ] **Step 2: Run the full unit suite and build**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug test \
+  -skipPackagePluginValidation -skipMacroValidation
+xcodebuild -project seahelm.xcodeproj -scheme seahelm -configuration Debug build \
+  -skipPackagePluginValidation -skipMacroValidation
+```
+
+Expected: `** TEST SUCCEEDED **` and `** BUILD SUCCEEDED **`. If Ghostty linking fails, preserve the exact output and report the infrastructure blocker without claiming success.
+
+- [ ] **Step 3: Verify the UI manually**
+
+Launch the debug app and confirm the right-aligned icon, native menu checkmark, unchanged repository order, approved status/time ordering, selected-row visibility across switches, restart persistence, and readable light/dark appearances.
+
+- [ ] **Step 4: Inspect and finish the diff**
+
+```bash
+git diff --check
+git status --short
+git diff --stat origin/main...HEAD
+```
+
+If XcodeGen changed only project membership:
+
+```bash
+git add seahelm.xcodeproj/project.pbxproj
+git commit -m "chore: register worktree grouping sources"
+```
+
+Expected: no Ghostty artifacts, build outputs, or `.superpowers/brainstorm` files are tracked.

--- a/docs/superpowers/specs/2026-07-20-worktree-grouping-mode-design.md
+++ b/docs/superpowers/specs/2026-07-20-worktree-grouping-mode-design.md
@@ -1,0 +1,117 @@
+# Worktree Grouping Mode Design
+
+## Goal
+
+Add a grouping control to the right side of the First Mate header so users can organize worktree rows by repository, status, or last activity time. The selected mode persists across app launches.
+
+## Scope
+
+- Add one grouping button and native menu to the First Mate header.
+- Support repository, status, and activity-time grouping.
+- Preserve existing worktree selection, row actions, and keyboard navigation.
+- Persist the last selected grouping mode.
+- Do not add global keyboard shortcuts or replace the existing stack-based list.
+
+## Architecture
+
+Introduce a pure grouping model outside the AppKit rendering code:
+
+- `WorktreeGroupingMode` defines `.repository`, `.status`, and `.activityTime`.
+- `WorktreeGroup` contains a stable identifier, display title, optional status presentation, and its ordered worktrees.
+- `WorktreeGrouping.groups(sailors:mode:now:)` transforms `[SailorDisplayInfo]` into deterministically ordered sections.
+
+`DashboardOverviewView` owns the current mode, asks the grouping model for sections, and renders those sections using the existing stack and row views. It rebuilds `orderedRows` in rendered order so the current keyboard navigation model continues to work without a second ordering source.
+
+The selected worktree is anchored by ID/path across a mode change. After rebuilding, the view restores its highlight and scroll visibility at the worktree's new position. It falls back to the first row only when that worktree no longer exists.
+
+## Activity Data
+
+Add `lastActivityAt: Date?` to `SailorDisplayInfo`. `TabCoordinator` supplies the same authoritative value already used elsewhere:
+
+```swift
+statusAggregator.lastActivity(for: agent.worktreePath) ?? agent.startedAt
+```
+
+Grouping uses this date directly. It must not parse the localized display string such as `"2h"`, and it must not rely solely on activity events, which may be empty even when persisted activity exists.
+
+## Grouping And Ordering
+
+### Repository
+
+- Group by repository display name.
+- Preserve repository groups in first-seen order, which follows the configured card/workspace order.
+- Preserve the current within-repository behavior: main worktree first, then linked worktrees by directory creation time from oldest to newest.
+- Use worktree path as the stable tie-breaker when creation times match.
+- Empty repository names share an `Unknown repository` group.
+
+### Status
+
+- Roll up pane states with `SailorStatus.highestPriority`, so the status identity follows the existing `Waiting > Error > Exited > Running > Idle > Unknown` pane arbitration.
+- Order groups as: Needs input, Running, Idle, Error, Dormant, Unknown.
+- Map `.exited` to the Dormant group; all other statuses map to their matching group.
+- Order worktrees within each group by `lastActivityAt` descending, then worktree path ascending.
+
+### Activity Time
+
+Calculate buckets against the injected `now` value so boundaries are deterministic and testable:
+
+1. Recent hour: activity less than 60 minutes old.
+2. Today: activity at least 60 minutes old but on the same local calendar day as `now`.
+3. Recent 7 days: activity before today but less than 7 times 24 hours old.
+4. Earlier: known activity at least 7 times 24 hours old.
+5. No activity: no known activity date.
+
+Order buckets as listed. Order worktrees within each bucket by activity descending, then worktree path ascending. Rows with no activity sort by path.
+
+Future timestamps are clamped into the Recent hour bucket rather than creating another group.
+
+## Header Interaction
+
+Add an unbordered icon button at the far right of the existing First Mate header row. Use the `rectangle.3.group` SF Symbol, sized and tinted to match the existing header controls. If that symbol is unavailable, fall back to a compact `☷` text glyph.
+
+Clicking the button opens a native `NSMenu` with:
+
+- Group by Repository
+- Group by Status
+- Group by Time
+
+The active item has a checkmark. Selecting an item closes the menu, rebuilds the worktree list immediately, updates the button tooltip/accessibility label, and persists the raw mode value in `UserDefaults`.
+
+The button does not join the overview's arrow-key focus ring. Native menu keyboard behavior remains available, but this feature adds no global shortcuts.
+
+## Persistence And Compatibility
+
+Use the dedicated `seahelm.dashboard.worktreeGroupingMode` `UserDefaults` key for the grouping mode. The default is repository grouping, matching the current user-facing layout. Missing or invalid stored values silently fall back to repository mode.
+
+The grouping preference is presentation-only and does not belong in the repository/workspace configuration model.
+
+## Rendering
+
+Each `WorktreeGroup` maps to the existing group-header plus vertical rows-box structure:
+
+- Repository headers show the repository name.
+- Status headers reuse existing status glyphs, colors, and labels.
+- Time headers use neutral header styling and the approved labels: Recent hour, Today, Recent 7 days, Earlier, No activity.
+
+Existing `RowView` behavior is unchanged. Repo tags may remain visible in status and time modes; in repository mode they may be omitted when redundant, matching the current grouped-by-repo appearance.
+
+## Testing
+
+Pure unit tests cover:
+
+- Repository first-seen ordering, main-worktree priority, and creation-time row ordering.
+- Status arbitration, fixed status order, and recency sorting.
+- All activity buckets, including exact 60-minute and 7-day boundaries.
+- Same-day handling, missing dates, and future timestamps.
+- Stable path tie-breakers.
+- Preference decoding and invalid-value fallback.
+
+Focused AppKit tests cover:
+
+- The header exposes all three menu items.
+- The active menu item is checked.
+- Choosing an item updates and persists the mode.
+- `orderedRows` matches rendered group order after each mode switch.
+- Selection remains anchored to the same worktree after regrouping.
+
+Run the focused grouping and dashboard tests first, then the full `seahelmTests` scheme. If repository-level Ghostty linking remains unavailable, report that infrastructure failure separately from focused pure-model test results.

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		2BC7A5243BDCCBADED457B44 /* SplitContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF31BD8D110A45D923D8B7D /* SplitContainerView.swift */; };
 		2C2802EE819E3CFE15765F18 /* WebhookStatusProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D1A230FCEF8663316AD13F /* WebhookStatusProviderTests.swift */; };
 		2CE3679CE395A49CDD452CEB /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358662BE2D7B5944F3C610F9 /* FuzzyMatchTests.swift */; };
+		2D473084E59DC7776E010F78 /* WorktreeGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448BBAB293764647E8FDB894 /* WorktreeGroupingTests.swift */; };
 		2F081A963842FF92DB2D1568 /* CodexHooksSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D815BD3789070197196037 /* CodexHooksSetupTests.swift */; };
 		2F5B5EC7F0428265CC344717 /* CodexHooksSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51B009382FE3586E735355D /* CodexHooksSetup.swift */; };
 		303FCEA37D46939EB9451358 /* WorktreeCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A85CAE555196AE450DDD90E /* WorktreeCreatorTests.swift */; };
@@ -164,6 +165,7 @@
 		8579DC09CEA0D01A125D5273 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C282D98A9A6117C70B06D3F1 /* NotificationManager.swift */; };
 		859DBEFE2BAE0BA0C975FD3E /* TaskProgressParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EE31EC02520149C8E193C0 /* TaskProgressParser.swift */; };
 		865D7441D1C630BD73850210 /* WeComFrameParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 401A403F90AAF10933AC1869 /* WeComFrameParser.swift */; };
+		86EB2D1A015733623B873AA9 /* WorktreeGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B4DF69385BC294488EF109 /* WorktreeGrouping.swift */; };
 		88159AB787745A8A302E0FB2 /* PaneStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D19639EE57241F8A021EBD2 /* PaneStatus.swift */; };
 		88FC5A9FA39ABA172ED4FAD7 /* SessionLaunchCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA54BB7C78ECA381712451D9 /* SessionLaunchCommandTests.swift */; };
 		89A6025BEEB8CC143CD40664 /* AgentManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8C0AA934FBBE1D3F9E6831 /* AgentManifest.swift */; };
@@ -396,6 +398,7 @@
 		1DB77CC892E8D4F3F9285B90 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		1E7D509CBBC0E7A5A275DC5F /* SailorDisplayHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SailorDisplayHelpers.swift; sourceTree = "<group>"; };
 		201D21B0CA40F70C2EDF3073 /* CursorSessionTitleLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorSessionTitleLookupTests.swift; sourceTree = "<group>"; };
+		20B4DF69385BC294488EF109 /* WorktreeGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeGrouping.swift; sourceTree = "<group>"; };
 		20D815BD3789070197196037 /* CodexHooksSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHooksSetupTests.swift; sourceTree = "<group>"; };
 		20E2397B00081F3F0861460E /* SeahelmUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmUITestCase.swift; sourceTree = "<group>"; };
 		20E7934A548F91E1E9FB161C /* SmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTests.swift; sourceTree = "<group>"; };
@@ -456,6 +459,7 @@
 		42E7300FEE6468E0C6CDD629 /* DashboardViewControllerClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewControllerClickTests.swift; sourceTree = "<group>"; };
 		42F821C1D0FA64C98C0E1E1B /* StatusBarModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarModeTests.swift; sourceTree = "<group>"; };
 		446946B61962D55D1395F45B /* BridgeCommandRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeCommandRouterTests.swift; sourceTree = "<group>"; };
+		448BBAB293764647E8FDB894 /* WorktreeGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeGroupingTests.swift; sourceTree = "<group>"; };
 		46776FFD2F37DD5907B7D108 /* ScanDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDecoderTests.swift; sourceTree = "<group>"; };
 		472ACEFBD0F23747FC60EB0D /* TerminalHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalHeaderViewTests.swift; sourceTree = "<group>"; };
 		4775959C72857610AC1F12DC /* WorktreeStatusAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeStatusAggregator.swift; sourceTree = "<group>"; };
@@ -1148,6 +1152,7 @@
 				3A85CAE555196AE450DDD90E /* WorktreeCreatorTests.swift */,
 				810968D6A752BC9C5B9C5F27 /* WorktreeDeleterTests.swift */,
 				22DBAC51DE05D73135AD2889 /* WorktreeDiscoveryTests.swift */,
+				448BBAB293764647E8FDB894 /* WorktreeGroupingTests.swift */,
 				4C97F6C22C29552377720F4D /* WorktreePathNavigationTests.swift */,
 				63F011748A6A508BC66F267E /* WorktreeSidePanelViewControllerTests.swift */,
 				517E6B353B84EA6AE224E0C1 /* WorktreeStatusAggregatorTests.swift */,
@@ -1168,6 +1173,7 @@
 				1320CBDF38D301E85655F40B /* InlineWorktreeCreateView.swift */,
 				78D1BBB07A2822E90114369F /* OverviewFocusModel.swift */,
 				3B2A81A9280FBAAA13232BAF /* RepoColor.swift */,
+				20B4DF69385BC294488EF109 /* WorktreeGrouping.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -1592,6 +1598,7 @@
 				303FCEA37D46939EB9451358 /* WorktreeCreatorTests.swift in Sources */,
 				BAC8750B961A40953BC4841F /* WorktreeDeleterTests.swift in Sources */,
 				02D9F0D1B7092AAE247A22A1 /* WorktreeDiscoveryTests.swift in Sources */,
+				2D473084E59DC7776E010F78 /* WorktreeGroupingTests.swift in Sources */,
 				80C1779FA957EF77BB2331A1 /* WorktreePathNavigationTests.swift in Sources */,
 				E855FF11BD4FE2723AE442AD /* WorktreeSidePanelViewControllerTests.swift in Sources */,
 				C444DD64D874C76934185DD6 /* WorktreeStatusAggregatorTests.swift in Sources */,
@@ -1803,6 +1810,7 @@
 				D27F424356DE8B506B1C7C05 /* WorktreeDeleter.swift in Sources */,
 				56D7FA05EEF91495A4DCED81 /* WorktreeDiscovery.swift in Sources */,
 				3A5FD6063BF092FB51DC280A /* WorktreeGitStats.swift in Sources */,
+				86EB2D1A015733623B873AA9 /* WorktreeGrouping.swift in Sources */,
 				C33A3CB170F8BA3BB37273E5 /* WorktreePathNavigation.swift in Sources */,
 				37BE597E2E04BAF208D95E3D /* WorktreeSailorTypeStore.swift in Sources */,
 				75772A087B197B7F7050BC43 /* WorktreeShellActions.swift in Sources */,

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		B658CA193508F17D6F6BA66D /* TaskProgressParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 249CA31487C12997605E1512 /* TaskProgressParserTests.swift */; };
 		B6741AD0610A1614FBA90BD9 /* CodexUsageSummaryProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99EAA5845DC0E1B3FD6DD1E8 /* CodexUsageSummaryProviderTests.swift */; };
 		B75B1219050B0C1C0E3F19E2 /* DialogKeymapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D388764AD2E566CBAC633F5 /* DialogKeymapTests.swift */; };
+		B7A8FEFA89D2783828B0FA1B /* DashboardOverviewGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FF03037A58F3583369D621C /* DashboardOverviewGroupingTests.swift */; };
 		B8C02C585F290AD6D6F19006 /* SailorStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDDD8680C8FD209F2BB3CD1 /* SailorStatus.swift */; };
 		B9872FE3B3521117DCE17ADC /* WeChatChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A49DE692E146DF04DADA3B50 /* WeChatChannel.swift */; };
 		B9B140426C5752800B0F3B22 /* FocusPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D002748AEBEA4297919DC48 /* FocusPanelView.swift */; };
@@ -497,6 +498,7 @@
 		5E39B8D0CAEA529E6BA78F29 /* ShipLogIngestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShipLogIngestTests.swift; sourceTree = "<group>"; };
 		5E88C517CE4270179492479E /* ChoiceOptionParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceOptionParserTests.swift; sourceTree = "<group>"; };
 		5EE7B36FE936C4D60F026A14 /* CursorHooksSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorHooksSetupTests.swift; sourceTree = "<group>"; };
+		5FF03037A58F3583369D621C /* DashboardOverviewGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardOverviewGroupingTests.swift; sourceTree = "<group>"; };
 		60EEEE2451A4C40006552810 /* WorktreeTaskStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeTaskStore.swift; sourceTree = "<group>"; };
 		6192629F1DE8EF1143009BEE /* PaneTitleResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTitleResolver.swift; sourceTree = "<group>"; };
 		6378708EA7D9DC4EA6D7D108 /* NotificationHistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHistoryTests.swift; sourceTree = "<group>"; };
@@ -1056,6 +1058,7 @@
 				5EE7B36FE936C4D60F026A14 /* CursorHooksSetupTests.swift */,
 				201D21B0CA40F70C2EDF3073 /* CursorSessionTitleLookupTests.swift */,
 				BA242C3631BD163C19CFDD38 /* DashboardFocusControllerTests.swift */,
+				5FF03037A58F3583369D621C /* DashboardOverviewGroupingTests.swift */,
 				42E7300FEE6468E0C6CDD629 /* DashboardViewControllerClickTests.swift */,
 				1D388764AD2E566CBAC633F5 /* DialogKeymapTests.swift */,
 				911314F4B91E512511E3FC21 /* EventHubTests.swift */,
@@ -1502,6 +1505,7 @@
 				B560407D380ED3AC6F69226D /* CursorHooksSetupTests.swift in Sources */,
 				0B486DC8922CD428C8D48A90 /* CursorSessionTitleLookupTests.swift in Sources */,
 				43BD24E5D16ABA5AC477E89C /* DashboardFocusControllerTests.swift in Sources */,
+				B7A8FEFA89D2783828B0FA1B /* DashboardOverviewGroupingTests.swift in Sources */,
 				D6494907C3E68AED14842187 /* DashboardViewControllerClickTests.swift in Sources */,
 				B75B1219050B0C1C0E3F19E2 /* DialogKeymapTests.swift in Sources */,
 				0828C3010E294CFD37CFFE70 /* EventHubTests.swift in Sources */,


### PR DESCRIPTION
## Summary

- add a native First Mate header menu for grouping worktrees by repository, status, or activity time
- persist the selected grouping mode and fall back safely when the stored value is invalid
- preserve selection and keyboard focus across regrouping, including stale-selection fallback
- pass authoritative last-activity dates into the dashboard and add focused model/AppKit coverage

## Validation

- XcodeGen generation succeeded; project membership is current
- `git diff --check` passed
- independent specification and code-quality reviews passed with no Critical or Important findings
- focused and full XCTest commands compile the changed Swift sources, but test launch is blocked while linking the host app because the cached Ghostty library lacks `_ghostty_*` symbols
- the Debug app build is blocked by the same pre-existing Ghostty linker issue, so manual UI launch verification is pending

## UI behavior

The icon on the right side of the First Mate title opens a native menu with:

- Group by Repository
- Group by Status
- Group by Time