### PR TITLE
fix: detect Cursor Agent CLI working state as running

### DIFF
--- a/Resources/Manifests/agent.json
+++ b/Resources/Manifests/agent.json
@@ -1,13 +1,14 @@
 {
   "id": "agent",
-  "version": "2026.07.08.1",
+  "version": "2026.07.22.1",
   "min_engine_version": 1,
   "aliases": [],
   "default_status": "idle",
   "message_skip_patterns": [
     "shift+tab",
     "accept edits",
-    "to interrupt"
+    "to interrupt",
+    "ctrl+c to stop"
   ],
   "authority": "screen_only",
   "rules": [
@@ -26,8 +27,51 @@
       "state": "running",
       "priority": 400,
       "region": "bottom_lines:10",
-      "contains": [
-        "to interrupt"
+      "any": [
+        {
+          "contains": [
+            "ctrl+c to stop"
+          ]
+        },
+        {
+          "contains": [
+            "to interrupt"
+          ]
+        },
+        {
+          "contains": [
+            "esc to abort"
+          ]
+        }
+      ],
+      "visible_working": true
+    },
+    {
+      "id": "working_status_line",
+      "state": "running",
+      "priority": 390,
+      "region": "bottom_lines:12",
+      "any": [
+        {
+          "line_regex": [
+            "(?i)^\\s*working…?\\s*$"
+          ]
+        },
+        {
+          "line_regex": [
+            "(?i)^\\s*thinking\\s*$"
+          ]
+        },
+        {
+          "line_regex": [
+            "(?i)^\\s*generating\\b"
+          ]
+        },
+        {
+          "line_regex": [
+            "(?i)\\d+(\\.\\d+)?k tokens"
+          ]
+        }
       ],
       "visible_working": true
     },

--- a/Resources/Manifests/cursor.json
+++ b/Resources/Manifests/cursor.json
@@ -1,16 +1,18 @@
 {
   "id": "cursor",
-  "version": "2026.07.08.1",
+  "version": "2026.07.22.1",
   "min_engine_version": 1,
   "aliases": [],
   "default_status": "idle",
   "message_skip_patterns": [
     "shift+tab",
     "accept edits",
-    "to interrupt"
+    "to interrupt",
+    "ctrl+c to stop"
   ],
   "process": {
     "exec_names": [
+      "agent",
       "cursor-agent",
       "cursor"
     ],
@@ -40,6 +42,11 @@
       "any": [
         {
           "contains": [
+            "ctrl+c to stop"
+          ]
+        },
+        {
+          "contains": [
             "to interrupt"
           ]
         },
@@ -51,6 +58,40 @@
         {
           "contains": [
             "esc to interrupt"
+          ]
+        },
+        {
+          "contains": [
+            "esc to abort"
+          ]
+        }
+      ],
+      "visible_working": true
+    },
+    {
+      "id": "working_status_line",
+      "state": "running",
+      "priority": 390,
+      "region": "bottom_lines:12",
+      "any": [
+        {
+          "line_regex": [
+            "(?i)^\\s*working…?\\s*$"
+          ]
+        },
+        {
+          "line_regex": [
+            "(?i)^\\s*thinking\\s*$"
+          ]
+        },
+        {
+          "line_regex": [
+            "(?i)^\\s*generating\\b"
+          ]
+        },
+        {
+          "line_regex": [
+            "(?i)\\d+(\\.\\d+)?k tokens"
           ]
         }
       ],

--- a/Sources/Core/Config.swift
+++ b/Sources/Core/Config.swift
@@ -280,10 +280,14 @@ struct SailorDetectConfig: Codable {
             SailorRule(status: "Error", patterns: ["error:"]),
         ], defaultStatus: "Idle", messageSkipPatterns: ["tip", "shortcuts", "switch layout"]),
         SailorDef(name: "agent", rules: [
-            SailorRule(status: "Running", patterns: ["to interrupt"]),
+            SailorRule(status: "Running", patterns: [
+                "ctrl+c to stop", "to interrupt", "esc to abort",
+            ]),
             SailorRule(status: "Error", patterns: ["error"]),
             SailorRule(status: "Waiting", patterns: ["?", "> "]),
-        ], defaultStatus: "Idle", messageSkipPatterns: ["shift+tab", "accept edits", "to interrupt"]),
+        ], defaultStatus: "Idle", messageSkipPatterns: [
+            "shift+tab", "accept edits", "to interrupt", "ctrl+c to stop",
+        ]),
     ])
 
     func includingMissingDefaultSailors() -> SailorDetectConfig {

--- a/Tests/ManifestEngineTests.swift
+++ b/Tests/ManifestEngineTests.swift
@@ -104,6 +104,53 @@ final class ManifestEngineTests: XCTestCase {
         }
     }
 
