### PR TITLE
feat: split edit-mode layout for side-by-side terminal + file preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,19 @@ Seahelm (sea + helm) is a native macOS terminal multiplexer built with Swift + A
 ## Build Commands
 
 ```bash
+# First-time setup: init the Ghostty submodule + build/reuse GhosttyKit.xcframework
+scripts/setup.sh
+
+# Build into .build/, kill any running Seahelm, and launch the debug app
+./run.sh                 # add --clean-restart to wipe .build first
+
+# Run UI tests (regenerates the project, optionally filtered to one class)
+./run_ui_tests.sh [TestClass]
+```
+
+Note: `run.sh` launches the app from `.build/`, NOT the DerivedData bundle — when inspecting a running instance, use the bundle the live pid actually came from.
+
+```bash
 # Generate Xcode project from project.yml (requires xcodegen)
 xcodegen generate
 
@@ -52,15 +65,21 @@ The project uses XcodeGen (`project.yml`) to generate the Xcode project file. Af
    - `Split/` — `SplitContainerView` renders `SplitTree` as frame-based leaf views with `DividerView` drag handles and dim overlays on unfocused panes
    - `Chrome/` — Two-column `WindowChromeController` (sidebar/terminal headers, divider, collapse)
    - `Dialog/` — Quick switcher (Cmd+P) and new branch dialog (Cmd+N)
+   - `SidePanel/` — Per-worktree right panel with First Mate / Files / Changes tabs (`WorktreeSidePanelViewController`, `BridgePanelViewController` for red/green-zone orders)
+   - `Diff/` — Code-review diff viewer (`DiffReviewView` + `DiffSyntaxHighlighter`)
+   - `Helm/` — The command-line "helm" input (`CommandInputView` with `/command · @repo · #agent` autocomplete) + keyboard-help overlay
+   - `StatusBar/` — Fixed 26pt bottom bar: mode indicator, global Claude/Codex usage, notification summary, shortcuts
+   - `Island/` — Floating "dynamic island" panel (morphs closed pill ↔ open surface) for notifications/status
+   - `Settings/`, `Onboarding/` — Tabbed settings window and the first-run wizard
 
 3. **Core Services** (`Sources/Core/`, `Sources/Status/`)
    - `ShipLog` — Single source of truth for all agent state; delegates notify UI of changes
    - `StatusPublisher` — Timer-based polling (2s) on background queue, reads viewport text via `ghosttyLock`-protected C API calls
-   - `StatusDetector` — Priority: process exit > OSC 133 shell phase > text pattern matching > Unknown
+   - `StatusDetector` — Authoritative status detector. Priority: process exit > OSC 133 shell phase > text pattern matching > Unknown. Its text-pattern tier consults a `CompiledManifest` from the manifest engine (see below); the manifest layer augments, it does not replace, this ladder.
    - `WorktreeStatusAggregator` — Aggregates per-pane statuses into per-worktree status, fires `WorktreeStatusDelegate`
    - `Config` — JSON config at `~/.config/seahelm/config.json`; uses `decodeIfPresent()` for backward compat (migrated from legacy ~/.config/amux on first launch)
    - `StationRegistry` — Global registry mapping surface IDs to `Station` instances
-   - `ExternalChannel` — Protocol for WeChat/WeCom bot integrations
+   - `ExternalChannel` — Protocol for inbound remote-control chat (`WeChatChannel`, `WeComBotChannel`)
 
 4. **Terminal & System** (`Sources/Terminal/`, `Sources/Git/`)
    - `GhosttyBridge` — Singleton wrapping the Ghostty C API (`ghostty.h` via bridging header)
@@ -87,6 +106,26 @@ The project uses XcodeGen (`project.yml`) to generate the Xcode project file. Af
 **Thread safety:** `ghosttyLock` (NSLock) serializes all Ghostty C API calls between the background status poll and main-thread input. Key input deliberately does NOT hold the lock (Ghostty is internally thread-safe for keys, and holding it would deadlock on synchronous callbacks).
 
 **Window key handling:** `SeahelmWindow.performKeyEquivalent` handles split pane shortcuts (Cmd+D split, Cmd+Shift+Arrow move focus, Cmd+Ctrl+Arrow resize) before menu key equivalents. `sendEvent` intercepts Escape.
+
+## Agent Orchestration ("the fleet")
+
+Seahelm frames each running agent with a nautical metaphor worth knowing before reading this code: a **Sailor** is one agent in one pane, and `ShipLog.shared` is the fleet-wide source of truth across worktree "ships."
+
+- **Sailor model** (`Sources/Core/Sailor*.swift`): `SailorType` = agent kind (claudeCode, codex, openCode, gemini, cline…), `SailorStatus` = state enum (owns the status-dot color), `SailorInfo` = per-pane snapshot, `SailorReducer` = pure `(old + inputs) → (new snapshot + delta)` (extracted from `ShipLog.updateStatus`), `SailorChannel` = protocol for talking to a sailor's terminal (`ZmxChannel` is the universal fallback via the `zmx` CLI; `HooksChannel` is the richer path for agents that report structured events).
+
+- **Manifest engine** (`Sources/Status/`): data-driven detection ported from a sibling project. `AgentManifest` is a JSON schema of priority-ordered regex rules/gates/process matchers (bundled under `Sources/Status/Manifests/`, overridable at `~/.config/seahelm/agents/<id>.json` — user override wins by id/alias). `ManifestStore` compiles them; `ManifestEngine` evaluates a terminal snapshot. The `*Decoder` files are the newer "signalman" seam: `SignalDecoder` translates one raw source into a unified `NormalizedEvent`; `ScanDecoder` wraps `StatusDetector` (screen-scan channel), `HookDecoder` maps webhook events. These feed the reducer/ingest pipeline broadcast through `EventHub`.
+
+- **Control socket & CLI** (`Sources/Core/`): `ControlSocketServer` listens on a 0600 Unix socket at `~/.config/seahelm/seahelm.sock` speaking newline-delimited JSON-RPC (`ControlProtocol` = transport-free router + `ControlDataSource` seam; `SeahelmControlDataSource` bridges it to live app state). `SeahelmCliInstaller` writes `~/.local/bin/seahelm` (python3 wrapper) so agents run e.g. `seahelm pane run <id> npm test` — this backs the `seahelm` skill. `BridgeCommand`/`BridgeCommandRouter` are a separate higher-level command grammar used by the chat/bridge surfaces (worktrees, orders, "return to port"). `EventHub` is the fan-out broker (bounded ring buffer, `events_after` replay) for control-socket subscribers.
+
+- **Hooks installers** (`Sources/Core/*HooksSetup.swift`, `*Installer.swift`): non-destructively install per-agent shims so third-party agent CLIs report lifecycle events back to seahelm. `SeahelmHookInstaller` writes `~/.local/bin/seahelm-hook` (the shared bridge: prefers the socket, falls back to HTTP webhook, relays Stop-hook block decisions via stdout); `ClaudeHooksSetup`/`CodexHooksSetup`/`CursorHooksSetup`/`OpenCodePluginInstaller` wire that bridge into each tool's config. `OnboardingHookInstaller` orchestrates which integrations get installed during the first-run wizard.
+
+- **FirstMate** (`Sources/Core/FirstMate*.swift`): an autonomous supervisor reacting to agent status transitions. A green-zone/red-zone action model (watchWaiting, watchError, inspect, autoCommit, suggestNextOrder, returnToPort, broadcastOrder); `FirstMateConfig` holds user policy; `FirstMateCoordinator` (main thread) consumes status edges, routes green-zone actions to side effects and red-zone actions to the `PendingOrdersQueue`. Watches idle/blocked/errored agents and either auto-handles or surfaces them for approval.
+
+- **Usage** (`Sources/Usage/`): `ClaudeUsageSummaryProvider`/`CodexUsageSummaryProvider` parse each tool's local session logs into token/quota figures; `UsageSummaryStore` refreshes both on a background timer and emits the global usage readout shown in the status bar.
+
+## Keyboard System (modal)
+
+`Sources/App/` has a modal Vim/which-key-style keyboard system (design in `docs/keyboard-redesign.md`). `KeyboardMode` = NORMAL vs INSERT (+ transient `KeyboardSubstate`); `KeyboardModeController` owns the mode machine and the leader (`Space`) which-key descent. `Keymap` resolves bare-key NORMAL chords to `KeyboardAction` (h/j/k/l focus, i=insert, d=delete, c=changes); `GlobalKeymap` centralizes window-level Cmd shortcuts; `DialogKeymap` unifies modal-dialog nav; `LeaderMenu` holds `LeaderCommand` leaf actions reachable through the leader tree (kept separate from `KeyboardAction`). Note `SeahelmWindow.performKeyEquivalent` (below) still handles the split-pane Cmd shortcuts.
 
 ## Key Technical Details
 

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -669,6 +669,10 @@ dashboard.stationManager = terminalCoordinator.stationManager
         dashboard.onCenterOverlayTitleChange = { [weak self] title in
             self?.windowChrome?.setOverlayTitle(title)
         }
