### PR TITLE
fix: HTML preview loads relative CSS via seahelm-local

### DIFF
--- a/Sources/UI/SidePanel/MarkdownPreviewView.swift
+++ b/Sources/UI/SidePanel/MarkdownPreviewView.swift
@@ -73,8 +73,14 @@ final class PreviewWebView: NSView {
         }
     }
 
-    /// Render a raw HTML document as-is. `baseURL` (the file's directory) lets
-    /// relative resources and links resolve.
+    /// Render a raw HTML document as-is. `baseURL` is the file's directory.
+    ///
+    /// WKWebView refuses `file://` subresources (CSS/JS/images) for pages loaded
+    /// via `loadHTMLString`, even when `baseURL` is a file URL — the same
+    /// restriction that forced markdown images onto `seahelm-local://`. Point
+    /// the document base at that custom scheme so relative `href`/`src` (and
+    /// relative `url(...)` inside those CSS files) resolve through
+    /// `LocalResourceSchemeHandler`.
     func renderHTML(_ html: String, baseURL: URL?) {
         var hasher = Hasher()
         hasher.combine(html)
@@ -82,7 +88,18 @@ final class PreviewWebView: NSView {
         let key = hasher.finalize()
         guard key != lastRenderKey else { return }
         lastRenderKey = key
-        webView.loadHTMLString(html, baseURL: baseURL)
+        resourceHandler.rootDirectory = baseURL
+        let schemeBase = baseURL.flatMap { Self.localResourceBaseURL(forDirectory: $0) }
+        webView.loadHTMLString(html, baseURL: schemeBase)
+    }
+
+    /// `seahelm-local://local/<abs-dir>/` — trailing slash so RFC 3986 relative
+    /// resolution keeps the last path segment as a directory.
+    static func localResourceBaseURL(forDirectory directory: URL) -> URL? {
+        let path = directory.standardizedFileURL.path
+        let encoded = path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        let withSlash = encoded.hasSuffix("/") ? encoded : encoded + "/"
+        return URL(string: "\(localScheme)://local\(withSlash)")
     }
 
     private static func page(body: String, dark: Bool) -> String {

--- a/Tests/HTMLPreviewResourceTests.swift
+++ b/Tests/HTMLPreviewResourceTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import seahelm
+
+final class HTMLPreviewResourceTests: XCTestCase {
+
+    func testLocalResourceBaseURLUsesCustomSchemeAndTrailingSlash() {
+        let dir = URL(fileURLWithPath: "/tmp/site/docs")
+        let base = PreviewWebView.localResourceBaseURL(forDirectory: dir)
+        XCTAssertEqual(base?.absoluteString, "\(PreviewWebView.localScheme)://local/tmp/site/docs/")
+    }
+
+    func testLocalResourceBaseURLAddsSlashWhenDirectoryHasNone() {
+        let dir = URL(fileURLWithPath: "/tmp/site")
+        let base = PreviewWebView.localResourceBaseURL(forDirectory: dir)!
+        XCTAssertTrue(base.absoluteString.hasSuffix("/"), base.absoluteString)
+    }
+
+    func testRelativeStylesheetResolvesUnderDocumentDirectory() {
+        let dir = URL(fileURLWithPath: "/tmp/site")
+        let base = PreviewWebView.localResourceBaseURL(forDirectory: dir)!
+        let css = URL(string: "css/app.css", relativeTo: base)!.absoluteURL
+        XCTAssertEqual(css.absoluteString, "\(PreviewWebView.localScheme)://local/tmp/site/css/app.css")
+    }
+
+    func testNestedRelativePathDoesNotEscapeWithoutTrailingSlashBug() {
+        // Without a trailing slash on the base, RFC 3986 would resolve
+        // "style.css" against "/tmp/site" as "/tmp/style.css".
+        let dir = URL(fileURLWithPath: "/tmp/site")
+        let base = PreviewWebView.localResourceBaseURL(forDirectory: dir)!
+        let css = URL(string: "style.css", relativeTo: base)!.absoluteURL
+        XCTAssertEqual(css.path, "/tmp/site/style.css", css.absoluteString)
+    }
+}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		9E6B89CACF0F49A0029E3BD1 /* GitDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = B032E95F9035447EBF27883B /* GitDiff.swift */; };
 		9E70B1DBD63DBC4873DC38EB /* QuickSwitcherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA513259B19E55E2FB46C9F /* QuickSwitcherViewController.swift */; };
 		9F3608916964651FE502DAD3 /* ChoiceOptionParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E88C517CE4270179492479E /* ChoiceOptionParserTests.swift */; };