+    /// Regression: Cursor Agent CLI (entrypoint `agent`) no longer prints
+    /// "to interrupt". Live panes show "ctrl+c to stop" plus a status line
+    /// ("Working" / "Grepping  83.03k tokens"). Without these rules the sidebar
+    /// stuck on idle/unknown while the process was clearly busy.
+    func testCursorAgentCLIWorkingSignalsDetectAsRunning() {
+        guard let cm = ManifestStore.shared.manifest(for: "cursor") else {
+            return XCTFail("missing cursor manifest")
+        }
+        // Captured from live zmx history (lowercased as StatusPublisher does).
+        let workingScreens = [
+            """
+            ✶ grepping  83.03k tokens
+                tip: use /mcp to connect cursor to your tools and data sources.
+              ❯ add a follow-up                                     ctrl+c to stop
+              auto · 62.1% · 8 files edited                         run everything
+            """,
+            """
+            ✶ working
+              ❯ add a follow-up                                     ctrl+c to stop
+              auto · 27% · 5 files edited                           run everything
+            """,
+            """
+            ✶ updating  17.71k tokens
+              ❯ add a follow-up                                     ctrl+c to stop
+            """,
+            // Older CLI builds kept the interrupt hint.
+            "esc to interrupt\n(thinking)",
+        ]
+        for screen in workingScreens {
+            let d = cm.evaluate(DetectionInput(screen: screen.lowercased()))
+            XCTAssertEqual(d.state, .running, "expected running for:\n\(screen)")
+            XCTAssertTrue(d.visibleWorking)
+        }
+
+        // Idle follow-up prompt: no ctrl+c to stop, no token spinner.
+        let idle = """
+            ❯ add a follow-up
+            auto · 17.5%                                          run everything
+            """
+        XCTAssertEqual(cm.evaluate(DetectionInput(screen: idle.lowercased())).state, .unknown,
+                       "idle follow-up must not match running rules")
+        // Todo list prose must not trip the Working status-line rule.
+        let todoProse = "to-do working on 1 to-do · 1 done\n❯ add a follow-up"
+        XCTAssertEqual(cm.evaluate(DetectionInput(screen: todoProse.lowercased())).state, .unknown,
+                       "todo 'Working on' must not match bare Working status line")
+    }
+
     func testHighestPriorityWins() throws {
         // Two rules match; the higher-priority (waiting) must win over running.
         let cm = try manifest("""

--- a/Tests/ProcessProbeTests.swift
+++ b/Tests/ProcessProbeTests.swift
@@ -72,6 +72,22 @@ final class ProcessProbeTests: XCTestCase {
         XCTAssertEqual(ProcessProbe.identify(procs: procs, manifests: ms), "opencode")
     }
 
+    /// Cursor's primary CLI entrypoint is now `agent` (cursor-agent remains an
+    /// alias). argv0 is `/…/bin/agent`; the install path still contains
+    /// `cursor-agent`, so either exec_names or argv_contains must identify it.
+    func testIdentifyCursorAgentCLIEntrypoint() {
+        let ms = ManifestStore.shared.all.map(\.manifest)
+        let viaAgent = [p(7, 1, [
+            "/Users/me/.local/bin/agent",
+            "--use-system-ca",
+            "/Users/me/.local/share/cursor-agent/versions/2026.07.17/index.js",
+        ])]
+        XCTAssertEqual(ProcessProbe.identify(procs: viaAgent, manifests: ms), "cursor")
+
+        let viaAlias = [p(8, 1, ["/Users/me/.local/bin/cursor-agent"])]
+        XCTAssertEqual(ProcessProbe.identify(procs: viaAlias, manifests: ms), "cursor")
+    }
+
     func testDescendantsWalk() {
         let all = [p(2, 1, ["zsh"]), p(3, 2, ["node"]), p(4, 3, ["codex"]), p(5, 1, ["unrelated"])]
         let d = ProcessProbe.descendants(of: 2, in: all).map(\.pid).sorted()


### PR DESCRIPTION
## Summary
- Cursor Agent CLI no longer prints `to interrupt`; live panes show `ctrl+c to stop` plus `Working` / `NNk tokens` status lines, so `screen_only` detection fell through to idle/unknown in the sidebar.
- Update `cursor` and `agent` manifests (and legacy SailorDef defaults) to match those signals; add `agent` to Cursor `exec_names`.
- Add regression tests from captured zmx history and process-probe coverage for the `agent` entrypoint.

## Test plan
- [ ] Run `agent` in a seahelm pane and confirm the sidebar status flips to running while busy (`ctrl+c to stop` visible).
- [ ] Confirm idle follow-up prompt (no `ctrl+c to stop`) stays idle/unknown, not running.
- [ ] Confirm todo prose like `Working on 1 to-do` does not mark the pane running.
- [ ] `xcodebuild … test -only-testing:seahelmTests/ManifestEngineTests/testCursorAgentCLIWorkingSignalsDetectAsRunning`
- [ ] `xcodebuild … test -only-testing:seahelmTests/ProcessProbeTests/testIdentifyCursorAgentCLIEntrypoint`


Made with [Cursor](https://cursor.com)