+        // Edit-mode toggle availability + on-state drive the chrome header icon.
+        dashboard.onEditModeStateChange = { [weak self] available, isOn in
+            self?.windowChrome?.setEditMode(available: available, isOn: isOn)
+        }
         // Keep chrome header icon tint in sync when dashboard changes side.
         dashboard.onActiveToolChanged = { [weak self] pane in
             guard let self else { return }
@@ -1455,6 +1459,17 @@ dashboard.stationManager = terminalCoordinator.stationManager
     }
 
     func moveFocus(_ axis: SplitAxis, positive: Bool) {
+        // In edit mode the terminal split is presented as tabs, so spatial focus
+        // movement becomes tab cycling: horizontal walks the terminal tabs, and
+        // vertical walks the preview tabs on the right.
+        if let dashboard = tabCoordinator.dashboardVC, dashboard.isEditModeActive {
+            if axis == .horizontal {
+                dashboard.editModeCycleTerminalTab(forward: positive)
+            } else {
+                dashboard.editModeCyclePreviewTab(forward: positive)
+            }
+            return
+        }
         terminalCoordinator.moveFocus(axis, positive: positive)
     }
 
@@ -1657,6 +1672,10 @@ extension MainWindowController: ChromeHeaderDelegate {
 
     func chromeDidToggleSidebar() {
         toggleChromeCollapsed()
+    }
+
+    func chromeDidToggleEditMode() {
+        tabCoordinator.dashboardVC?.toggleEditMode()
     }
 }
 