+		9F5D2E6010FDB991FA2F0B32 /* HTMLPreviewResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF22C41D6F582FFD30D8BD2D /* HTMLPreviewResourceTests.swift */; };
 		9FA0C6130443BF763BA2BE24 /* StopHookResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B1A2AE485F12ED562023B0 /* StopHookResponder.swift */; };
 		9FB87117B233D150F2A05BD0 /* EditLayoutContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25346A39BB85A9E74B496865 /* EditLayoutContainerView.swift */; };
 		A03021337425A92FF6DFBE1B /* OpenCodePluginInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0A70D4315E684DAEAFF18A8 /* OpenCodePluginInstaller.swift */; };
@@ -735,6 +736,7 @@
 		ECBEC0B8D9CEC4A93075C660 /* OpenedSurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenedSurfaceView.swift; sourceTree = "<group>"; };
 		ED032A4F5701E6B65774EBAB /* ClaudeUsageSummaryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeUsageSummaryProviderTests.swift; sourceTree = "<group>"; };
 		ED6A0AE5886DB08F5B0D024C /* StatusDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDetector.swift; sourceTree = "<group>"; };
+		EF22C41D6F582FFD30D8BD2D /* HTMLPreviewResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLPreviewResourceTests.swift; sourceTree = "<group>"; };
 		EF3E143D632D86B7DBBC840E /* PersistedStringMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedStringMap.swift; sourceTree = "<group>"; };
 		EF9EEEBC6FB86CD29B2B3D45 /* FirstMate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMate.swift; sourceTree = "<group>"; };
 		F0479C060435CDD5ED956DFE /* WorktreeCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCreator.swift; sourceTree = "<group>"; };
@@ -1171,6 +1173,7 @@
 				1AB9B880E783FE26BA01DA38 /* GatewayStateTests.swift */,
 				47F339357674536CA6736266 /* GlobalKeymapTests.swift */,
 				EB82719AC58E2E0289564007 /* HookDecoderTests.swift */,
+				EF22C41D6F582FFD30D8BD2D /* HTMLPreviewResourceTests.swift */,
 				7CFF2129E5D3A2E51C49F22C /* IdeaStoreTests.swift */,
 				63049780738A9E97C8BCB55B /* InlineCabinCreateViewTests.swift */,
 				FC0B811C8897D41F6EA6B4FE /* KeyboardModeControllerTests.swift */,
@@ -1631,6 +1634,7 @@
 				2CE3679CE395A49CDD452CEB /* FuzzyMatchTests.swift in Sources */,
 				A831B5F796896B48509F1F91 /* GatewayStateTests.swift in Sources */,
 				91AE9A595CB36E54847C8274 /* GlobalKeymapTests.swift in Sources */,
+				9F5D2E6010FDB991FA2F0B32 /* HTMLPreviewResourceTests.swift in Sources */,
 				6D66FA7BE6A91F8748F3F780 /* HookDecoderTests.swift in Sources */,
 				19A26EE54A5CE77EB9A5A51B /* IdeaStoreTests.swift in Sources */,
 				AC2875297F590321111FDFEA /* InlineCabinCreateViewTests.swift in Sources */,


### PR DESCRIPTION
## Summary
- WKWebView blocks `file://` subresources for `loadHTMLString` pages, so HTML preview never loaded relative CSS/JS/images.
- Point the document `baseURL` at the existing `seahelm-local://` scheme (same path markdown images already use) so relative stylesheets resolve.

## Test plan
- [ ] Open an HTML file with `<link rel="stylesheet" href="…">` in the same folder tree and toggle preview — styles apply
- [ ] Relative images/scripts in that HTML still load
- [ ] Markdown preview images still work
- [ ] `HTMLPreviewResourceTests` pass


Made with [Cursor](https://cursor.com)