### PR TITLE
fix: sync First Mate overview selection + status-dot spinner/overview work

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -1375,7 +1375,13 @@ dashboard.stationManager = terminalCoordinator.stationManager
     @objc private func handlePaneDidAcquireFocus(_ note: Notification) {
         guard let station = note.object as? Station else { return }
         let path = tabCoordinator.selectedSailor?.worktreePath ?? ""
-        guard let title = PaneTitleResolver.displayOscTitle(station.oscTitle, worktreePath: path) else { return }
+        // Prefer the live OSC title; on a fresh launch it hasn't arrived yet, so
+        // fall back to the pane's persisted (last-known) title instead of leaving
+        // the header stale.
+        let persisted = station.persistedTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = PaneTitleResolver.displayOscTitle(station.oscTitle, worktreePath: path)
+            ?? (persisted?.isEmpty == false ? persisted : nil)
+        guard let title else { return }
         windowChrome?.updateTerminalTitle(repo: "", pane: title)
     }
 
@@ -1391,10 +1397,15 @@ dashboard.stationManager = terminalCoordinator.stationManager
             ?? tabCoordinator.repoName(forWorktree: path)
 
         let paneTitle: String
-        if let tree = terminalCoordinator.stationManager.tree(forPath: path),
-           let stationId = PaneTitleResolver.focusedStationId(in: tree),
-           let focusedSailor = ShipLog.shared.sailors(forWorktree: path)
-            .first(where: { $0.id == stationId }) {
+        let worktreeSailors = ShipLog.shared.sailors(forWorktree: path)
+        if let info, !worktreeSailors.isEmpty {
+            // Current (focused) pane, or the most-recently-active pane otherwise.
+            let tree = terminalCoordinator.stationManager.tree(forPath: path)
+            let focusedSailor = PaneTitleResolver.representativeSailor(
+                focusedStationId: PaneTitleResolver.focusedStationId(in: tree),
+                among: worktreeSailors,
+                fallback: info
+            )
             paneTitle = PaneTitleResolver.title(for: focusedSailor)
         } else if let info {
             paneTitle = PaneTitleResolver.title(for: info)

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -158,8 +158,8 @@ class TabCoordinator {
         panel.canChooseDirectories = true
         panel.canChooseFiles = false
         panel.allowsMultipleSelection = false
-        panel.message = "Select a git repository to add"
-        panel.prompt = "Add Repo"
+        panel.message = "Select a directory to add (git repo or any folder)"
+        panel.prompt = "Add"
 
         guard let window else { return }
         panel.beginSheetModal(for: window) { [weak self] response in
@@ -198,7 +198,7 @@ class TabCoordinator {
     func integrateDiscoveredRepo(repoPath: String, worktrees: [WorktreeInfo], activateTab: Bool = true) -> Int {
         let effectiveWorktrees: [WorktreeInfo]
         if worktrees.isEmpty {
-            effectiveWorktrees = [WorktreeInfo(path: repoPath, branch: "main", commitHash: "", isMainWorktree: true)]
+            effectiveWorktrees = [WorktreeInfo(path: repoPath, branch: "", commitHash: "", isMainWorktree: true)]
         } else {
             effectiveWorktrees = worktrees
         }
@@ -348,10 +348,14 @@ class TabCoordinator {
                                             lastUserPrompt: mostRecentUserPrompt,
                                             branch: worktreeName) { _ in }
 
-            // Current pane = last-focused leaf in the split tree, else first pane.
-            let focusedStationId = PaneTitleResolver.focusedStationId(in: tree) ?? agent.id
-            let focusedSailor = (agentsByWorktree[agent.worktreePath] ?? [])
-                .first(where: { $0.id == focusedStationId }) ?? agent
+            // Worktree title = the current (focused) pane, or the most recently
+            // active pane when this worktree has no genuine focus.
+            let focusedStationId = PaneTitleResolver.focusedStationId(in: tree)
+            let focusedSailor = PaneTitleResolver.representativeSailor(
+                focusedStationId: focusedStationId,
+                among: agentsByWorktree[agent.worktreePath] ?? [],
+                fallback: agent
+            )
             let currentPaneTitle = PaneTitleResolver.title(for: focusedSailor)
             let currentPaneRunTime: String = {
                 if focusedSailor.status == .running, focusedSailor.roundDuration > 0 {
@@ -360,6 +364,21 @@ class TabCoordinator {
                 }
                 return lastActivityAge
             }()
+
+            // Per-pane rows for the expanded "Group by Sailor" mode. Aligned to
+            // paneStations (leaf order); title/status come from each pane's own
+            // ShipLog sailor, so sibling panes read distinctly.
+            let worktreeSailors = agentsByWorktree[agent.worktreePath] ?? []
+            let panes: [PaneDisplayInfo] = paneStations.map { paneStation in
+                let paneSailor = worktreeSailors.first(where: { $0.id == paneStation.id })
+                return PaneDisplayInfo(
+                    stationId: paneStation.id,
+                    title: paneSailor.map { PaneTitleResolver.title(for: $0) }
+                        ?? PaneTitleResolver.shortenPath(agent.worktreePath),
+                    status: paneSailor?.status ?? .unknown,
+                    isFocused: paneStation.id == focusedStationId
+                )
+            }
 
             result.append(SailorDisplayInfo(
                 id: agent.id,
@@ -383,7 +402,8 @@ class TabCoordinator {
                 lastActivityAt: lastActivity,
                 gitStats: gitStats,
                 currentPaneTitle: currentPaneTitle,
-                currentPaneRunTime: currentPaneRunTime
+                currentPaneRunTime: currentPaneRunTime,
+                panes: panes
             ))
         }
 
@@ -1054,9 +1074,12 @@ class TabCoordinator {
     }
 
     func restoreSessionState() {
-        // Restore selected agent card from config
+        // Restore selected agent card from config. Use commitWorktreeSelection
+        // (not selectSailor) so the left "First mate" overview selection stays in
+        // sync with the right-hand terminal — selectSailor moves only the terminal,
+        // leaving the overview highlight on the first row and mismatched on launch.
         if let savedPath = config.selectedWorktreePath {
-            dashboardVC?.selectSailor(byWorktreePath: savedPath)
+            dashboardVC?.commitWorktreeSelection(path: savedPath, focusTerminal: true)
         }
     }
 

--- a/Sources/Core/PaneTitleResolver.swift
+++ b/Sources/Core/PaneTitleResolver.swift
@@ -10,48 +10,51 @@ import Foundation
 /// 5. Branch
 /// 6. Worktree path (never a wandering tool cwd outside the worktree)
 enum PaneTitleResolver {
+    /// Resolution order (per-pane, never worktree-scoped, so sibling agent panes
+    /// stay distinct):
+    /// 1. Agent session title (per-session id) — *strong*, persisted
+    /// 2. OSC title (agent panes, live) — *strong*, persisted
+    /// 3. `Station.persistedTitle` — last strong title, so a restored pane shows
+    ///    its real title before a fresh OSC/session arrives after relaunch
+    /// 4. Shell command line (non-agent panes only)
+    /// 5. Branch name (the worktree default)
+    /// 6. Repo name, else the worktree path
+    ///
+    /// Steps 1–2 write the resolved title back to `Station.persistedTitle` so it
+    /// survives a relaunch (saved into the split layout).
     static func title(
         for sailor: SailorInfo,
         sessionTitle: (String, String) -> String? = { path, sid in
             SessionTitleLookup.title(worktreePath: path, sessionId: sid)
                 ?? CursorSessionTitleLookup.title(worktreePath: path, sessionId: sid)
         },
-        worktreeSessionTitle: (String) -> String? = { path in
-            SessionTitleLookup.title(worktreePath: path)
-                ?? CursorSessionTitleLookup.title(worktreePath: path)
-        },
         pathDisplay: (String) -> String = { shortenPath($0) }
     ) -> String {
-        // The terminal's own OSC title is the only per-pane source that updates
-        // live. Everything below it is either worktree-scoped (identical for
-        // sibling agent panes, so switching panes appeared to do nothing) or
-        // only refreshed when the agent next writes — hence a title that moved
-        // on message, not on click.
-        if isAgentPane(sailor), let osc = oscTitle(for: sailor) {
-            return osc
-        }
-
-        // Per-session next — two agents in one tree must not share a title.
+        // 1. Per-session agent title — two agents in one tree must not share it.
         if let ref = sailor.station?.agentSessionRef, ref.kind == .id,
            let title = sessionTitle(sailor.worktreePath, ref.sessionId)?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !title.isEmpty {
+            sailor.station?.persistedTitle = title
             return title
         }
 
-        // Worktree-scoped session title only for agent panes. A shell sibling
-        // must not inherit the agent session name (e.g. "Seahelm Layout Redesign").
-        if isAgentPane(sailor),
-           let title = worktreeSessionTitle(sailor.worktreePath)?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-           !title.isEmpty {
-            return title
+        // 2. The terminal's own OSC title — the only per-pane source that updates
+        // live, so it wins for agent panes.
+        if isAgentPane(sailor), let osc = oscTitle(for: sailor) {
+            sailor.station?.persistedTitle = osc
+            return osc
         }
 
-        let prompt = sailor.lastUserPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !prompt.isEmpty { return prompt }
+        // 3. Last-known strong title, restored from the saved layout. Bridges the
+        // startup gap where OSC/session data hasn't landed yet — without it every
+        // restored pane collapsed to the same branch/repo fallback.
+        if let persisted = sailor.station?.persistedTitle?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !persisted.isEmpty {
+            return persisted
+        }
 
-        // Shell command only when this pane isn't an AI agent — otherwise a
+        // 4. Shell command only when this pane isn't an AI agent — otherwise a
         // cursor-agent tool `cd` would steal the row title.
         if !isAgentPane(sailor),
            let cmd = sailor.commandLine?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -59,10 +62,34 @@ enum PaneTitleResolver {
             return cmd
         }
 
+        // 5. Branch (the worktree default).
         let branch = sailor.branch.trimmingCharacters(in: .whitespacesAndNewlines)
         if !branch.isEmpty { return branch }
 
+        // 6. Repo name, else the worktree path.
+        let project = sailor.project.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !project.isEmpty { return project }
         return pathDisplay(displayPath(for: sailor))
+    }
+
+    /// The pane whose title represents the whole worktree: the current (focused)
+    /// pane when it maps to a live sailor, otherwise the most-recently-active
+    /// pane (by `activityEvents`, then `startedAt`). `fallback` is returned only
+    /// when the worktree has no panes at all.
+    static func representativeSailor(
+        focusedStationId: String?,
+        among sailors: [SailorInfo],
+        fallback: SailorInfo
+    ) -> SailorInfo {
+        if let focusedStationId,
+           let focused = sailors.first(where: { $0.id == focusedStationId }) {
+            return focused
+        }
+        return sailors.max(by: { lastActivity($0) < lastActivity($1) }) ?? fallback
+    }
+
+    private static func lastActivity(_ sailor: SailorInfo) -> Date {
+        sailor.activityEvents.map(\.timestamp).max() ?? sailor.startedAt ?? .distantPast
     }
 
     /// Last-selected leaf in the tree, else the first leaf, else `nil`.

--- a/Sources/Core/SailorStatus.swift
+++ b/Sources/Core/SailorStatus.swift
@@ -8,17 +8,34 @@ enum SailorStatus: String, Codable {
     case exited = "Exited"
     case unknown = "Unknown"
 
+    /// Single source of truth for the status dot's colour — used by the
+    /// dashboard worktree card and the "group by status" headers alike.
     var color: NSColor {
         switch self {
         case .running:  return SemanticColors.running
+        case .waiting:  return SemanticColors.attention
         case .idle:     return SemanticColors.idle
-        case .waiting:  return SemanticColors.waiting
         case .error:    return SemanticColors.danger
         case .exited:   return SemanticColors.idle
         case .unknown:  return SemanticColors.subtle
         }
     }
 
+    /// Dot glyph. `running` is drawn as a spinning arc by `SpinnerDotView`;
+    /// this glyph is its static fallback (and what the group header shows).
+    var glyph: String {
+        switch self {
+        case .running:  return "◐"
+        case .waiting:  return "●"
+        case .idle:     return "○"
+        case .error:    return "✕"
+        case .exited:   return "◌"
+        case .unknown:  return "◌"
+        }
+    }
+
+    /// Text glyph for notifications, the island, and ShipLog markdown — plain
+    /// characters that read well inline (distinct from the dashboard `glyph`).
     var icon: String {
         switch self {
         case .running:  return "●"
@@ -27,6 +44,18 @@ enum SailorStatus: String, Codable {
         case .error:    return "✕"
         case .exited:   return "◻"
         case .unknown:  return "?"
+        }
+    }
+
+    /// Human label for the "group by status" section headers.
+    var groupLabel: String {
+        switch self {
+        case .running:  return "Running"
+        case .waiting:  return "Needs input"
+        case .idle:     return "Idle"
+        case .error:    return "Error"
+        case .exited:   return "Dormant"
+        case .unknown:  return "Unknown"
         }
     }
 }

--- a/Sources/Core/SessionManager.swift
+++ b/Sources/Core/SessionManager.swift
@@ -32,7 +32,7 @@ enum SessionManager {
 
     static func sessionNames(in layout: CodableSplitNode) -> [String] {
         switch layout {
-        case .leaf(let sessionName):
+        case .leaf(let sessionName, _):
             return [sessionName]
         case .split(_, _, let first, let second):
             return sessionNames(in: first) + sessionNames(in: second)

--- a/Sources/Terminal/SplitNode.swift
+++ b/Sources/Terminal/SplitNode.swift
@@ -147,11 +147,11 @@ indirect enum SplitNode {
 
 /// Serializable split layout (no live station references).
 indirect enum CodableSplitNode: Codable {
-    case leaf(sessionName: String)
+    case leaf(sessionName: String, title: String?)
     case split(axis: String, ratio: Double, first: CodableSplitNode, second: CodableSplitNode)
 
     private enum CodingKeys: String, CodingKey {
-        case type, sessionName, axis, ratio, first, second
+        case type, sessionName, title, axis, ratio, first, second
     }
 
     init(from decoder: Decoder) throws {
@@ -159,7 +159,8 @@ indirect enum CodableSplitNode: Codable {
         let type = try container.decode(String.self, forKey: .type)
         if type == "leaf" {
             let name = try container.decode(String.self, forKey: .sessionName)
-            self = .leaf(sessionName: name)
+            let title = try container.decodeIfPresent(String.self, forKey: .title)
+            self = .leaf(sessionName: name, title: title)
         } else {
             let axis = try container.decode(String.self, forKey: .axis)
             let ratio = try container.decode(Double.self, forKey: .ratio)
@@ -172,9 +173,10 @@ indirect enum CodableSplitNode: Codable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
-        case .leaf(let sessionName):
+        case .leaf(let sessionName, let title):
             try container.encode("leaf", forKey: .type)
             try container.encode(sessionName, forKey: .sessionName)
+            try container.encodeIfPresent(title, forKey: .title)
         case .split(let axis, let ratio, let first, let second):
             try container.encode("split", forKey: .type)
             try container.encode(axis, forKey: .axis)
@@ -187,8 +189,11 @@ indirect enum CodableSplitNode: Codable {
     /// Convert runtime SplitNode to serializable form.
     static func from(_ node: SplitNode) -> CodableSplitNode {
         switch node {
-        case .leaf(_, _, let sessionName):
-            return .leaf(sessionName: sessionName)
+        case .leaf(_, let stationId, let sessionName):
+            // Capture the pane's last-known strong title so a restored layout can
+            // show it before fresh OSC/agent-session data arrives.
+            let title = StationRegistry.shared.station(forId: stationId)?.persistedTitle
+            return .leaf(sessionName: sessionName, title: title)
         case .split(_, let axis, let ratio, let first, let second):
             return .split(axis: axis.rawValue, ratio: Double(ratio), first: from(first), second: from(second))
         }

--- a/Sources/Terminal/SplitTree.swift
+++ b/Sources/Terminal/SplitTree.swift
@@ -87,10 +87,11 @@ class SplitTree {
 
     private static func restoreNode(from codable: CodableSplitNode, backend: String) -> (SplitNode?, String?) {
         switch codable {
-        case .leaf(let sessionName):
+        case .leaf(let sessionName, let title):
             let station = Station()
             station.sessionName = sessionName
             station.backend = backend
+            station.persistedTitle = title
             StationRegistry.shared.register(station)
             let leafId = UUID().uuidString
             return (.leaf(id: leafId, stationId: station.id, sessionName: sessionName), leafId)

--- a/Sources/Terminal/Station.swift
+++ b/Sources/Terminal/Station.swift
@@ -34,6 +34,10 @@ class Station {
 
     /// Session name for persistence backend (nil = direct shell)
     var sessionName: String?
+    /// Last-known "strong" pane title (agent session / OSC title), persisted in
+    /// the split layout so a restored pane shows its real title immediately —
+    /// before a fresh OSC title or agent session ref lands after relaunch.
+    var persistedTitle: String?
     /// Persistence backend for the sessionName above.
     var backend: String = "zmx"
     /// Agent resume ref, if this pane runs a recognized agent. When a *fresh*

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -15,6 +15,16 @@ protocol DashboardDelegate: AnyObject {
     func dashboardDidRequestShowChanges(worktreePath: String)
 }
 
+// MARK: - PaneDisplayInfo
+
+/// One split pane, for the fully-expanded "Group by Sailor" fleet rows.
+struct PaneDisplayInfo {
+    let stationId: String   // Station.id — the leaf's surface
+    let title: String       // per-pane title (PaneTitleResolver)
+    let status: SailorStatus
+    let isFocused: Bool      // the worktree's last-focused pane
+}
+
 // MARK: - SailorDisplayInfo
 
 struct SailorDisplayInfo {
@@ -42,6 +52,8 @@ struct SailorDisplayInfo {
     let currentPaneTitle: String
     /// Running / activity age for that focused pane (compact: `12s` / `3m`).
     let currentPaneRunTime: String
+    /// Per-pane rows for the expanded "Group by Sailor" mode (leaf order).
+    var panes: [PaneDisplayInfo] = []
 
     /// Rolled-up status for display/grouping: the highest-priority pane, so a
     /// worktree whose first pane is idle but a later pane is running still reads
@@ -244,6 +256,11 @@ class DashboardViewController: NSViewController {
         overviewView.onSelectWorktree = { [weak self] path in
             self?.handleWorktreeRowClick(path: path)
         }
+        // Pane row (expanded "Group by Sailor"): enter the worktree, then focus
+        // the specific pane once its split container is embedded.
+        overviewView.onSelectPane = { [weak self] path, stationId in
+            self?.handlePaneRowClick(path: path, stationId: stationId)
+        }
         // Row context menu → the delegate's confirm-and-tear-down path.
         overviewView.onDeleteWorktree = { [weak self] path in
             guard let self, let agent = self.agents.first(where: { $0.worktreePath == path }) else { return }
@@ -394,11 +411,17 @@ class DashboardViewController: NSViewController {
     ///
     /// The worktree need not be staffed: the cursor still moves, and the caller
     /// tells the user there is no agent to talk to yet.
-    func commitWorktreeSelection(path: String) {
+    func commitWorktreeSelection(path: String, focusTerminal: Bool = false) {
         lastCommittedWorktreePath = path
         guard agents.contains(where: { $0.worktreePath == path }) else { return }
-        selectSailor(byWorktreePath: path, focusTerminal: false)
+        selectSailor(byWorktreePath: path, focusTerminal: focusTerminal)
         overviewSelectedId = selectedSailorId
+        // Push the highlight onto the overview so a programmatic commit (e.g. launch
+        // restore, chat steering) moves the selected row just like a click does.
+        if !overviewView.isHidden {
+            overviewView.selectedId = overviewSelectedId
+            overviewView.update(agents)
+        }
     }
 
     func selectSailor(byWorktreePath path: String, focusTerminal: Bool = true) {
@@ -1291,6 +1314,20 @@ class DashboardViewController: NSViewController {
     /// Test seam for the row-click path (the click itself arrives via a closure).
     func handleWorktreeRowClickForTesting(path: String) { handleWorktreeRowClick(path: path) }
 
+    /// Pane row click in "Group by Sailor": drill into the worktree, then focus
+    /// the clicked pane's leaf. The split container may still be settling, so the
+    /// focus attempt is deferred (mirrors `focusActiveTerminalLeaf`).
+    private func handlePaneRowClick(path: String, stationId: String) {
+        enterWorktree(byWorktreePath: path)
+        guard let container = activeSplitContainer, let tree = container.tree,
+              let leaf = tree.allLeaves.first(where: { $0.stationId == stationId }) else { return }
+        tree.focusedId = leaf.id
+        container.layoutTree()
+        DispatchQueue.main.async { [weak self] in
+            self?.focusActiveTerminalLeaf(tree: tree)
+        }
+    }
+
     private func handleWorktreeRowClick(path: String) {
         guard let i = overviewView.orderedRows.firstIndex(where: { $0.path == path }) else {
             // Not a fleet row (orders card path, stale list) — drill in as before.
@@ -1632,6 +1669,9 @@ final class DashboardOverviewView: NSView {
     /// Resolves a worktree's current-pane title for order cards.
     var currentPaneTitleProvider: ((String) -> String?)?
     var onSelectWorktree: ((String) -> Void)?
+    /// A pane row was clicked in the expanded "Group by Sailor" mode. Args:
+    /// the pane's worktree path and its Station id.
+    var onSelectPane: ((String, String) -> Void)?
     var onDeleteWorktree: ((String) -> Void)?
     var onSubmitCommand: ((String) -> Void)?
     var onGroupingChanged: (() -> Void)?
@@ -1692,18 +1732,6 @@ final class DashboardOverviewView: NSView {
     fileprivate static let red        = NSColor(srgbRed: 0xe0/255, green: 0x7a/255, blue: 0x6a/255, alpha: 1)
     private static let orange     = NSColor(srgbRed: 0xe0/255, green: 0xa4/255, blue: 0x58/255, alpha: 1)
     fileprivate static let emerald    = NSColor(srgbRed: 0x5f/255, green: 0xb8/255, blue: 0x7a/255, alpha: 1)
-
-    /// Per-status group presentation (glyph, group colour, info-line colour, label).
-    private static func groupMeta(_ s: SailorStatus) -> (glyph: String, color: NSColor, info: NSColor, label: String) {
-        switch s {
-        case .waiting: return ("●", orange, orange, "Needs input")
-        case .running: return ("◐", sea, inkDim, "Running")
-        case .idle:    return ("○", emerald, inkDim, "Idle")
-        case .error:   return ("✕", red, red, "Error")
-        case .exited:  return ("◌", inkDim, inkFaint, "Dormant")
-        case .unknown: return ("◌", inkDim, inkFaint, "Unknown")
-        }
-    }
 
     private let headerTitle = NSTextField(labelWithString: "First mate")
     private let headerSub = NSTextField(labelWithString: "")
@@ -1874,6 +1902,7 @@ final class DashboardOverviewView: NSView {
             (.repository, "Group by Repository"),
             (.status, "Group by Status"),
             (.activityTime, "Group by Time"),
+            (.sailor, "Expand All Panes"),
         ]
         for (mode, title) in entries {
             let item = NSMenuItem(title: title, action: #selector(selectGroupingMode(_:)), keyEquivalent: "")
@@ -1913,6 +1942,7 @@ final class DashboardOverviewView: NSView {
         case .repository: description = "Group worktrees by repository"
         case .status: description = "Group worktrees by status"
         case .activityTime: description = "Group worktrees by time"
+        case .sailor: description = "Expand worktrees into panes"
         }
         groupingButton.toolTip = description
         groupingButton.setAccessibilityLabel(description)
@@ -2247,6 +2277,20 @@ final class DashboardOverviewView: NSView {
                 row.widthAnchor.constraint(equalTo: rowsBox.widthAnchor).isActive = true
                 orderedRows.append((groupedItem.id, groupedItem.path))
                 rowViewsByID[groupedItem.id] = row
+
+                // Fully-expanded third level: one clickable row per pane. A
+                // single-pane worktree is already represented by its own row, so
+                // expanding it would just duplicate — only expand 2+ panes.
+                if groupingMode == .sailor, sailor.panes.count > 1 {
+                    for pane in sailor.panes {
+                        let paneRow = PaneRowView(pane: pane)
+                        paneRow.onTap = { [weak self] stationId in
+                            self?.onSelectPane?(sailor.worktreePath, stationId)
+                        }
+                        rowsBox.addArrangedSubview(paneRow)
+                        paneRow.widthAnchor.constraint(equalTo: rowsBox.widthAnchor).isActive = true
+                    }
+                }
             }
             stack.addArrangedSubview(rowsBox)
             pin(rowsBox)
@@ -2354,15 +2398,18 @@ final class DashboardOverviewView: NSView {
     private func makeGroupHeader(group: WorktreeGroup, topGap: CGFloat) -> NSView {
         var views: [NSView] = []
         if let status = group.status {
-            let meta = Self.groupMeta(status)
-            let glyph = NSTextField(labelWithString: meta.glyph)
-            glyph.font = AppFont.mono(size: 8)
-            glyph.textColor = meta.color
-            views.append(glyph)
+            if status == .running {
+                views.append(SpinnerDotView(color: status.color))
+            } else {
+                let glyph = NSTextField(labelWithString: status.glyph)
+                glyph.font = AppFont.mono(size: 8)
+                glyph.textColor = status.color
+                views.append(glyph)
+            }
 
-            let title = NSTextField(labelWithString: meta.label)
+            let title = NSTextField(labelWithString: status.groupLabel)
             title.font = AppFont.mono(size: 11)
-            title.textColor = meta.color
+            title.textColor = status.color
             title.lineBreakMode = .byTruncatingTail
             views.append(title)
 
@@ -2445,7 +2492,10 @@ final class DashboardOverviewView: NSView {
 
             // Status dot sits in its own column so both text lines share one
             // leading edge — a fixed indent under "● + spacing" drifts with glyph metrics.
-            let dot = Self.label("\u{25CF}", status.color, 8)
+            // `running` spins a 3/4 arc; every other status is a static glyph.
+            let dot: NSView = status == .running
+                ? SpinnerDotView(color: status.color)
+                : Self.label(status.glyph, status.color, 8)
             dot.translatesAutoresizingMaskIntoConstraints = false
             dot.setContentHuggingPriority(.required, for: .horizontal)
             dot.setContentCompressionResistancePriority(.required, for: .horizontal)
@@ -2608,6 +2658,76 @@ final class DashboardOverviewView: NSView {
         override func viewDidChangeEffectiveAppearance() {
             super.viewDidChangeEffectiveAppearance()
             applyBackground(hovered: false)
+        }
+    }
+
+    // MARK: - Pane row (Group by Sailor)
+
+    /// Third-level row under a worktree in the expanded "Group by Sailor" mode:
+    /// an indented, clickable pane. `● pane title`, dimmed unless focused.
+    private final class PaneRowView: NSView {
+        var onTap: ((String) -> Void)?
+        private let stationId: String
+
+        private static let cornerRadius: CGFloat = 6
+        private static let hoverFill = NSColor(name: nil) { appearance in
+            appearance.isDark
+                ? NSColor.white.withAlphaComponent(0.05)
+                : NSColor.black.withAlphaComponent(0.04)
+        }
+
+        init(pane: PaneDisplayInfo) {
+            self.stationId = pane.stationId
+            super.init(frame: .zero)
+            wantsLayer = true
+            layer?.cornerRadius = Self.cornerRadius
+            layer?.masksToBounds = true
+            setAccessibilityElement(true)
+            setAccessibilityIdentifier("chrome.paneRow.\(pane.stationId)")
+            setAccessibilityLabel(pane.title)
+
+            let dot = NSTextField(labelWithString: "\u{25CF}")
+            dot.font = AppFont.mono(size: 7)
+            dot.textColor = pane.status.color
+            dot.translatesAutoresizingMaskIntoConstraints = false
+            dot.setContentHuggingPriority(.required, for: .horizontal)
+            dot.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+            let title = NSTextField(labelWithString: pane.title)
+            title.font = AppFont.mono(size: 11)
+            title.textColor = pane.isFocused ? DashboardOverviewView.inkDim : DashboardOverviewView.inkFaint
+            title.lineBreakMode = .byTruncatingTail
+            title.translatesAutoresizingMaskIntoConstraints = false
+            title.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+            addSubview(dot)
+            addSubview(title)
+            NSLayoutConstraint.activate([
+                // Indent under the worktree row's status dot + text column.
+                dot.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 27),
+                dot.centerYAnchor.constraint(equalTo: title.centerYAnchor),
+                title.leadingAnchor.constraint(equalTo: dot.trailingAnchor, constant: 7),
+                title.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+                title.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+                title.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4),
+            ])
+        }
+        required init?(coder: NSCoder) { fatalError() }
+
+        override func mouseDown(with event: NSEvent) { onTap?(stationId) }
+
+        private var tracking: NSTrackingArea?
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            if let tracking { removeTrackingArea(tracking) }
+            let t = NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect], owner: self)
+            addTrackingArea(t); tracking = t
+        }
+        override func mouseEntered(with event: NSEvent) {
+            layer?.backgroundColor = resolvedCGColor(Self.hoverFill)
+        }
+        override func mouseExited(with event: NSEvent) {
+            layer?.backgroundColor = NSColor.clear.cgColor
         }
     }
 

--- a/Sources/UI/Dashboard/WorktreeGrouping.swift
+++ b/Sources/UI/Dashboard/WorktreeGrouping.swift
@@ -4,6 +4,10 @@ enum WorktreeGroupingMode: String, CaseIterable {
     case repository
     case status
     case activityTime
+    /// Fully-expanded three-level view: repository header → worktree row → pane
+    /// rows. Groups by repository like `.repository`; the pane expansion is a
+    /// render-time concern (see `DashboardOverviewView.render`).
+    case sailor
 }
 
 enum WorktreeActivityBucket: String, CaseIterable {
@@ -59,7 +63,7 @@ enum WorktreeGrouping {
         calendar: Calendar = .current
     ) -> [WorktreeGroup] {
         switch mode {
-        case .repository:
+        case .repository, .sailor:
             return repositoryGroups(items)
         case .status:
             return statusGroups(items)

--- a/Sources/UI/Shared/SemanticColors.swift
+++ b/Sources/UI/Shared/SemanticColors.swift
@@ -87,6 +87,11 @@ enum SemanticColors {
         appearance.isDark ? NSColor(hex: 0xe84635) : NSColor(hex: 0xdc2626)
     }
 
+    /// Amber "needs input" accent — waiting statuses that want the user's attention.
+    static let attention: NSColor = NSColor(name: nil) { appearance in
+        appearance.isDark ? NSColor(hex: 0xe0a458) : NSColor(hex: 0xd08706)
+    }
+
     // MARK: - Pre-computed derived colors
 
     static let cardBgSelected: NSColor = NSColor(name: nil) { a in

--- a/Sources/UI/Shared/SpinnerDotView.swift
+++ b/Sources/UI/Shared/SpinnerDotView.swift
@@ -1,0 +1,95 @@
+import AppKit
+
+/// A small spinning 3/4-arc used as the `running` status dot in the dashboard.
+///
+/// The dashboard rebuilds every worktree row from scratch on each refresh
+/// (`render()` tears down `stack.arrangedSubviews`), so a naive rotation would
+/// restart from 0° on every rebuild and visibly jitter. We anchor the animation
+/// to the layer's *absolute* time origin (`beginTime = convertTime(0, from: nil)`),
+/// so a freshly created spinner resumes at the current phase — recreations are
+/// seamless and every running dot on screen spins in lock-step.
+final class SpinnerDotView: NSView {
+    /// Visual diameter, matched to the weight of the 8pt glyph it replaces.
+    private static let diameter: CGFloat = 9
+    private static let lineWidth: CGFloat = 1.5
+    private static let spinDuration: CFTimeInterval = 1.0
+    private static let animationKey = "seahelm.spin"
+
+    /// Appearance-aware stroke colour (resolved per effective appearance).
+    private let color: NSColor
+    private let arc = CAShapeLayer()
+
+    init(color: NSColor) {
+        self.color = color
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+
+        arc.fillColor = nil
+        arc.lineWidth = Self.lineWidth
+        arc.lineCap = .round
+        layer?.addSublayer(arc)
+        applyStrokeColor()
+    }
+    required init?(coder: NSCoder) { fatalError() }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: Self.diameter, height: Self.diameter)
+    }
+
+    override func layout() {
+        super.layout()
+        // Centred arc, inset by half the stroke so it isn't clipped.
+        let inset = Self.lineWidth / 2
+        let rect = bounds.insetBy(dx: inset, dy: inset)
+        let path = CGMutablePath()
+        // 3/4 sweep (270°), leaving a gap that reads as motion when spun.
+        path.addArc(center: CGPoint(x: rect.midX, y: rect.midY),
+                    radius: min(rect.width, rect.height) / 2,
+                    startAngle: 0, endAngle: 1.5 * .pi, clockwise: false)
+        arc.path = path
+        arc.frame = layer?.bounds ?? bounds
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        // Animations are stripped when a layer leaves the window; (re)install
+        // whenever we're attached and motion is allowed.
+        if window != nil { installSpin() } else { arc.removeAnimation(forKey: Self.animationKey) }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyStrokeColor()
+    }
+
+    private func applyStrokeColor() {
+        arc.strokeColor = color.resolvedCGColor(for: effectiveAppearance)
+    }
+
+    private func installSpin() {
+        guard arc.animation(forKey: Self.animationKey) == nil else { return }
+        guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else { return }
+        let spin = CABasicAnimation(keyPath: "transform.rotation.z")
+        spin.fromValue = 0
+        spin.toValue = -2 * CGFloat.pi          // clockwise (flipped layer coords)
+        spin.duration = Self.spinDuration
+        spin.repeatCount = .infinity
+        spin.isRemovedOnCompletion = false
+        // Anchor to absolute t=0 so phase is shared across all spinners and
+        // survives row rebuilds without snapping back to 0°.
+        spin.beginTime = arc.convertTime(0, from: nil)
+        arc.add(spin, forKey: Self.animationKey)
+    }
+}
+
+private extension NSColor {
+    /// Resolve a dynamic `NSColor` to a concrete `CGColor` under `appearance`.
+    func resolvedCGColor(for appearance: NSAppearance) -> CGColor {
+        var cg = cgColor
+        appearance.performAsCurrentDrawingAppearance {
+            cg = self.cgColor
+        }
+        return cg
+    }
+}

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -35,9 +35,9 @@ final class DashboardOverviewGroupingTests: XCTestCase {
                                              now: { self.now })
 
             XCTAssertEqual(view.groupingMenuTitlesForTesting, [
-                "Group by Repository", "Group by Status", "Group by Time",
+                "Group by Repository", "Group by Status", "Group by Time", "Expand All Panes",
             ])
-            XCTAssertEqual(view.groupingMenuKeyEquivalentsForTesting, ["", "", ""])
+            XCTAssertEqual(view.groupingMenuKeyEquivalentsForTesting, ["", "", "", ""])
             XCTAssertTrue(view.groupingButtonRefusesFirstResponderForTesting)
         }
     }

--- a/Tests/PaneTitleResolverTests.swift
+++ b/Tests/PaneTitleResolverTests.swift
@@ -17,25 +17,12 @@ final class PaneTitleResolverTests: XCTestCase {
         sailor.station = station
         let title = PaneTitleResolver.title(
             for: sailor,
-            sessionTitle: { _, _ in "Fix login flake" },
-            worktreeSessionTitle: { _ in nil }
+            sessionTitle: { _, _ in "Fix login flake" }
         )
         XCTAssertEqual(title, "Fix login flake")
     }
 
-    func testWorktreeSessionTitleBeforePrompt() {
-        let sailor = makeSailor(agentType: .cursor, prompt: "Do the thing", branch: "feat/x")
-        XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: sailor,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in "Check Error Logs" }
-            ),
-            "Check Error Logs"
-        )
-    }
-
-    func testShellIgnoresWorktreeSessionTitle() {
+    func testShellPrefersCommandOverBranch() {
         let sailor = makeSailor(
             agentType: .shellCommand,
             prompt: "",
@@ -43,65 +30,59 @@ final class PaneTitleResolverTests: XCTestCase {
             commandLine: "brew update"
         )
         XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: sailor,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in "Seahelm Layout Redesign" }
-            ),
+            PaneTitleResolver.title(for: sailor, sessionTitle: { _, _ in nil }),
             "brew update"
         )
     }
 
-    func testAgentFallsBackToPromptThenBranch() {
-        var sailor = makeSailor(agentType: .claudeCode, prompt: "Do the thing", branch: "feat/x")
+    func testAgentWithoutSessionOrOscFallsBackToBranch() {
+        // Prompt is no longer a per-pane title source — an agent with no session
+        // title and no OSC title reads as its branch.
+        let sailor = makeSailor(agentType: .claudeCode, prompt: "Do the thing", branch: "feat/x")
         XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: sailor,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in nil }
-            ),
-            "Do the thing"
-        )
-        sailor.lastUserPrompt = ""
-        XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: sailor,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in nil }
-            ),
+            PaneTitleResolver.title(for: sailor, sessionTitle: { _, _ in nil }),
             "feat/x"
         )
     }
 
-    func testShellPrefersCommandThenWorktreePathNotWanderingPwd() {
+    func testPersistedTitleBridgesMissingLiveSources() {
+        // Restored pane: no session title, OSC not yet arrived — the persisted
+        // title stands in ahead of the branch/repo fallback.
+        let station = Station()
+        station.persistedTitle = "Add grouping mode"
+        var sailor = makeSailor(agentType: .claudeCode, prompt: "", branch: "feat/x")
+        sailor.station = station
+        XCTAssertEqual(
+            PaneTitleResolver.title(for: sailor, sessionTitle: { _, _ in nil }),
+            "Add grouping mode"
+        )
+    }
+
+    func testStrongTitleWritesBackToPersistedTitle() {
+        let station = Station()
+        station.setOscTitle("✳ Wire up the resolver")
+        var sailor = makeSailor(agentType: .claudeCode, prompt: "", branch: "main")
+        sailor.station = station
+        _ = PaneTitleResolver.title(for: sailor, sessionTitle: { _, _ in nil })
+        XCTAssertEqual(station.persistedTitle, "Wire up the resolver")
+    }
+
+    func testFallsBackToRepoThenPath() {
         let station = Station()
         station.setPwd("/Users/me/.cursor/plugins/cache/foo")
         var sailor = makeSailor(
             agentType: .shellCommand,
             prompt: "",
             branch: "",
-            commandLine: "git status",
+            commandLine: nil,
             worktreePath: "/Users/me/proj"
         )
         sailor.station = station
+        // Repo name wins as the default before falling through to the path.
         XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: sailor,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in nil }
-            ),
-            "git status"
+            PaneTitleResolver.title(for: sailor, sessionTitle: { _, _ in nil }),
+            "proj"
         )
-
-        sailor.commandLine = nil
-        let title = PaneTitleResolver.title(
-            for: sailor,
-            sessionTitle: { _, _ in nil },
-            worktreeSessionTitle: { _ in nil },
-            pathDisplay: { path in path == "/Users/me/proj" ? "~/proj" : path }
-        )
-        // Wandering tool cwd must not become the title.
-        XCTAssertEqual(title, "~/proj")
     }
 
     func testAgentIgnoresShellCommandLine() {
@@ -112,11 +93,7 @@ final class PaneTitleResolverTests: XCTestCase {
             commandLine: "cd ~/.cursor/plugins/cache"
         )
         XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: sailor,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in nil }
-            ),
+            PaneTitleResolver.title(for: sailor, sessionTitle: { _, _ in nil }),
             "ops/rds-cpu-degrade"
         )
     }
@@ -131,11 +108,7 @@ final class PaneTitleResolverTests: XCTestCase {
             commandLine: "brew update"
         )
         XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: sailor,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in "Cursor Session Title" }
-            ),
+            PaneTitleResolver.title(for: sailor, sessionTitle: { _, _ in nil }),
             "brew update"
         )
     }
@@ -164,11 +137,7 @@ final class PaneTitleResolverTests: XCTestCase {
         var sailor = makeSailor(agentType: .claudeCode, prompt: "old prompt", branch: "main")
         sailor.station = station
         XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: sailor,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in "Shared Worktree Title" }
-            ),
+            PaneTitleResolver.title(for: sailor, sessionTitle: { _, _ in nil }),
             "修复重启后的onboarding重复弹出"
         )
     }
@@ -182,11 +151,7 @@ final class PaneTitleResolverTests: XCTestCase {
             var sailor = makeSailor(agentType: .claudeCode, prompt: "p", branch: "main")
             sailor.station = station
             XCTAssertEqual(
-                PaneTitleResolver.title(
-                    for: sailor,
-                    sessionTitle: { _, _ in nil },
-                    worktreeSessionTitle: { _ in nil }
-                ),
+                PaneTitleResolver.title(for: sailor, sessionTitle: { _, _ in nil }),
                 "Update title",
                 "failed for \(raw)"
             )
@@ -202,11 +167,7 @@ final class PaneTitleResolverTests: XCTestCase {
         )
         shell.station = shellStation
         XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: shell,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in nil }
-            ),
+            PaneTitleResolver.title(for: shell, sessionTitle: { _, _ in nil }),
             "brew update"
         )
 
@@ -216,11 +177,7 @@ final class PaneTitleResolverTests: XCTestCase {
         var agent = makeSailor(agentType: .claudeCode, prompt: "", branch: "feat/x")
         agent.station = agentStation
         XCTAssertEqual(
-            PaneTitleResolver.title(
-                for: agent,
-                sessionTitle: { _, _ in nil },
-                worktreeSessionTitle: { _ in nil }
-            ),
+            PaneTitleResolver.title(for: agent, sessionTitle: { _, _ in nil }),
             "feat/x"
         )
     }

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -46,8 +46,8 @@ class SessionManagerTests: XCTestCase {
         let layout = CodableSplitNode.split(
             axis: "horizontal",
             ratio: 0.5,
-            first: .leaf(sessionName: "seahelm-repo-main"),
-            second: .leaf(sessionName: "seahelm-repo-main-1")
+            first: .leaf(sessionName: "seahelm-repo-main", title: nil),
+            second: .leaf(sessionName: "seahelm-repo-main-1", title: nil)
         )
 
         XCTAssertEqual(

--- a/Tests/SplitNodeTests.swift
+++ b/Tests/SplitNodeTests.swift
@@ -28,22 +28,32 @@ final class SplitNodeTests: XCTestCase {
     }
 
     func testCodableRoundTrip_Leaf() throws {
-        let node = CodableSplitNode.leaf(sessionName: "seahelm-repo-main")
+        let node = CodableSplitNode.leaf(sessionName: "seahelm-repo-main", title: "Fix the bug")
         let data = try JSONEncoder().encode(node)
         let decoded = try JSONDecoder().decode(CodableSplitNode.self, from: data)
-        if case .leaf(let name) = decoded {
+        if case .leaf(let name, let title) = decoded {
             XCTAssertEqual(name, "seahelm-repo-main")
+            XCTAssertEqual(title, "Fix the bug")
         } else {
             XCTFail("Expected leaf")
         }
+    }
+
+    func testCodableLeaf_DecodesLegacyWithoutTitle() throws {
+        // Older configs have no `title` key — must still decode (title = nil).
+        let json = Data(#"{"type":"leaf","sessionName":"seahelm-repo-main"}"#.utf8)
+        let decoded = try JSONDecoder().decode(CodableSplitNode.self, from: json)
+        guard case .leaf(let name, let title) = decoded else { return XCTFail("Expected leaf") }
+        XCTAssertEqual(name, "seahelm-repo-main")
+        XCTAssertNil(title)
     }
 
     func testCodableRoundTrip_Split() throws {
         let node = CodableSplitNode.split(
             axis: "horizontal",
             ratio: 0.6,
-            first: .leaf(sessionName: "seahelm-repo-main"),
-            second: .leaf(sessionName: "seahelm-repo-main-1")
+            first: .leaf(sessionName: "seahelm-repo-main", title: nil),
+            second: .leaf(sessionName: "seahelm-repo-main-1", title: nil)
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		2F081A963842FF92DB2D1568 /* CodexHooksSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D815BD3789070197196037 /* CodexHooksSetupTests.swift */; };
 		2F5B5EC7F0428265CC344717 /* CodexHooksSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51B009382FE3586E735355D /* CodexHooksSetup.swift */; };
 		303FCEA37D46939EB9451358 /* WorktreeCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A85CAE555196AE450DDD90E /* WorktreeCreatorTests.swift */; };
+		321A7CB783FEBABFD944F744 /* SpinnerDotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BF7C60A5333E90B1FFEDB5 /* SpinnerDotView.swift */; };
 		3228A013E381D520EE386C05 /* UpdateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AB93A5F8C2A6D49CA1AA79 /* UpdateCoordinator.swift */; };
 		33513E7190811BE875658EC5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75D8071B308F62A8D6D3379 /* AppDelegate.swift */; };
 		33C396FE204DA5CF4648543C /* SplitPanePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36A62BF0D9481F17D7071390 /* SplitPanePage.swift */; };
@@ -647,6 +648,7 @@
 		C537B2B1B68C50EF9685736B /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		C6F98DB046516F2EB312E63F /* ZmxChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxChannel.swift; sourceTree = "<group>"; };
 		C71C3A59719695387993016D /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
+		C9BF7C60A5333E90B1FFEDB5 /* SpinnerDotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerDotView.swift; sourceTree = "<group>"; };
 		CCA00190FE1317EED4BDFA0D /* ProcessRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessRunner.swift; sourceTree = "<group>"; };
 		CD6CAE97113B8F2314759D70 /* PendingOrdersQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingOrdersQueue.swift; sourceTree = "<group>"; };
 		CD8F0A0F456C94284935BE32 /* RegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegressionTests.swift; sourceTree = "<group>"; };
@@ -996,6 +998,7 @@
 				0B4A39D9322D17CBEF79A686 /* FrostedPanelView.swift */,
 				1E7D509CBBC0E7A5A275DC5F /* SailorDisplayHelpers.swift */,
 				F15A95E0337AEDBCE9546B8F /* SemanticColors.swift */,
+				C9BF7C60A5333E90B1FFEDB5 /* SpinnerDotView.swift */,
 				8E004E8B96865467209D3F2D /* Theme.swift */,
 				0A25DADE8C435CBAA6E78BAB /* ThemedBackgroundView.swift */,
 			);
@@ -1807,6 +1810,7 @@
 				1945A6AC8F512F03D83EBB70 /* ShipLog.swift in Sources */,
 				06CF922E9ABD675BEC1F7502 /* SidebarHeaderView.swift in Sources */,
 				64206379E233A088405B9EE9 /* SignalDecoder.swift in Sources */,
+				321A7CB783FEBABFD944F744 /* SpinnerDotView.swift in Sources */,
 				2BC7A5243BDCCBADED457B44 /* SplitContainerView.swift in Sources */,
 				CECDE06AB48C038C87A37076 /* SplitNode.swift in Sources */,
 				BC59B36704952688AFE19EDC /* SplitTree.swift in Sources */,


### PR DESCRIPTION
## Summary
- Fix: on launch the right terminal restored to the last-used worktree, but the left **First mate** overview highlighted the first row instead. Restore now routes through `commitWorktreeSelection` (with a new `focusTerminal` flag to preserve terminal focus) and pushes the highlight onto the overview when visible, so both sides agree.
- Also lands the in-progress overview work on this branch: Group-by / **Expand All Panes** mode with per-pane rows, and the shared `SpinnerDotView` status glyphs.

## Testing
- `xcodebuild ... build` succeeds.
- Verified in-app: relaunch now highlights the restored worktree row in the First Mate list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)