--- a/Sources/Terminal/GhosttyNSView.swift
+++ b/Sources/Terminal/GhosttyNSView.swift
@@ -514,6 +514,14 @@ class GhosttyNSView: NSView, NSTextInputClient {
 
         menu.addItem(.separator())
 
+        if let path = selectedFilePath() {
+            let previewItem = NSMenuItem(title: "Preview", action: #selector(contextPreview), keyEquivalent: "")
+            previewItem.target = self
+            previewItem.representedObject = path
+            menu.addItem(previewItem)
+            menu.addItem(.separator())
+        }
+
         let copyItem = NSMenuItem(title: "Copy", action: #selector(contextCopy), keyEquivalent: "")
         copyItem.target = self
         copyItem.isEnabled = surface.map { ghostty_surface_has_selection($0) } ?? false
@@ -531,6 +539,68 @@ class GhosttyNSView: NSView, NSTextInputClient {
         menu.addItem(closeItem)
 
         return menu
+    }
+
+    /// If the current selection is a path pointing at an existing file (relative
+    /// paths resolved against the pane's working directory), return that file's
+    /// URL. Returns nil for no selection, directories, or non-existent paths so
+    /// the Preview menu item is only offered when it will actually work.
+    private func selectedFilePath() -> URL? {
+        let hasSel = surface.map { ghostty_surface_has_selection($0) } ?? false
+        NSLog("[preview] selectedFilePath called surface=%@ hasSelection=%@",
+              surface == nil ? "nil" : "set", hasSel ? "true" : "false")
+        guard let surface, ghostty_surface_has_selection(surface) else { return nil }
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_selection(surface, &text) else { return nil }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard let cString = text.text else { return nil }
+        let raw = String(cString: cString)
+        // The pane's registered worktree root is the most reliable base on
+        // restore, where OSC 7 pwd is often unreported inside zmx sessions.
+        let worktreePath = station.map { ShipLog.shared.sailor(for: $0.id)?.worktreePath } ?? nil
+        let bases: [String?] = [station?.pwd, worktreePath, station?.initialWorkingDirectory]
+        let result = Self.resolveSelectedPath(raw: raw, bases: bases)
+        NSLog("[preview] raw=%@ pwd=%@ worktree=%@ initDir=%@ -> %@",
+              raw, station?.pwd ?? "nil", worktreePath ?? "nil",
+              station?.initialWorkingDirectory ?? "nil", result?.path ?? "nil")
+        return result
+    }
+
+    /// Pure resolver (unit-testable): trims `raw`, rejects multi-token/multi-line
+    /// selections, then returns the first existing *file* found by treating `raw`
+    /// as an absolute/`~` path or resolving it against each base in `bases`
+    /// (first non-empty base that yields an existing file wins).
+    static func resolveSelectedPath(raw: String, bases: [String?]) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        // A path shouldn't span lines or contain interior whitespace; reject
+        // multi-token selections rather than guessing.
+        guard !trimmed.isEmpty,
+              !trimmed.contains(where: { $0 == "\n" || $0 == " " || $0 == "\t" }) else { return nil }
+
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        let candidates: [String]
+        if expanded.hasPrefix("/") {
+            candidates = [expanded]
+        } else {
+            candidates = bases
+                .compactMap { $0 }
+                .filter { !$0.isEmpty }
+                .map { ($0 as NSString).appendingPathComponent(expanded) }
+        }
+
+        let fm = FileManager.default
+        for candidate in candidates {
+            var isDir: ObjCBool = false
+            if fm.fileExists(atPath: candidate, isDirectory: &isDir), !isDir.boolValue {
+                return URL(fileURLWithPath: candidate)
+            }
+        }
+        return nil
+    }
+
+    @objc private func contextPreview(_ sender: NSMenuItem) {
+        guard let url = sender.representedObject as? URL else { return }
+        FilePreviewWindowController.shared.preview(url: url)
     }
 
     @objc private func contextSplitHorizontal() { onRequestSplit?(.horizontal) }

--- a/Sources/Terminal/Station.swift
+++ b/Sources/Terminal/Station.swift
@@ -31,6 +31,10 @@ class Station {
     func setOscTitle(_ t: String) { oscLock.lock(); _oscTitle = t; oscLock.unlock() }
     func setOscProgress(_ p: String) { oscLock.lock(); _oscProgress = p; oscLock.unlock() }
     func setPwd(_ p: String) { oscLock.lock(); _pwd = p; oscLock.unlock() }
+    /// Directory the pane's surface was created in (worktree root, typically).
+    /// Used as a fallback base for resolving relative paths when the live OSC 7
+    /// `pwd` hasn't been reported — which is the common case inside zmx sessions.
+    private(set) var initialWorkingDirectory: String?
 
     /// Session name for persistence backend (nil = direct shell)
     var sessionName: String?
@@ -176,6 +180,7 @@ class Station {
         // strdup + retain until destroy — see `ownedCommand` docs.
         freeOwnedSurfaceStrings()
         if let workingDirectory {
+            initialWorkingDirectory = workingDirectory
             ownedWorkingDirectory = strdup(workingDirectory)
             config.working_directory = UnsafePointer(ownedWorkingDirectory)
         }

--- a/Sources/UI/Chrome/ChromeHeaderDelegate.swift
+++ b/Sources/UI/Chrome/ChromeHeaderDelegate.swift
@@ -4,4 +4,6 @@ protocol ChromeHeaderDelegate: AnyObject {
     func chromeDidToggleTheme()
     func chromeDidSelectPane(_ pane: ChromeLeftPane)
     func chromeDidToggleSidebar()
+    /// Toggle the terminal column between focus mode and split file-edit mode.
+    func chromeDidToggleEditMode()
 }

--- a/Sources/UI/Chrome/TerminalHeaderView.swift
+++ b/Sources/UI/Chrome/TerminalHeaderView.swift
@@ -12,7 +12,11 @@ final class TerminalHeaderView: NSView {
     private let titleLabel = NSTextField(labelWithString: "")
     private let iconCluster = ChromeIconClusterView()
     private let expandButton = ChromeIconButton()
+    private let editModeButton = ChromeIconButton()
     private let collapsedLeadingStack = NSStackView()
+
+    /// Whether edit mode is currently on (drives the icon's active tint).
+    private var editModeOn = false
 
     private var isCollapsed = false
     private var collapsedConstraints: [NSLayoutConstraint] = []
@@ -102,6 +106,9 @@ final class TerminalHeaderView: NSView {
         configureExpandButton()
         addSubview(expandButton)
 
+        configureEditModeButton()
+        addSubview(editModeButton)
+
         colorSchemeObserver = NotificationCenter.default.addObserver(
             forName: .ghosttyColorSchemeDidChange,
             object: nil,
@@ -110,12 +117,19 @@ final class TerminalHeaderView: NSView {
             self?.refreshImmersion()
         }
 
+        // Edit-mode toggle is always visible (both collapse states); center it
+        // vertically once and swap only its trailing anchor per state.
+        NSLayoutConstraint.activate([
+            editModeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+
         // Expanded: true horizontal center in the terminal column.
         expandedConstraints = [
             titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
             titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
             titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 12),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -12),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: editModeButton.leadingAnchor, constant: -8),
+            editModeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
         ]
 
         collapsedConstraints = [
@@ -132,7 +146,9 @@ final class TerminalHeaderView: NSView {
                 equalTo: collapsedLeadingStack.trailingAnchor, constant: 10),
             titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
             titleLabel.trailingAnchor.constraint(
-                lessThanOrEqualTo: expandButton.leadingAnchor, constant: -8),
+                lessThanOrEqualTo: editModeButton.leadingAnchor, constant: -8),
+
+            editModeButton.trailingAnchor.constraint(equalTo: expandButton.leadingAnchor, constant: -4),
 
             expandButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
             expandButton.centerYAnchor.constraint(equalTo: centerYAnchor),
@@ -187,8 +203,43 @@ final class TerminalHeaderView: NSView {
         needsLayout = true
     }
 
+    private func configureEditModeButton() {
+        let config = NSImage.SymbolConfiguration(pointSize: 12, weight: .medium)
+        if let image = NSImage(systemSymbolName: "square.split.2x1",
+                               accessibilityDescription: "Toggle File Edit Layout") {
+            editModeButton.image = image.withSymbolConfiguration(config)
+        }
+        editModeButton.bezelStyle = .recessed
+        editModeButton.isBordered = false
+        editModeButton.imagePosition = .imageOnly
+        editModeButton.target = self
+        editModeButton.action = #selector(editModeClicked)
+        editModeButton.translatesAutoresizingMaskIntoConstraints = false
+        editModeButton.setAccessibilityIdentifier("chrome.icon.editMode")
+        editModeButton.setAccessibilityLabel("Toggle File Edit Layout")
+        editModeButton.wantsLayer = true
+        editModeButton.layer?.cornerRadius = 7
+        editModeButton.isEnabled = false
+        NSLayoutConstraint.activate([
+            editModeButton.widthAnchor.constraint(equalToConstant: 26),
+            editModeButton.heightAnchor.constraint(equalToConstant: 26),
+        ])
+    }
+
+    /// Enable + light the edit-mode toggle. `available` gates it on there being
+    /// at least one open preview (empty set → focus mode only).
+    func setEditMode(available: Bool, isOn: Bool) {
+        editModeOn = isOn
+        editModeButton.isEnabled = available
+        refreshImmersion()
+    }
+
     @objc private func expandClicked() {
         delegate?.chromeDidToggleSidebar()
+    }
+
+    @objc private func editModeClicked() {
+        delegate?.chromeDidToggleEditMode()
     }
 
     override func viewDidChangeEffectiveAppearance() {
@@ -202,5 +253,14 @@ final class TerminalHeaderView: NSView {
         layer?.backgroundColor = bridge.terminalChromeBackground.cgColor
         titleLabel.textColor = bridge.terminalChromeForeground
         expandButton.contentTintColor = bridge.terminalChromeForeground.withAlphaComponent(0.55)
+        let editTint = editModeButton.isEnabled
+            ? (editModeOn
+                ? SemanticColors.accent
+                : bridge.terminalChromeForeground.withAlphaComponent(0.55))
+            : bridge.terminalChromeForeground.withAlphaComponent(0.2)
+        editModeButton.contentTintColor = editTint
+        editModeButton.layer?.backgroundColor = editModeOn && editModeButton.isEnabled
+            ? SemanticColors.accent.withAlphaComponent(0.15).cgColor
+            : NSColor.clear.cgColor
     }
 }

--- a/Sources/UI/Chrome/WindowChromeController.swift
+++ b/Sources/UI/Chrome/WindowChromeController.swift
@@ -127,6 +127,11 @@ final class WindowChromeController: NSViewController {
         terminalHeader.setWorktreeContextEnabled(enabled)
     }
 
+    /// Drive the terminal header's edit-mode toggle (availability + on-state).
+    func setEditMode(available: Bool, isOn: Bool) {
+        terminalHeader.setEditMode(available: available, isOn: isOn)
+    }
+
     /// View that owns `Region.titlebar` keyboard focus for the current collapse state.
     func titlebarRegionFocusTarget() -> NSView {
         state.isCollapsed ? terminalHeader : sidebarHeader

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -113,6 +113,10 @@ class DashboardViewController: NSViewController {
     var onRequestSelectChromePane: ((ChromeLeftPane) -> Void)?
     /// File / changelog overlay title for the chrome terminal header (`nil` = restore pane title).
     var onCenterOverlayTitleChange: ((String?) -> Void)?
+
+    /// Fires when the edit-mode toggle's availability or on-state changes, so the
+    /// chrome header can enable/dim/light its icon. `(available, isOn)`.
+    var onEditModeStateChange: ((Bool, Bool) -> Void)?
     /// Last worktree the user actually committed into (split/terminal). Backs the
     /// mode-1 ⇄ mode-2 back-key toggle.
     private(set) var lastCommittedWorktreePath: String?
@@ -186,6 +190,33 @@ class DashboardViewController: NSViewController {
 
     // Center overlay
     private var centerOverlay: CenterOverlayView?
+
+    // MARK: - Edit-mode (split file-preview layout)
+
+    /// Per-worktree preview-set + edit-mode model (decoupled from display mode).
+    let previewSets = PreviewSetController()
+    /// The two-column edit container, created lazily and reused across worktrees.
+    private var editLayoutContainer: EditLayoutContainerView?
+    /// Built preview content views keyed by file path (preserves editor state
+    /// across tab switches). Torn down on explicit tab close / worktree deletion.
+    private var previewContentCache: [String: NSView] = [:]
+
+    /// Where the terminal `SplitContainerView` should live right now — the edit
+    /// container's terminal host when edit mode is attached, else the focus panel.
+    private var currentTerminalContainer: NSView {
+        if let edit = editLayoutContainer, edit.superview != nil { return edit.terminalHost }
+        return leftRightFocusPanel.terminalContainer
+    }
+
+    private var currentWorktreePath: String? {
+        (agents.first(where: { $0.id == selectedSailorId }) ?? agents.first)?.worktreePath
+    }
+
+    /// True when the selected worktree is showing the split edit layout.
+    var isEditModeActive: Bool {
+        guard let wt = currentWorktreePath else { return false }
+        return previewSets.isEditMode(for: wt) && editLayoutContainer?.superview != nil
+    }
 
     // `?` keyboard cheat-sheet overlay (the floating First Mate cockpit was
     // removed; the command composer lives in the overview now).
@@ -382,6 +413,8 @@ class DashboardViewController: NSViewController {
             reembedSplitContainerIfDetached()
         }
         syncSidePanelToSelection()
+        // Keep edit-mode terminal tab titles current (strip diffs internally).
+        refreshEditModeTabsIfActive()
     }
 
     private func syncSidePanelToSelection() {
@@ -909,10 +942,13 @@ class DashboardViewController: NSViewController {
     /// `focusTerminal: false` is used for live nav preview — it keeps the dashboard
     /// VC as first responder so arrow keys keep driving the nav ring.
     func embedSplitContainerForSelectedSailor(focusTerminal: Bool = true) {
-        let container = leftRightFocusPanel.terminalContainer
-
         guard let agent = agents.first(where: { $0.id == selectedSailorId }) ?? agents.first else { return }
         let worktreePath = agent.worktreePath
+
+        // Attach/detach the edit container for THIS worktree's mode before we pick
+        // the embed target — currentTerminalContainer depends on it.
+        prepareEditContainer(forWorktree: worktreePath)
+        let container = currentTerminalContainer
 
         // Skip re-embed if the same split container is already active for this
         // worktree — but still hand it the keyboard when asked (e.g. committing
@@ -920,7 +956,7 @@ class DashboardViewController: NSViewController {
         if let active = activeSplitContainer,
            active.superview === container,
            activeSplitWorktreePath == worktreePath {
-            if focusTerminal { focusActiveTerminalLeaf() }
+            finalizeEditLayout(focusTerminal: focusTerminal)
             return
         }
 
@@ -986,6 +1022,25 @@ class DashboardViewController: NSViewController {
         }
         syncSidePanelToSelection()
 
+        finalizeEditLayout(focusTerminal: focusTerminal, tree: tree)
+    }
+
+    /// Shared tail for `embedSplitContainerForSelectedSailor`: applies zoom + tab
+    /// strips in edit mode (or restores the spatial split in focus mode), then
+    /// takes keyboard focus when asked. Never re-enters embed (no recursion).
+    private func finalizeEditLayout(focusTerminal: Bool, tree: SplitTree? = nil) {
+        let editMode = editLayoutContainer?.superview != nil
+        if editMode {
+            applyZoomToFocusedLeaf()
+            refreshEditModeTabs()
+            updatePreviewContent()
+        } else if let container = activeSplitContainer, container.zoomedLeafId != nil {
+            // Leaving edit mode: drop the zoom so the spatial split is restored.
+            container.zoomedLeafId = nil
+            container.layoutTree()
+        }
+        notifyEditModeState()
+
         // Focus the active leaf — defer to let the view hierarchy settle.
         // Skipped during nav preview so the dashboard VC keeps first responder.
         guard focusTerminal else { return }
@@ -997,7 +1052,11 @@ class DashboardViewController: NSViewController {
             windowKeyboardMode?.enterInsert()
         }
 
-        focusActiveTerminalLeaf(tree: tree)
+        if editMode {
+            focusZoomedLeaf()
+        } else {
+            focusActiveTerminalLeaf(tree: tree)
+        }
     }
 
     /// Make the active split leaf's Ghostty view first responder (immediate +
@@ -1027,6 +1086,13 @@ class DashboardViewController: NSViewController {
             activeSplitWorktreePath = nil
         }
         splitContainers.removeValue(forKey: path)
+
+        // Drop this worktree's preview set + any cached preview content views.
+        for file in previewSets.files(for: path) {
+            previewContentCache[file]?.removeFromSuperview()
+            previewContentCache.removeValue(forKey: file)
+        }
+        previewSets.forget(worktree: path)
     }
 
     // MARK: - Dashboard Navigation (D-state)
@@ -1600,10 +1666,300 @@ extension DashboardViewController {
 }
 
 
+// MARK: - Edit mode (split file-preview layout)
+
+extension DashboardViewController {
+
+    /// Toggle the selected worktree between focus and edit layout. No-op if the
+    /// preview set is empty (nothing to show in the right column).
+    func toggleEditMode() {
+        guard let wt = currentWorktreePath, !previewSets.isEmpty(wt) else { return }
+        let goingEdit = !previewSets.isEditMode(for: wt)
+        previewSets.setEditMode(goingEdit, for: wt)
+        // Re-embed retargets the split into the right container (prepare attaches/
+        // detaches the edit shell). Don't steal terminal focus when entering edit.
+        embedSplitContainerForSelectedSailor(focusTerminal: !goingEdit)
+        if goingEdit {
+            if let active = previewSets.activeFile(for: wt) { selectPreviewTab(active) }
+        } else {
+            // Carry the active file across: focus mode shows it fullscreen.
+            dismissCenterOverlay()
+            if let active = previewSets.activeFile(for: wt) { presentFileOverlay(path: active) }
+        }
+        notifyEditModeState()
+    }
+
+    private func notifyEditModeState() {
+        guard let wt = currentWorktreePath else {
+            onEditModeStateChange?(false, false)
+            return
+        }
+        onEditModeStateChange?(!previewSets.isEmpty(wt), previewSets.isEditMode(for: wt))
+    }
+
+    // MARK: Container attach / detach
+
+    /// Attach or detach the two-column edit shell for `wt`'s current mode. Runs
+    /// before the embed target is chosen; never re-enters embed.
+    private func prepareEditContainer(forWorktree wt: String) {
+        let container = leftRightFocusPanel.terminalContainer
+        if previewSets.isEditMode(for: wt) {
+            dismissCenterOverlay()
+            let edit = editLayoutContainer ?? makeEditContainer()
+            edit.updateRatio(previewSets.splitRatio(for: wt))
+            if edit.superview !== container {
+                edit.frame = container.bounds
+                edit.autoresizingMask = [.width, .height]
+                container.addSubview(edit)
+            }
+        } else if let edit = editLayoutContainer {
+            edit.removeFromSuperview()
+            editLayoutContainer = nil
+        }
+    }
+
+    private func makeEditContainer() -> EditLayoutContainerView {
+        let ratio = currentWorktreePath.map { previewSets.splitRatio(for: $0) } ?? 0.5
+        let edit = EditLayoutContainerView(ratio: ratio)
+        edit.onRatioChange = { [weak self] r in
+            guard let self, let wt = self.currentWorktreePath else { return }
+            self.previewSets.setSplitRatio(r, for: wt)
+        }
+        edit.terminalTabStrip.onSelect = { [weak self] id in self?.selectTerminalTab(id) }
+        edit.previewTabStrip.onSelect = { [weak self] id in self?.selectPreviewTab(id) }
+        edit.previewTabStrip.onClose = { [weak self] id in self?.closePreviewTab(id) }
+        editLayoutContainer = edit
+        return edit
+    }
+
+    // MARK: Terminal tabs (LEFT column)
+
+    private func applyZoomToFocusedLeaf() {
+        guard let split = activeSplitContainer, let tree = split.tree else { return }
+        let id = split.zoomedLeafId ?? tree.focusedId
+        guard tree.allLeaves.contains(where: { $0.id == id }) else {
+            // Focused leaf gone (pane closed): fall back to the first leaf.
+            if let first = tree.allLeaves.first {
+                tree.focusedId = first.id
+                split.setZoom(leafId: first.id, on: true)
+            }
+            return
+        }
+        tree.focusedId = id
+        split.setZoom(leafId: id, on: true)
+    }
+
+    private func selectTerminalTab(_ leafId: String) {
+        guard let split = activeSplitContainer, let tree = split.tree,
+              tree.allLeaves.contains(where: { $0.id == leafId }) else { return }
+        tree.focusedId = leafId
+        split.setZoom(leafId: leafId, on: true)
+        refreshEditModeTabs()
+        focusZoomedLeaf()
+    }
+
+    func editModeCycleTerminalTab(forward: Bool) {
+        guard let split = activeSplitContainer, let tree = split.tree else { return }
+        let leaves = tree.allLeaves
+        guard !leaves.isEmpty else { return }
+        let current = split.zoomedLeafId ?? tree.focusedId
+        let idx = leaves.firstIndex(where: { $0.id == current }) ?? 0
+        let next = leaves[(idx + (forward ? 1 : leaves.count - 1)) % leaves.count]
+        selectTerminalTab(next.id)
+    }
+
+    private func focusZoomedLeaf() {
+        guard let split = activeSplitContainer, let tree = split.tree else { return }
+        let id = split.zoomedLeafId ?? tree.focusedId
+        guard let leaf = tree.allLeaves.first(where: { $0.id == id }),
+              let view = split.surfaceViews[leaf.stationId] else { return }
+        view.window?.makeFirstResponder(view)
+        DispatchQueue.main.async {
+            if !(view.window?.firstResponder is GhosttyNSView) {
+                view.window?.makeFirstResponder(view)
+            }
+        }
+    }
+
+    // MARK: Preview tabs (RIGHT column)
+
+    private func selectPreviewTab(_ path: String) {
+        guard let wt = currentWorktreePath else { return }
+        previewSets.setActive(path, for: wt)
+        updatePreviewContent()
+        refreshEditModeTabs()
+    }
+
+    func editModeCyclePreviewTab(forward: Bool) {
+        guard let wt = currentWorktreePath else { return }
+        let files = previewSets.files(for: wt)
+        guard !files.isEmpty else { return }
+        let current = previewSets.activeFile(for: wt)
+        let idx = current.flatMap { files.firstIndex(of: $0) } ?? 0
+        let next = files[(idx + (forward ? 1 : files.count - 1)) % files.count]
+        selectPreviewTab(next)
+    }
+
+    private func closePreviewTab(_ path: String) {
+        guard let wt = currentWorktreePath else { return }
+        previewContentCache[path]?.removeFromSuperview()
+        previewContentCache.removeValue(forKey: path)
+        _ = previewSets.remove(path, from: wt)
+
+        if previewSets.isEmpty(wt) {
+            // Degrade to focus mode when the last preview closes.
+            previewSets.setEditMode(false, for: wt)
+            embedSplitContainerForSelectedSailor(focusTerminal: true)
+        } else {
+            updatePreviewContent()
+            refreshEditModeTabs()
+        }
+        notifyEditModeState()
+    }
+
+    /// Show the active preview file's content view in the right host, building +
+    /// caching it on first use so tab switches preserve editor state.
+    private func updatePreviewContent() {
+        guard let edit = editLayoutContainer, let wt = currentWorktreePath else { return }
+        let host = edit.previewHost
+        guard let active = previewSets.activeFile(for: wt) else {
+            host.subviews.forEach { $0.isHidden = true }
+            return
+        }
+        let content: NSView
+        if let cached = previewContentCache[active] {
+            content = cached
+        } else {
+            content = makePreviewContent(path: active)
+            previewContentCache[active] = content
+            content.translatesAutoresizingMaskIntoConstraints = false
+            host.addSubview(content)
+            NSLayoutConstraint.activate([
+                content.topAnchor.constraint(equalTo: host.topAnchor),
+                content.leadingAnchor.constraint(equalTo: host.leadingAnchor),
+                content.trailingAnchor.constraint(equalTo: host.trailingAnchor),
+                content.bottomAnchor.constraint(equalTo: host.bottomAnchor),
+            ])
+        }
+        if content.superview !== host {
+            content.removeFromSuperview()
+            content.translatesAutoresizingMaskIntoConstraints = false
+            host.addSubview(content)
+            NSLayoutConstraint.activate([
+                content.topAnchor.constraint(equalTo: host.topAnchor),
+                content.leadingAnchor.constraint(equalTo: host.leadingAnchor),
+                content.trailingAnchor.constraint(equalTo: host.trailingAnchor),
+                content.bottomAnchor.constraint(equalTo: host.bottomAnchor),
+            ])
+        }
+        for sub in host.subviews { sub.isHidden = (sub !== content) }
+    }
+
+    /// Build the content view for a preview tab, wrapped in the same
+    /// `CenterOverlayView` chrome the focus-mode overlay uses (Close / Save /
+    /// Preview toolbar + Cmd+S + Esc) so the two modes are identical. The
+    /// toolbar's Close closes this tab.
+    private func makePreviewContent(path: String) -> NSView {
+        buildPreviewOverlayView(path: path) { [weak self] in
+            self?.closePreviewTab(path)
+        }
+    }
+
+    /// Shared builder: file → editor/media/fallback wrapped in `CenterOverlayView`,
+    /// with Save/Preview wiring for editable text. Used by the edit-mode right
+    /// column (the focus-mode path builds its own via `showCenterOverlay`).
+    private func buildPreviewOverlayView(path: String, onClose: @escaping () -> Void) -> NSView {
+        if let media = MediaPreviewView.make(path: path) {
+            return CenterOverlayView(content: media, onClose: onClose)
+        }
+        guard let editor = CodeEditorView(path: path) else {
+            let fallback = MediaPreviewView.fallback(path: path) ?? FileContentView(path: path)
+            return CenterOverlayView(content: fallback, onClose: onClose)
+        }
+        weak var overlayRef: CenterOverlayView?
+        let overlay = CenterOverlayView(
+            content: editor,
+            onSave: { [weak editor] in editor?.save() },
+            onPreview: editor.isPreviewable ? { [weak editor] in
+                guard let editor else { return }
+                overlayRef?.setPreviewing(editor.togglePreview())
+            } : nil,
+            onClose: onClose
+        )
+        overlayRef = overlay
+        editor.onDirtyChange = { [weak overlay] dirty in
+            overlay?.setDirty(dirty)
+        }
+        return overlay
+    }
+
+    // MARK: Tab strip refresh
+
+    private func refreshEditModeTabs() {
+        guard let edit = editLayoutContainer, let wt = currentWorktreePath else { return }
+
+        let tree = activeSplitContainer?.tree
+        let leaves = tree?.allLeaves ?? []
+        let selectedLeaf = activeSplitContainer?.zoomedLeafId ?? tree?.focusedId
+        let termItems = leaves.map { leaf in
+            EditTabStripView.Item(
+                id: leaf.id,
+                title: terminalTabTitle(leaf: leaf, worktree: wt),
+                closable: false
+            )
+        }
+        edit.terminalTabStrip.apply(items: termItems, selectedId: selectedLeaf)
+
+        let files = previewSets.files(for: wt)
+        let previewItems = files.map { path in
+            EditTabStripView.Item(
+                id: path,
+                title: URL(fileURLWithPath: path).lastPathComponent,
+                closable: true
+            )
+        }
+        edit.previewTabStrip.apply(items: previewItems, selectedId: previewSets.activeFile(for: wt))
+    }
+
+    private func terminalTabTitle(leaf: SplitNode.LeafInfo, worktree: String) -> String {
+        if let sailor = ShipLog.shared.sailors(forWorktree: worktree)
+            .first(where: { $0.id == leaf.stationId }) {
+            return PaneTitleResolver.title(for: sailor)
+        }
+        return leaf.sessionName
+    }
+
+    /// Called by the status/title refresh path so edit-mode terminal tabs track
+    /// pane titles without churning the view tree (the strip diffs internally).
+    func refreshEditModeTabsIfActive() {
+        guard isEditModeActive else { return }
+        refreshEditModeTabs()
+    }
+}
+
 // MARK: - WorktreeSidePanelDelegate
 
 extension DashboardViewController: WorktreeSidePanelDelegate {
     func sidePanel(_ vc: WorktreeSidePanelViewController, didSelectFile path: String) {
+        // Record the file into the (mode-decoupled) preview set. In edit mode it
+        // becomes a right-column tab; otherwise it opens as the fullscreen overlay.
+        guard let wt = currentWorktreePath else {
+            presentFileOverlay(path: path)
+            return
+        }
+        previewSets.add(path, to: wt)
+
+        if previewSets.isEditMode(for: wt) {
+            embedSplitContainerForSelectedSailor(focusTerminal: false)
+            selectPreviewTab(path)
+        } else {
+            presentFileOverlay(path: path)
+        }
+        notifyEditModeState()
+    }
+
+    /// Present a file as the fullscreen center overlay (focus-mode viewer).
+    func presentFileOverlay(path: String) {
         let title = URL(fileURLWithPath: path).lastPathComponent
 
         // Images and audio/video get a native viewer. Everything else — including

--- a/Sources/UI/Dashboard/EditLayoutContainerView.swift
+++ b/Sources/UI/Dashboard/EditLayoutContainerView.swift
@@ -1,0 +1,120 @@
+import AppKit
+
+/// Edit-mode's two-column shell: LEFT terminal column (tab strip + terminal host)
+/// and RIGHT preview column (tab strip + preview host), separated by a draggable
+/// divider. It owns only geometry — the hosts are filled by
+/// `DashboardViewController` (the terminal `SplitContainerView` on the left, the
+/// active preview content on the right). Columns/divider are frame-laid so a drag
+/// is a cheap frame move; column internals use Auto Layout.
+final class EditLayoutContainerView: NSView, DividerDelegate {
+    /// Host for the terminal `SplitContainerView` (shown one pane at a time).
+    let terminalHost = NSView()
+    /// Host for the active preview file's content view.
+    let previewHost = NSView()
+    let terminalTabStrip = EditTabStripView()
+    let previewTabStrip = EditTabStripView()
+
+    /// Fraction of width given to the LEFT (terminal) column.
+    private var ratio: CGFloat
+    /// Fired continuously while dragging (frames already moved) and once on end.
+    var onRatioChange: ((CGFloat) -> Void)?
+
+    private let leftColumn = NSView()
+    private let rightColumn = NSView()
+    private let divider = DividerView(splitNodeId: "editmode.column", axis: .horizontal)
+
+    init(ratio: CGFloat) {
+        self.ratio = ratio
+        super.init(frame: .zero)
+        wantsLayer = true
+        translatesAutoresizingMaskIntoConstraints = false
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func setup() {
+        for column in [leftColumn, rightColumn] {
+            column.translatesAutoresizingMaskIntoConstraints = true
+            column.autoresizingMask = []
+            addSubview(column)
+        }
+        divider.delegate = self
+        addSubview(divider)
+
+        configureColumn(leftColumn, strip: terminalTabStrip, host: terminalHost)
+        configureColumn(rightColumn, strip: previewTabStrip, host: previewHost)
+    }
+
+    private func configureColumn(_ column: NSView, strip: EditTabStripView, host: NSView) {
+        strip.translatesAutoresizingMaskIntoConstraints = false
+        host.translatesAutoresizingMaskIntoConstraints = false
+        host.wantsLayer = true
+        column.addSubview(strip)
+        column.addSubview(host)
+        NSLayoutConstraint.activate([
+            strip.topAnchor.constraint(equalTo: column.topAnchor),
+            strip.leadingAnchor.constraint(equalTo: column.leadingAnchor),
+            strip.trailingAnchor.constraint(equalTo: column.trailingAnchor),
+
+            host.topAnchor.constraint(equalTo: strip.bottomAnchor),
+            host.leadingAnchor.constraint(equalTo: column.leadingAnchor),
+            host.trailingAnchor.constraint(equalTo: column.trailingAnchor),
+            host.bottomAnchor.constraint(equalTo: column.bottomAnchor),
+        ])
+    }
+
+    /// Apply a stored per-worktree ratio (e.g. when switching worktrees while the
+    /// container is reused). No-op if unchanged.
+    func updateRatio(_ newRatio: CGFloat) {
+        guard abs(newRatio - ratio) > 0.001 else { return }
+        ratio = newRatio
+        needsLayout = true
+    }
+
+    // MARK: - Layout
+
+    override func layout() {
+        super.layout()
+        let w = bounds.width
+        let h = bounds.height
+        guard w > 0, h > 0 else { return }
+        let seam = DividerView.thickness
+        let leftW = floor((w - seam) * ratio)
+        leftColumn.frame = CGRect(x: 0, y: 0, width: leftW, height: h)
+        rightColumn.frame = CGRect(x: leftW + seam, y: 0, width: w - leftW - seam, height: h)
+
+        let hit = DividerView.hitThickness
+        divider.frame = CGRect(x: leftW + seam / 2 - hit / 2, y: 0, width: hit, height: h)
+        divider.parentSplitSize = w
+        divider.currentRatio = ratio
+    }
+
+    // MARK: - DividerDelegate
+
+    func dividerDidBeginDrag(_ splitNodeId: String) {
+        // Defer Ghostty PTY set_size for the whole drag (SIGWINCH tolerance).
+        GhosttyBridge.shared.beginLiveResize(pinHeight: false)
+    }
+
+    func dividerDidMove(_ splitNodeId: String, newRatio: CGFloat) {
+        ratio = newRatio
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+        onRatioChange?(newRatio)
+    }
+
+    func dividerDidEndDrag(_ splitNodeId: String) {
+        GhosttyBridge.shared.endLiveResize()
+        onRatioChange?(ratio)
+    }
+
+    func dividerDidDoubleClick(_ splitNodeId: String) {
+        ratio = 0.5
+        GhosttyBridge.shared.beginLiveResize(pinHeight: false)
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+        GhosttyBridge.shared.endLiveResize()
+        onRatioChange?(ratio)
+    }
+}

--- a/Sources/UI/Dashboard/EditTabStripView.swift
+++ b/Sources/UI/Dashboard/EditTabStripView.swift
@@ -1,0 +1,208 @@
+import AppKit
+
+/// A compact horizontal tab strip used by edit-mode's LEFT (terminal panes) and
+/// RIGHT (file previews) columns. Purely presentational: it renders `items`,
+/// highlights `selectedId`, and reports taps/closes through callbacks. The owner
+/// owns all state — the strip never mutates the model itself.
+final class EditTabStripView: NSView {
+    struct Item: Equatable {
+        let id: String
+        let title: String
+        /// When true a close (×) affordance is shown on the tab.
+        let closable: Bool
+    }
+
+    static let stripHeight: CGFloat = 30
+
+    var onSelect: ((String) -> Void)?
+    var onClose: ((String) -> Void)?
+
+    private let scroll = NonScrollingClipScrollView()
+    private let stack = NSStackView()
+    private var items: [Item] = []
+    private var selectedId: String?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not supported") }
+
+    private func setup() {
+        wantsLayer = true
+        translatesAutoresizingMaskIntoConstraints = false
+        refreshBackground()
+
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        scroll.drawsBackground = false
+        scroll.hasHorizontalScroller = false
+        scroll.hasVerticalScroller = false
+        scroll.horizontalScrollElasticity = .allowed
+        scroll.verticalScrollElasticity = .none
+        addSubview(scroll)
+
+        stack.orientation = .horizontal
+        stack.spacing = 2
+        stack.alignment = .centerY
+        stack.edgeInsets = NSEdgeInsets(top: 4, left: 6, bottom: 4, right: 6)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        let doc = FlippedDocumentView()
+        doc.translatesAutoresizingMaskIntoConstraints = false
+        doc.addSubview(stack)
+        scroll.documentView = doc
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: Self.stripHeight),
+            scroll.topAnchor.constraint(equalTo: topAnchor),
+            scroll.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scroll.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scroll.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            stack.topAnchor.constraint(equalTo: doc.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: doc.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: doc.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: doc.bottomAnchor),
+            doc.heightAnchor.constraint(equalTo: scroll.heightAnchor),
+        ])
+    }
+
+    // MARK: - Model application
+
+    /// Update the strip. Rebuilds the tab views only when the id set changes;
+    /// otherwise just refreshes titles + selection in place so the 2s status
+    /// poll (which nudges titles) never churns the whole view tree.
+    func apply(items newItems: [Item], selectedId: String?) {
+        let idsChanged = newItems.map(\.id) != items.map(\.id)
+            || newItems.map(\.closable) != items.map(\.closable)
+        self.items = newItems
+        self.selectedId = selectedId
+
+        if idsChanged {
+            rebuild()
+        } else {
+            for case let tab as TabButton in stack.arrangedSubviews {
+                if let item = newItems.first(where: { $0.id == tab.itemId }) {
+                    tab.title = item.title
+                    tab.isSelectedTab = (item.id == selectedId)
+                }
+            }
+        }
+    }
+
+    private func rebuild() {
+        stack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        for item in items {
+            let tab = TabButton(itemId: item.id)
+            tab.title = item.title
+            tab.showsClose = item.closable
+            tab.isSelectedTab = (item.id == selectedId)
+            tab.onSelect = { [weak self] id in self?.onSelect?(id) }
+            tab.onClose = { [weak self] id in self?.onClose?(id) }
+            stack.addArrangedSubview(tab)
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        refreshBackground()
+    }
+
+    private func refreshBackground() {
+        layer?.backgroundColor = GhosttyBridge.shared.terminalChromeBackground.cgColor
+    }
+}
+
+// MARK: - Tab button
+
+private final class TabButton: NSView {
+    let itemId: String
+    var onSelect: ((String) -> Void)?
+    var onClose: ((String) -> Void)?
+
+    var title: String = "" { didSet { label.stringValue = title } }
+    var showsClose: Bool = false { didSet { closeButton.isHidden = !showsClose } }
+    var isSelectedTab: Bool = false { didSet { refreshAppearance() } }
+
+    private let label = NSTextField(labelWithString: "")
+    private let closeButton = NSButton()
+
+    init(itemId: String) {
+        self.itemId = itemId
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.cornerRadius = 5
+        translatesAutoresizingMaskIntoConstraints = false
+
+        label.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        label.lineBreakMode = .byTruncatingTail
+        label.maximumNumberOfLines = 1
+        label.cell?.usesSingleLineMode = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+
+        let cfg = NSImage.SymbolConfiguration(pointSize: 8, weight: .bold)
+        closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: "Close")?
+            .withSymbolConfiguration(cfg)
+        closeButton.bezelStyle = .recessed
+        closeButton.isBordered = false
+        closeButton.imagePosition = .imageOnly
+        closeButton.target = self
+        closeButton.action = #selector(closeClicked)
+        closeButton.isHidden = true
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(closeButton)
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: 22),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 9),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            closeButton.leadingAnchor.constraint(equalTo: label.trailingAnchor, constant: 5),
+            closeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            closeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            closeButton.widthAnchor.constraint(equalToConstant: 12),
+            widthAnchor.constraint(lessThanOrEqualToConstant: 200),
+        ])
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        refreshAppearance()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func mouseDown(with event: NSEvent) {
+        onSelect?(itemId)
+    }
+
+    @objc private func closeClicked() {
+        onClose?(itemId)
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        refreshAppearance()
+    }
+
+    private func refreshAppearance() {
+        let fg = GhosttyBridge.shared.terminalChromeForeground
+        if isSelectedTab {
+            layer?.backgroundColor = fg.withAlphaComponent(0.16).cgColor
+            label.textColor = fg
+        } else {
+            layer?.backgroundColor = NSColor.clear.cgColor
+            label.textColor = fg.withAlphaComponent(0.6)
+        }
+        closeButton.contentTintColor = fg.withAlphaComponent(0.6)
+    }
+}
+
+// MARK: - Helpers
+
+private final class FlippedDocumentView: NSView {
+    override var isFlipped: Bool { true }
+}
+
+/// Scroll view that lets horizontal wheel/trackpad scroll through but never grabs
+/// keyboard focus away from the terminal.
+private final class NonScrollingClipScrollView: NSScrollView {
+    override var acceptsFirstResponder: Bool { false }
+}

--- a/Sources/UI/Dashboard/PreviewSetController.swift
+++ b/Sources/UI/Dashboard/PreviewSetController.swift
@@ -1,0 +1,98 @@
+import AppKit
+
+/// Per-worktree "open file previews" model, decoupled from the display mode.
+///
+/// Selecting a file in the Files side panel adds it here; focus mode shows the
+/// active file fullscreen (center overlay) while edit mode shows the whole set as
+/// tabs. State is keyed by worktree path so it naturally follows the worktree as
+/// the user switches tabs. Intentionally in-memory: a preview set is session
+/// scratch, and persisting file paths would resurrect stale/deleted files on
+/// relaunch. The edit-mode flag + split ratio live here too so the whole
+/// edit-layout state has one owner.
+final class PreviewSetController {
+    private var filesByWorktree: [String: [String]] = [:]
+    private var activeByWorktree: [String: String] = [:]
+    private var editModeByWorktree: [String: Bool] = [:]
+    private var ratioByWorktree: [String: CGFloat] = [:]
+
+    // MARK: - Preview files
+
+    func files(for worktree: String) -> [String] {
+        filesByWorktree[worktree] ?? []
+    }
+
+    func activeFile(for worktree: String) -> String? {
+        activeByWorktree[worktree]
+    }
+
+    func isEmpty(_ worktree: String) -> Bool {
+        files(for: worktree).isEmpty
+    }
+
+    /// Append the file if new (preserving tab order) and make it active.
+    func add(_ path: String, to worktree: String) {
+        var list = filesByWorktree[worktree] ?? []
+        if !list.contains(path) {
+            list.append(path)
+            filesByWorktree[worktree] = list
+        }
+        activeByWorktree[worktree] = path
+    }
+
+    func setActive(_ path: String, for worktree: String) {
+        guard files(for: worktree).contains(path) else { return }
+        activeByWorktree[worktree] = path
+    }
+
+    /// Remove a file; re-pick the adjacent tab as active. Returns the new active
+    /// file (nil once the set is empty).
+    @discardableResult
+    func remove(_ path: String, from worktree: String) -> String? {
+        var list = filesByWorktree[worktree] ?? []
+        guard let idx = list.firstIndex(of: path) else {
+            return activeByWorktree[worktree]
+        }
+        list.remove(at: idx)
+        filesByWorktree[worktree] = list
+
+        if activeByWorktree[worktree] == path {
+            if list.isEmpty {
+                activeByWorktree[worktree] = nil
+            } else {
+                // Prefer the tab that slid into this slot, else the previous one.
+                activeByWorktree[worktree] = list[min(idx, list.count - 1)]
+            }
+        }
+        return activeByWorktree[worktree]
+    }
+
+    // MARK: - Edit mode
+
+    /// Edit mode is only *effective* when there is something to preview.
+    func isEditMode(for worktree: String) -> Bool {
+        (editModeByWorktree[worktree] ?? false) && !isEmpty(worktree)
+    }
+
+    func setEditMode(_ enabled: Bool, for worktree: String) {
+        editModeByWorktree[worktree] = enabled
+    }
+
+    func splitRatio(for worktree: String) -> CGFloat {
+        ratioByWorktree[worktree] ?? 0.5
+    }
+
+    func setSplitRatio(_ ratio: CGFloat, for worktree: String) {
+        ratioByWorktree[worktree] = min(max(ratio, 0.15), 0.85)
+    }
+
+    // MARK: - Cleanup
+
+    /// Drop state for worktrees that no longer exist (called when a worktree is
+    /// deleted) so the dictionaries don't leak.
+    func forget(worktree: String) {
+        filesByWorktree.removeValue(forKey: worktree)
+        activeByWorktree.removeValue(forKey: worktree)
+        editModeByWorktree.removeValue(forKey: worktree)
+        ratioByWorktree.removeValue(forKey: worktree)
+    }
+}

--- a/Sources/UI/SidePanel/FilePreviewWindowController.swift
+++ b/Sources/UI/SidePanel/FilePreviewWindowController.swift
@@ -1,0 +1,47 @@
+import AppKit
+import QuickLookUI
+
+/// Floating window that previews a single file with QuickLook, opened from the
+/// pane context menu when the terminal selection resolves to an existing file.
+///
+/// A single shared window is reused across previews: re-invoking Preview just
+/// retargets it and brings it forward, so repeated previews don't litter the
+/// screen with windows.
+final class FilePreviewWindowController: NSWindowController {
+
+    static let shared = FilePreviewWindowController()
+
+    private let previewView = QLPreviewView(frame: .zero, style: .normal) ?? QLPreviewView()
+
+    private init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 560),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.titlebarAppearsTransparent = false
+        super.init(window: window)
+
+        previewView.autostarts = true
+        previewView.shouldCloseWithWindow = false
+        window.contentView = previewView
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) not supported") }
+
+    /// Preview the file at `url`, reusing (and re-centering, if first shown) the
+    /// shared window.
+    func preview(url: URL) {
+        guard let window else { return }
+        window.title = url.lastPathComponent
+        previewView.previewItem = url as NSURL
+        previewView.refreshPreviewItem()
+        if !window.isVisible {
+            window.center()
+        }
+        showWindow(nil)
+        window.makeKeyAndOrderFront(nil)
+    }
+}

--- a/Tests/SelectedFilePathResolutionTests.swift
+++ b/Tests/SelectedFilePathResolutionTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import seahelm
+
+/// Covers `GhosttyNSView.resolveSelectedPath` — the pure path resolver behind the
+/// pane context menu's "Preview" item.
+final class SelectedFilePathResolutionTests: XCTestCase {
+
+    private var tmpDir: String = ""
+
+    override func setUpWithError() throws {
+        tmpDir = NSTemporaryDirectory().appending("seahelm-preview-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(atPath: tmpDir)
+    }
+
+    private func touch(_ relative: String) throws -> String {
+        let full = (tmpDir as NSString).appendingPathComponent(relative)
+        try FileManager.default.createDirectory(
+            atPath: (full as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: full, contents: Data("x".utf8))
+        return full
+    }
+
+    func testRelativePathResolvedAgainstBase() throws {
+        let full = try touch("docs/remote-clients-design.md")
+        let url = GhosttyNSView.resolveSelectedPath(
+            raw: "docs/remote-clients-design.md",
+            bases: [nil, "", tmpDir]
+        )
+        XCTAssertEqual(url?.path, full)
+    }
+
+    func testFirstExistingBaseWins() throws {
+        let full = try touch("a/file.txt")
+        let url = GhosttyNSView.resolveSelectedPath(
+            raw: "a/file.txt",
+            bases: ["/nonexistent/base", tmpDir]
+        )
+        XCTAssertEqual(url?.path, full)
+    }
+
+    func testTrailingWhitespaceTrimmed() throws {
+        let full = try touch("notes.md")
+        let url = GhosttyNSView.resolveSelectedPath(raw: "  notes.md \n", bases: [tmpDir])
+        XCTAssertEqual(url?.path, full)
+    }
+
+    func testAbsolutePathUsedDirectly() throws {
+        let full = try touch("abs.txt")
+        let url = GhosttyNSView.resolveSelectedPath(raw: full, bases: [nil])
+        XCTAssertEqual(url?.path, full)
+    }
+
+    func testNonexistentFileReturnsNil() {
+        XCTAssertNil(GhosttyNSView.resolveSelectedPath(raw: "does/not/exist.md", bases: [tmpDir]))
+    }
+
+    func testDirectoryReturnsNil() throws {
+        _ = try touch("subdir/keep.txt")  // creates subdir
+        XCTAssertNil(GhosttyNSView.resolveSelectedPath(raw: "subdir", bases: [tmpDir]))
+    }
+
+    func testMultiTokenSelectionRejected() throws {
+        _ = try touch("file.md")
+        XCTAssertNil(GhosttyNSView.resolveSelectedPath(raw: "file.md Mobile", bases: [tmpDir]))
+    }
+
+    func testEmptySelectionReturnsNil() {
+        XCTAssertNil(GhosttyNSView.resolveSelectedPath(raw: "   \n ", bases: [tmpDir]))
+    }
+}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		2C2802EE819E3CFE15765F18 /* WebhookStatusProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D1A230FCEF8663316AD13F /* WebhookStatusProviderTests.swift */; };
 		2CE3679CE395A49CDD452CEB /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358662BE2D7B5944F3C610F9 /* FuzzyMatchTests.swift */; };
 		2D473084E59DC7776E010F78 /* WorktreeGroupingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448BBAB293764647E8FDB894 /* WorktreeGroupingTests.swift */; };
+		2E74EEEB640ABA51B1CBBC01 /* EditTabStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 641B13C5C51C4D5B012443A6 /* EditTabStripView.swift */; };
 		2F081A963842FF92DB2D1568 /* CodexHooksSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D815BD3789070197196037 /* CodexHooksSetupTests.swift */; };
 		2F5B5EC7F0428265CC344717 /* CodexHooksSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51B009382FE3586E735355D /* CodexHooksSetup.swift */; };
 		303FCEA37D46939EB9451358 /* WorktreeCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A85CAE555196AE450DDD90E /* WorktreeCreatorTests.swift */; };
