### PR TITLE
fix: surface Codex approval choices in First Mate

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -2190,7 +2190,18 @@ extension MainWindowController {
                 branch: order.action.branch,
                 deleteBranch: deleteBranch,
                 force: force)
-        } else if order.action.payload == "ask-user-question" {
+        } else if order.action.payload == FirstMateAction.screenChoicePayload {
+            // Permission prompts discovered from the viewport are not guaranteed
+            // to support digit shortcuts (Codex advertises y/p/esc). Drive the
+            // visible list relative to its current selected row instead.
+            if let idx = order.action.options?.firstIndex(of: optionText) {
+                let selectedIndex = StationRegistry.shared.station(forId: order.action.terminalID)
+                    .flatMap { $0.readViewportText() }
+                    .flatMap { ChoiceOptionParser.parse($0).firstIndex(where: \.selected) } ?? 0
+                ShipLog.shared.answerChoiceByArrows(
+                    to: order.action.terminalID, index: idx, from: selectedIndex)
+            }
+        } else if order.action.payload == FirstMateAction.askUserQuestionPayload {
             // AskUserQuestion TUI selects by digit; typing the label text would
             // land in the free-form field instead. Send the option's number —
             // sendCommand follows with a Return that confirms the selection.

--- a/Sources/Core/FirstMate.swift
+++ b/Sources/Core/FirstMate.swift
@@ -16,6 +16,13 @@ struct FirstMateAction: Equatable {
     /// Payload marking an AskUserQuestion card (answered by option NUMBER in the
     /// TUI). Such cards auto-resolve once the agent moves on (tool use / stop).
     static let askUserQuestionPayload = "ask-user-question"
+    /// A choice prompt discovered from the live terminal viewport. These are
+    /// answered with arrow keys because not every TUI supports number shortcuts.
+    static let screenChoicePayload = "screen-choice"
+
+    static func isQuestionPayload(_ payload: String?) -> Bool {
+        payload == askUserQuestionPayload || payload == screenChoicePayload
+    }
 
     let kind: FirstMateActionKind
     let zone: FirstMateZone
@@ -69,14 +76,20 @@ enum FirstMate {
         if case .question(let prompt, let options, let followups) = outcome.event.kind {
             guard !options.isEmpty else { return [] }
             let i = outcome.info
-            // AskUserQuestion card: the question itself is the summary, and the
-            // payload marks the tap handler to answer by option NUMBER (the TUI
-            // selects by digit), not by typing the label text.
+            let payload: String
+            if case .scan = outcome.event.source {
+                payload = FirstMateAction.screenChoicePayload
+            } else {
+                payload = FirstMateAction.askUserQuestionPayload
+            }
+            // The question itself is the summary. The payload tells the tap
+            // handler whether to answer a native tool by number or drive a
+            // viewport-discovered choice with arrow keys.
             return [FirstMateAction(kind: .suggestNextOrder, zone: .red,
                                     worktreePath: i.worktreePath, branch: i.branch,
                                     project: i.project, terminalID: i.id,
                                     message: String(prompt.prefix(200)),
-                                    payload: FirstMateAction.askUserQuestionPayload, options: options,
+                                    payload: payload, options: options,
                                     followups: followups.isEmpty ? nil : followups)]
         }
 

--- a/Sources/Core/FirstMateCoordinator.swift
+++ b/Sources/Core/FirstMateCoordinator.swift
@@ -29,6 +29,10 @@ final class FirstMateCoordinator {
             // the question card is stale, clear it. (AskUserQuestion's own
             // tool_use_start is decoded as .question, so it can't self-clear.)
             queue.resolveQuestion(terminalID: outcome.info.id)
+        case .screenObserved where outcome.newStatus != .waiting:
+            // A viewport-discovered permission dialog disappeared. Remove its
+            // card once the same pane is visibly no longer awaiting input.
+            queue.resolveQuestion(terminalID: outcome.info.id)
         default:
             break
         }

--- a/Sources/Core/PendingOrdersQueue.swift
+++ b/Sources/Core/PendingOrdersQueue.swift
@@ -73,7 +73,7 @@ final class PendingOrdersQueue {
     func resolveQuestion(terminalID: String) {
         let before = orders.count
         orders.removeAll {
-            $0.action.payload == FirstMateAction.askUserQuestionPayload
+            FirstMateAction.isQuestionPayload($0.action.payload)
                 && $0.action.terminalID == terminalID
         }
         if orders.count != before { notify() }

--- a/Sources/Core/ShipLog.swift
+++ b/Sources/Core/ShipLog.swift
@@ -295,10 +295,15 @@ class ShipLog {
             if hookWaitingSince[event.terminalID] == nil { hookWaitingSince[event.terminalID] = now }
             message = text
         case .question(let prompt, _, _):
-            // Agent is blocked on an AskUserQuestion choice — same as awaiting input.
-            next.hookStatus = .waiting
-            hookRunningSince[event.terminalID] = nil
-            if hookWaitingSince[event.terminalID] == nil { hookWaitingSince[event.terminalID] = now }
+            // Hook-native questions own hook status. Viewport-discovered choices
+            // own scan status so the next screen frame can clear them naturally.
+            if case .scan = event.source {
+                next.scanStatus = .waiting
+            } else {
+                next.hookStatus = .waiting
+                hookRunningSince[event.terminalID] = nil
+                if hookWaitingSince[event.terminalID] == nil { hookWaitingSince[event.terminalID] = now }
+            }
             message = prompt
         case .agentStopped(let success):
             next.hookStatus = success ? .idle : .error
@@ -611,12 +616,14 @@ class ShipLog {
 
     /// Answer an on-screen choice dialog by arrow keys: Down × index, then Return.
     /// For agent TUIs without digit shortcuts (opencode's question tool) — their
-    /// selection starts at index 0 when the dialog opens, so the offset is absolute
-    /// as long as the user hasn't moved it.
-    func answerChoiceByArrows(to terminalID: String, index: Int) {
+    /// `selectedIndex` defaults to the first row for native question tools, while
+    /// viewport-discovered prompts pass their currently highlighted row.
+    func answerChoiceByArrows(to terminalID: String, index: Int, from selectedIndex: Int = 0) {
         guard let station = StationRegistry.shared.station(forId: terminalID) else { return }
         DispatchQueue.main.async {
-            for _ in 0..<max(0, index) { station.sendText("\u{1b}[B") }
+            let offset = index - selectedIndex
+            let arrow = offset >= 0 ? "\u{1b}[B" : "\u{1b}[A"
+            for _ in 0..<abs(offset) { station.sendText(arrow) }
             // Same beat as sendCommand: let the TUI ingest the arrows first.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
                 station.sendEnterKey()

--- a/Sources/Status/ChoiceOptionParser.swift
+++ b/Sources/Status/ChoiceOptionParser.swift
@@ -21,29 +21,67 @@ enum ChoiceOptionParser {
     private static let line = try! NSRegularExpression(
         pattern: "^\\s*([❯›>•*]?)\\s*(\\d+)\\.\\s+(.+?)\\s*$")
 
-    /// Parse the numbered choice list from the bottom of a screen snapshot.
+    /// Parse the last numbered choice list near the bottom of a screen snapshot.
     /// Returns [] unless there are ≥2 options numbered consecutively from 1
-    /// (avoids matching stray "1. foo" prose in normal output).
+    /// (avoids matching stray "1. foo" prose in normal output). Wrapped option
+    /// labels and footer text after the list are both supported.
     static func parse(_ screen: String, bottomLines: Int = 25) -> [Option] {
         let lines = screen.split(separator: "\n", omittingEmptySubsequences: false).suffix(bottomLines)
-        var opts: [Option] = []
+        var current: [Option] = []
+        var lastValid: [Option] = []
+        var continuationColumn = Int.max
+
+        func finishRun() {
+            if current.count >= 2, current.contains(where: \.selected) {
+                lastValid = current
+            }
+            current.removeAll()
+            continuationColumn = Int.max
+        }
+
         for raw in lines {
             let s = String(raw)
             let ns = s as NSString
-            guard let m = line.firstMatch(in: s, range: NSRange(location: 0, length: ns.length)),
-                  let idx = Int(ns.substring(with: m.range(at: 2))) else {
-                // A non-option line between options breaks the run; keep only a
-                // trailing contiguous block.
-                if !opts.isEmpty && !s.trimmingCharacters(in: .whitespaces).isEmpty { opts.removeAll() }
+            if let m = line.firstMatch(in: s, range: NSRange(location: 0, length: ns.length)),
+               let idx = Int(ns.substring(with: m.range(at: 2))) {
+                if idx == 1 { finishRun() }
+                guard idx == current.count + 1 else {
+                    finishRun()
+                    continue
+                }
+                let cursor = ns.substring(with: m.range(at: 1))
+                let label = ns.substring(with: m.range(at: 3))
+                current.append(Option(index: idx, label: label, selected: !cursor.isEmpty))
+                continuationColumn = m.range(at: 3).location
                 continue
             }
-            let cursor = ns.substring(with: m.range(at: 1))
-            let label = ns.substring(with: m.range(at: 3))
-            opts.append(Option(index: idx, label: label, selected: !cursor.isEmpty))
+
+            let trimmed = s.trimmingCharacters(in: .whitespaces)
+            guard !current.isEmpty else {
+                // Only harmless choice-dialog chrome may trail a completed run.
+                // Any real content means an older list in the viewport is stale.
+                if !trimmed.isEmpty, !isChoiceFooter(trimmed) {
+                    lastValid.removeAll()
+                }
+                continue
+            }
+            let leading = s.prefix { $0 == " " || $0 == "\t" }.count
+            if !trimmed.isEmpty, leading >= continuationColumn, let previous = current.popLast() {
+                current.append(Option(index: previous.index,
+                                      label: previous.label + " " + trimmed,
+                                      selected: previous.selected))
+            } else {
+                // A footer (for example Codex's "Press enter to confirm") ends
+                // the list but must not discard the valid options above it.
+                finishRun()
+            }
         }
-        // Validate: consecutive 1..n, at least 2.
-        guard opts.count >= 2 else { return [] }
-        for (i, o) in opts.enumerated() where o.index != i + 1 { return [] }
-        return opts
+        finishRun()
+        return lastValid
+    }
+
+    private static func isChoiceFooter(_ text: String) -> Bool {
+        let lower = text.lowercased()
+        return lower.contains("press enter") && (lower.contains("confirm") || lower.contains("cancel"))
     }
 }

--- a/Sources/Status/StatusPublisher.swift
+++ b/Sources/Status/StatusPublisher.swift
@@ -286,6 +286,19 @@ class StatusPublisher {
                                       commandLine: commandLine, agentType: agentType,
                                       roundDuration: roundDur, tasks: webhookTasks))
             ShipLog.shared.ingest(normalized)
+
+            // Agent permission dialogs are rendered by the TUI rather than sent
+            // through Codex/Claude hooks. Surface their numbered choices through
+            // the same First Mate question-card pipeline used by native tools.
+            let choices = ChoiceOptionParser.parse(content)
+            if agentType.isAIAgent, !choices.isEmpty {
+                let question = NormalizedEvent(
+                    terminalID: terminalID, source: .scan,
+                    kind: .question(
+                        prompt: "\(agentType.displayName) requires approval",
+                        options: choices.map(\.label), followups: []))
+                ShipLog.shared.ingest(question)
+            }
             // The worktree aggregator is now fed from ShipLog outcomes (arbitrated
             // scan+hook+OSC) in TabCoordinator, not directly here — the scan path
             // is viewport-hash-gated and would push a stale idle while an agent is

--- a/Sources/UI/Island/OpenedSurfaceView.swift
+++ b/Sources/UI/Island/OpenedSurfaceView.swift
@@ -389,7 +389,7 @@ private struct SuggestionCard: View {
     let onDismiss: () -> Void
 
     private var isQuestion: Bool {
-        order.action.payload == FirstMateAction.askUserQuestionPayload
+        FirstMateAction.isQuestionPayload(order.action.payload)
     }
 
     var body: some View {

--- a/Tests/ChoiceOptionParserTests.swift
+++ b/Tests/ChoiceOptionParserTests.swift
@@ -34,6 +34,31 @@ final class ChoiceOptionParserTests: XCTestCase {
         XCTAssertTrue(opts[1].selected)
     }
 
+    func testParsesCodexApprovalWithWrappedOptionAndFooter() {
+        let screen = """
+        Would you like to run the following command?
+
+        Environment: local
+
+        Reason: Allow me to rebase the PR branch onto the latest main and
+        resolve its conflicts?
+
+        $ git rebase origin/main
+
+        ❯ 1. Yes, proceed (y)
+          2. Yes, and don't ask again for commands that start with `git rebase
+             origin/main` (p)
+          3. No, and tell Codex what to do differently (esc)
+
+        Press enter to confirm or esc to cancel
+        """
+        let opts = ChoiceOptionParser.parse(screen)
+        XCTAssertEqual(opts.map(\.index), [1, 2, 3])
+        XCTAssertEqual(opts[1].label,
+                       "Yes, and don't ask again for commands that start with `git rebase origin/main` (p)")
+        XCTAssertTrue(opts[0].selected)
+    }
+
     func testIgnoresNonConsecutiveProse() {
         // A numbered list in normal output must NOT be treated as a choice box.
         let screen = """
@@ -47,6 +72,16 @@ final class ChoiceOptionParserTests: XCTestCase {
 
     func testIgnoresSingleOption() {
         XCTAssertTrue(ChoiceOptionParser.parse("1. Only one").isEmpty)
+    }
+
+    func testDoesNotReturnStaleChoiceAboveNewOutput() {
+        let screen = """
+        ❯ 1. Approve
+          2. Reject
+
+        The command completed successfully.
+        """
+        XCTAssertTrue(ChoiceOptionParser.parse(screen).isEmpty)
     }
 
     func testEmptyScreen() {

--- a/Tests/FirstMateCoordinatorOutcomeTests.swift
+++ b/Tests/FirstMateCoordinatorOutcomeTests.swift
@@ -51,6 +51,24 @@ final class FirstMateCoordinatorOutcomeTests: XCTestCase {
         XCTAssertTrue(q.all().isEmpty, "answered AskUserQuestion card must clear on agent stop")
     }
 
+    func testRunningScreenFrameResolvesViewportQuestionCard() {
+        let q = PendingOrdersQueue()
+        let action = FirstMateAction(
+            kind: .suggestNextOrder, zone: .red, worktreePath: "/wt",
+            branch: "b", project: "p", terminalID: "t1",
+            message: "Codex requires approval",
+            payload: FirstMateAction.screenChoicePayload, options: ["Yes", "No"])
+        q.upsert(action)
+        let coord = FirstMateCoordinator(config: .default, queue: q,
+            notify: { _ in }, runInspection: { _ in })
+        coord.handle(outcome(
+            kind: .screenObserved(status: .running, message: "", activity: [],
+                                  commandLine: nil, agentType: .codex,
+                                  roundDuration: 0, tasks: []),
+            changed: true, completion: false, newStatus: .running))
+        XCTAssertTrue(q.all().isEmpty)
+    }
+
     func testToolUseKeepsQuestionCardOfOtherWorktree() {
         let q = PendingOrdersQueue()
         q.upsert(questionAction(worktree: "/other", terminalID: "t2"))

--- a/Tests/FirstMateEvaluateOutcomeTests.swift
+++ b/Tests/FirstMateEvaluateOutcomeTests.swift
@@ -5,7 +5,8 @@ import XCTest
 /// the agent-suggestion path into the pure rule engine (no longer special-cased
 /// in FirstMateCoordinator).
 final class FirstMateEvaluateOutcomeTests: XCTestCase {
-    private func outcome(kind: NormalizedEventKind, changed: Bool = false,
+    private func outcome(kind: NormalizedEventKind, source: EventSource = .hook("claude-code"),
+                         changed: Bool = false,
                          completion: Bool = false, newStatus: SailorStatus = .running,
                          hold: Double = 0) -> IngestOutcome {
         let info = SailorInfo(id: "t1", worktreePath: "/wt", agentType: .claudeCode,
@@ -14,7 +15,7 @@ final class FirstMateEvaluateOutcomeTests: XCTestCase {
                               channel: nil, taskProgress: TaskProgress())
         return IngestOutcome(info: info, statusChanged: changed, oldStatus: .running,
                              newStatus: newStatus, holdSeconds: hold, isCompletionSignal: completion,
-                             event: NormalizedEvent(terminalID: "t1", source: .hook("claude-code"), kind: kind))
+                             event: NormalizedEvent(terminalID: "t1", source: source, kind: kind))
     }
 
     func testSuggestEventEmitsRedSuggestNextOrderWithOptions() {
@@ -43,6 +44,15 @@ final class FirstMateEvaluateOutcomeTests: XCTestCase {
         let acts = FirstMate.evaluate(
             outcome(kind: .question(prompt: "Pick?", options: [], followups: [])), config: .default)
         XCTAssertTrue(acts.isEmpty)
+    }
+
+    func testScreenChoiceUsesViewportPayloadMarker() {
+        let acts = FirstMate.evaluate(
+            outcome(kind: .question(prompt: "Codex requires approval",
+                                    options: ["Yes", "No"], followups: []),
+                    source: .scan),
+            config: .default)
+        XCTAssertEqual(acts.first?.payload, FirstMateAction.screenChoicePayload)
     }
 
     func testStatusTransitionRoutedThroughOutcomeEntry() {

--- a/docs/suggestion-flow.md
+++ b/docs/suggestion-flow.md
@@ -51,9 +51,13 @@ end-of-turn Stop fell through to `Y` and forced a wasted round-trip.
 `sessionSuggestedAt[turnKey]` is cleared on each new `.userPrompt`. A fresh user
 message starts a new turn, so the agent must suggest again.
 
-## Not the same thing: `pane.options`
+## Viewport choices — permission prompts and `pane.options`
 
 `SeahelmControlDataSource.paneOptions(paneId:)` reads the pane's **live viewport
 text** and parses on-screen choices via `ChoiceOptionParser` (Happy-style
-detection of permission prompts / AskUserQuestion). That is screen scanning, a
-separate channel from the `seahelm-suggest` hook events described above.
+detection of permission prompts / AskUserQuestion). The status poller uses the
+same parser to emit a screen-native question event, which becomes a First Mate
+card on desktop. Picking a card option drives the original TUI with arrow keys
+and Return. Wrapped labels and confirmation footers after the option list are
+supported. This remains a separate channel from the `seahelm-suggest` hook
+events described above.


### PR DESCRIPTION
## Summary

- parse wrapped Codex permission choices followed by the confirmation footer
- surface viewport choices as clickable First Mate question cards
- answer relative to the currently highlighted row and clear stale cards when the terminal resumes

## Validation

- actual ChoiceOptionParser harness passed against the captured Codex prompt
- git diff --check
- plutil -lint seahelm.xcodeproj/project.pbxproj
- targeted xcodebuild compiled the changed Swift sources; final test linking remains blocked by the existing GhosttyKit archive missing exported ghostty C symbols