@@ -73,6 +74,7 @@
 		3942E57F0C66DB17F7BF5535 /* CodexSessionPromptLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C16AC1C12C568E0A2971C9E /* CodexSessionPromptLookup.swift */; };
 		3996E70F14274967ED09305E /* IdeaStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5512F73C560C4BEA3AA8424 /* IdeaStore.swift */; };
 		3A5FD6063BF092FB51DC280A /* WorktreeGitStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8BB5725BBA721E41CF23CF /* WorktreeGitStats.swift */; };
+		3B6E064F838BAF33075485C8 /* PreviewSetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4808E81C577D8BF32131B574 /* PreviewSetController.swift */; };
 		3BB046CB910F5735999EAF2F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 23B112FAA14CF6135A4F7202 /* Assets.xcassets */; };
 		3BE5AE4B30540C9F80527B7F /* ChromeDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4AD78048C5DC1D7D1D5E3F /* ChromeDividerView.swift */; };
 		3C498141117B2348743A7A3E /* SettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DFC7C439D7D5CB85100DB4D /* SettingsPage.swift */; };
@@ -211,6 +213,7 @@
 		9F3608916964651FE502DAD3 /* ChoiceOptionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E88C517CE4270179492479E /* ChoiceOptionParserTests.swift */; };
 		9F9D60884BFD0AAA1A738DFA /* WorktreeTitleResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70189637B0B7BCD249901040 /* WorktreeTitleResolver.swift */; };
 		9FA0C6130443BF763BA2BE24 /* StopHookResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B1A2AE485F12ED562023B0 /* StopHookResponder.swift */; };
+		9FB87117B233D150F2A05BD0 /* EditLayoutContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25346A39BB85A9E74B496865 /* EditLayoutContainerView.swift */; };
 		A03021337425A92FF6DFBE1B /* OpenCodePluginInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A70D4315E684DAEAFF18A8 /* OpenCodePluginInstaller.swift */; };
 		A0A5267095AB8E2FBAAB8C03 /* ghostty.conf in Resources */ = {isa = PBXBuildFile; fileRef = E4BEF7BAC8EF2918D2F601F7 /* ghostty.conf */; };
 		A2A33CDFDE9F70751E8F5DF0 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E7934A548F91E1E9FB161C /* SmokeTests.swift */; };
@@ -276,7 +279,9 @@
 		C7CB9AA977EF6E8B1C8F1F57 /* ChromeLayoutStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1479F39CD088308B1796C1F /* ChromeLayoutStateTests.swift */; };
 		C94539AC393B4AA9EB7D4BFC /* StatusDetectorActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2691E78106330B779373C2 /* StatusDetectorActivityTests.swift */; };
 		C98FA9225C36EA1C59E1A67E /* OpenCodePluginInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2230C586651F0975429B2DDD /* OpenCodePluginInstallerTests.swift */; };
+		CA43EB5F470FF6E325C0934F /* SelectedFilePathResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32E46B1123B9F111F2E557 /* SelectedFilePathResolutionTests.swift */; };
 		CA52C85A65D3725357E07FDB /* PaneTitleResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6192629F1DE8EF1143009BEE /* PaneTitleResolver.swift */; };
+		CB4F8F747FB190D2107B173E /* FilePreviewWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC642ADEFDCCDFBFD150DC35 /* FilePreviewWindowController.swift */; };
 		CBB8B4ECA774CBFE1EF1A070 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E004E8B96865467209D3F2D /* Theme.swift */; };
 		CDE025440DDC3A5CFE827DB1 /* WeChatConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09FCD7618004CFF5B04BF9A /* WeChatConfig.swift */; };
 		CECDE06AB48C038C87A37076 /* SplitNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D7FF8E6F2D2E5EC4963C627 /* SplitNode.swift */; };
@@ -416,6 +421,7 @@
 		23B112FAA14CF6135A4F7202 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		249CA31487C12997605E1512 /* TaskProgressParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskProgressParserTests.swift; sourceTree = "<group>"; };
 		24BD97D45539400A4E3160E2 /* FirstMateConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateConfig.swift; sourceTree = "<group>"; };
+		25346A39BB85A9E74B496865 /* EditLayoutContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLayoutContainerView.swift; sourceTree = "<group>"; };
 		258A1C3E5F11466A79C1CAF3 /* ClaudeUsageSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeUsageSummaryProvider.swift; sourceTree = "<group>"; };
 		26EFCABEFB8EEA92A8B6FA13 /* ClaudeStatuslineBridgeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeStatuslineBridgeInstaller.swift; sourceTree = "<group>"; };
 		27293C9549D95350D5CA8E80 /* DiffReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewView.swift; sourceTree = "<group>"; };
@@ -469,6 +475,7 @@
 		4775959C72857610AC1F12DC /* WorktreeStatusAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeStatusAggregator.swift; sourceTree = "<group>"; };
 		47B0201979B7976AC0A77D56 /* ActivityEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityEvent.swift; sourceTree = "<group>"; };
 		47F339357674536CA6736266 /* GlobalKeymapTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalKeymapTests.swift; sourceTree = "<group>"; };
+		4808E81C577D8BF32131B574 /* PreviewSetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSetController.swift; sourceTree = "<group>"; };
 		4890F1362CCDACF15E685662 /* ChromeLayoutMetricsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeLayoutMetricsTests.swift; sourceTree = "<group>"; };
 		49437644810F143C24E9273B /* PaneTitleResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTitleResolverTests.swift; sourceTree = "<group>"; };
 		49AB93A5F8C2A6D49CA1AA79 /* UpdateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCoordinator.swift; sourceTree = "<group>"; };
@@ -510,6 +517,7 @@
 		63C8FE4C75F1A4EF074C03C2 /* PaneStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneStatusTests.swift; sourceTree = "<group>"; };
 		63F011748A6A508BC66F267E /* WorktreeSidePanelViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSidePanelViewControllerTests.swift; sourceTree = "<group>"; };
 		63F65EEAACEE71D08FEF9313 /* MainWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowController.swift; sourceTree = "<group>"; };
+		641B13C5C51C4D5B012443A6 /* EditTabStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTabStripView.swift; sourceTree = "<group>"; };
 		64961AFD1B97D23C0490E083 /* StatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarView.swift; sourceTree = "<group>"; };
 		669FC11510A48A9E8656C26A /* JetBrainsMono-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Bold.ttf"; sourceTree = "<group>"; };
 		66D1A230FCEF8663316AD13F /* WebhookStatusProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookStatusProviderTests.swift; sourceTree = "<group>"; };
@@ -605,6 +613,7 @@
 		AA151402CD4A6E95C947C0AB /* ExternalChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalChannel.swift; sourceTree = "<group>"; };
 		AA3A8892B1DC42E27FCD2A98 /* CodexUsageSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageSummaryProvider.swift; sourceTree = "<group>"; };
 		AB8C0AA934FBBE1D3F9E6831 /* AgentManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentManifest.swift; sourceTree = "<group>"; };
+		AC642ADEFDCCDFBFD150DC35 /* FilePreviewWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewWindowController.swift; sourceTree = "<group>"; };
 		ADC1F3A1FF1F0CC45B8BD0A8 /* NormalizedEventDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventDecoderTests.swift; sourceTree = "<group>"; };
 		AE1079E906A5CC63135C2DD5 /* MenuRowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuRowButton.swift; sourceTree = "<group>"; };
 		B02AE5789115FC73A4CF4BF2 /* CursorHooksSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorHooksSetup.swift; sourceTree = "<group>"; };
@@ -717,6 +726,7 @@
 		FBFDE609B6678D11A208461F /* SessionTitleLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTitleLookup.swift; sourceTree = "<group>"; };
 		FC0B811C8897D41F6EA6B4FE /* KeyboardModeControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardModeControllerTests.swift; sourceTree = "<group>"; };
 		FC981A1D0F39B20BE16B2F93 /* OnboardingPermissionsStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPermissionsStepView.swift; sourceTree = "<group>"; };
+		FE32E46B1123B9F111F2E557 /* SelectedFilePathResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedFilePathResolutionTests.swift; sourceTree = "<group>"; };
 		FEC6CEDF0BAE28FF326D89F9 /* SidebarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderView.swift; sourceTree = "<group>"; };
 		FFC7E1231F33AA739B410611 /* ChoiceOptionParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoiceOptionParser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -949,6 +959,7 @@
 				D43DCAEEFB34DDC4D03467C3 /* CodeEditorView.swift */,
 				3A09155A1FFCC67267E9F246 /* EditorTheme+Seahelm.swift */,
 				DCC4A1C262ABBDCDACB560CD /* FileContentView.swift */,
+				AC642ADEFDCCDFBFD150DC35 /* FilePreviewWindowController.swift */,
 				A657EAE120C252D650A7961B /* FileTreeOutlineController.swift */,
 				E0CD4486C05DC41B6EBC51CC /* MarkdownPreviewView.swift */,
 				DAFE8F526F75CD13158309C6 /* MediaPreviewView.swift */,
@@ -1139,6 +1150,7 @@
 				90BFD1E80754F390DB43E63A /* SeahelmHookInstallerTests.swift */,
 				BBA707703AD383C078C3DFC3 /* SeahelmSkillInstallerTests.swift */,
 				03C5A891709AE9B5E02D084E /* SeahelmSuggestInstallerTests.swift */,
+				FE32E46B1123B9F111F2E557 /* SelectedFilePathResolutionTests.swift */,
 				DA54BB7C78ECA381712451D9 /* SessionLaunchCommandTests.swift */,
 				C197F88AECB09C7C3D4449DE /* SessionManagerTests.swift */,
 				BFFAE60D0EF11A5DC22B2B73 /* SessionRestoreConfigTests.swift */,
@@ -1205,9 +1217,12 @@
 				D7C9832D9B06996A7156C57D /* ActivityFeedRenderer.swift */,
 				D241FA217901216F43E4BDBE /* DashboardFocusController.swift */,
 				BCEC0119082025691BCED456 /* DashboardViewController.swift */,
+				25346A39BB85A9E74B496865 /* EditLayoutContainerView.swift */,
+				641B13C5C51C4D5B012443A6 /* EditTabStripView.swift */,
 				3D002748AEBEA4297919DC48 /* FocusPanelView.swift */,
 				1320CBDF38D301E85655F40B /* InlineWorktreeCreateView.swift */,
 				78D1BBB07A2822E90114369F /* OverviewFocusModel.swift */,
+				4808E81C577D8BF32131B574 /* PreviewSetController.swift */,
 				3B2A81A9280FBAAA13232BAF /* RepoColor.swift */,
 				20B4DF69385BC294488EF109 /* WorktreeGrouping.swift */,
 			);
@@ -1589,6 +1604,7 @@
 				92E9F0AABB7C9DCD16D9445F /* SeahelmHookInstallerTests.swift in Sources */,
 				D498FA22D507E98139DE451B /* SeahelmSkillInstallerTests.swift in Sources */,
 				9ACCE5E25F983F07EEE326A7 /* SeahelmSuggestInstallerTests.swift in Sources */,
+				CA43EB5F470FF6E325C0934F /* SelectedFilePathResolutionTests.swift in Sources */,
 				88FC5A9FA39ABA172ED4FAD7 /* SessionLaunchCommandTests.swift in Sources */,
 				6C1B1F431CA9B09EF8806D11 /* SessionManagerTests.swift in Sources */,
 				0F486115B10D4353770B261C /* SessionRestoreConfigTests.swift in Sources */,
@@ -1721,10 +1737,13 @@
 				62E1DFF3457248FF5F30594F /* DiffReviewView.swift in Sources */,
 				FD31D39DD1C179392C0993F6 /* DiffSyntaxHighlighter.swift in Sources */,
 				EF25AD093968ED3CBC4A960B /* DividerView.swift in Sources */,
+				9FB87117B233D150F2A05BD0 /* EditLayoutContainerView.swift in Sources */,
+				2E74EEEB640ABA51B1CBBC01 /* EditTabStripView.swift in Sources */,
 				6F46B38545D8EA067171AF5B /* EditorTheme+Seahelm.swift in Sources */,
 				506F03CBC8DB229C2F20E98F /* EventHub.swift in Sources */,
 				9B78DBBAF5994540D7C95C0B /* ExternalChannel.swift in Sources */,
 				D561B55100D9032AC7C173E5 /* FileContentView.swift in Sources */,
+				CB4F8F747FB190D2107B173E /* FilePreviewWindowController.swift in Sources */,
 				C3E90FF67663F4290485E940 /* FileSystemProbe.swift in Sources */,
 				E5020C3F03A4093F06D0F2E4 /* FileTreeOutlineController.swift in Sources */,
 				FED31A3C39D21CA95E4FE06D /* FirstMate.swift in Sources */,
@@ -1783,6 +1802,7 @@
 				9C55DE7AD6C3DCE23F18B842 /* PendingOrdersQueue.swift in Sources */,
 				DA2A0458E60D38BD6F7C9649 /* PendingWorktreeTransfer.swift in Sources */,
 				9A03CF75CF0BCBBD3E4778FA /* PersistedStringMap.swift in Sources */,
+				3B6E064F838BAF33075485C8 /* PreviewSetController.swift in Sources */,
 				DEDCDC483983AFA6EE444A63 /* ProcessProbe.swift in Sources */,
 				07D61705F36F11CF9B8CF316 /* ProcessRunner.swift in Sources */,
 				9E70B1DBD63DBC4873DC38EB /* QuickSwitcherViewController.swift in Sources */,


### PR DESCRIPTION
## What

Adds an **edit mode** for the terminal content area, toggled by a top-right chrome icon.

- **Focus mode (unchanged):** panes tiled, files open fullscreen.
- **Edit mode:** the area splits into two columns —
  - **LEFT:** terminal panes flattened into a tab strip, one shown at a time via `SplitContainerView`'s existing `zoomedLeafId` (the `SplitTree` is never mutated; toggling back restores the spatial split verbatim).
  - **RIGHT:** open file previews as tabs.

A per-worktree **preview set**, decoupled from display mode, backs both: clicking a file records it and either opens fullscreen (focus) or as a right-column tab (edit). Right-column previews reuse `CenterOverlayView`, so Close/Save/Preview toolbar, Cmd+S and Esc match focus mode exactly. Empty preview set auto-degrades to focus and dims the toggle; in edit mode Cmd+Opt+arrows cycle tabs instead of moving spatial focus.

## New files
- `PreviewSetController` — in-memory, per-worktree preview set + edit flag + split ratio
- `EditLayoutContainerView` — two-column shell with draggable divider
- `EditTabStripView` — reusable diffing tab strip (left + right columns)

## Notes
- Preview set is in-memory (session-scoped) — avoids resurrecting stale/deleted files on relaunch.
- Terminal split/resize/focus machinery is untouched; edit mode splits above the `SplitTree` layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)