### PR TITLE
feat: tap Island suggestion blank area to focus its pane

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -2193,6 +2193,9 @@ extension MainWindowController {
         model.onOptionTapped = { [weak self] order, optionText in
             self?.handleSuggestionTapped(order: order, optionText: optionText)
         }
+        model.onRevealSuggestion = { [weak self] order in
+            self?.revealSuggestionPane(order)
+        }
         model.onDismissOrder = { [weak self] order in
             self?.tabCoordinator.pendingOrders.resolve(id: order.id)
         }
@@ -2215,6 +2218,22 @@ extension MainWindowController {
             self?.refreshIsland()
         }
         refreshIsland()
+    }
+
+    /// Jump to the pane that raised `order` without resolving the suggestion.
+    /// Used when the user taps blank area on an Island suggestion card.
+    private func revealSuggestionPane(_ order: PendingOrder) {
+        let path = order.action.worktreePath
+        tabCoordinator.handleNavigateToWorktree(worktreePath: path, paneIndex: nil)
+        let terminalID = order.action.terminalID
+        // Embed/layout of the split container is deferred; focus after it lands.
+        if !terminalID.isEmpty {
+            DispatchQueue.main.async { [weak self] in
+                _ = self?.terminalCoordinator.focusPane(targetStationId: terminalID)
+            }
+        }
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
     }
 
     /// Surface new suggestions in the First Mate sidebar while Seahelm is frontmost.

--- a/Sources/UI/Island/IslandModel.swift
+++ b/Sources/UI/Island/IslandModel.swift
@@ -64,6 +64,8 @@ final class IslandModel {
     // Wired by MainWindowController.
     var onNavigate: ((_ worktreePath: String, _ paneIndex: Int?) -> Void)?
     var onOptionTapped: ((_ order: PendingOrder, _ optionText: String) -> Void)?
+    /// Jump to the pane that raised a suggestion without resolving the card.
+    var onRevealSuggestion: ((_ order: PendingOrder) -> Void)?
     /// Dismiss a suggestion card without acting on it.
     var onDismissOrder: ((_ order: PendingOrder) -> Void)?
     /// Bridge command submit (same handler as the First Mate composer).

--- a/Sources/UI/Island/OpenedSurfaceView.swift
+++ b/Sources/UI/Island/OpenedSurfaceView.swift
@@ -51,7 +51,11 @@ struct OpenedSurfaceView: View {
                                        onOption: { optionText in
                                            model.onOptionTapped?(order, optionText)
                                        },
-                                       onDismiss: { model.onDismissOrder?(order) })
+                                       onDismiss: { model.onDismissOrder?(order) },
+                                       onReveal: {
+                                           model.onRevealSuggestion?(order)
+                                           model.close()
+                                       })
                         .transition(.opacity.combined(with: .move(edge: .top)))
                     }
                 } else {
@@ -325,6 +329,8 @@ private struct SuggestionCard: View {
     let order: PendingOrder
     let onOption: (String) -> Void
     let onDismiss: () -> Void
+    /// Blank-area tap: jump to the raising pane without resolving the card.
+    let onReveal: () -> Void
 
     private var isQuestion: Bool {
         FirstMateAction.isQuestionPayload(order.action.payload)
@@ -361,6 +367,7 @@ private struct SuggestionCard: View {
                     .lineLimit(4)
                     .fixedSize(horizontal: false, vertical: true)
             }
+            // Options keep their own taps so they don't bubble to onReveal.
             OptionList(options: order.action.options ?? [], onTap: onOption)
         }
         .padding(12)
@@ -372,6 +379,8 @@ private struct SuggestionCard: View {
                         .stroke(IslandStyle.accent.opacity(0.3), lineWidth: 1)
                 )
         )
+        .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .onTapGesture { onReveal() }
     }
 }
 


### PR DESCRIPTION
## Summary
- Clicking blank area on an Island suggestion card (not option chips / dismiss) navigates to the raising worktree and focuses that pane
- Closes the Island without resolving the suggestion so it remains in First Mate

## Test plan
- [ ] Trigger an Island suggestion while Seahelm is in background
- [ ] Click card blank area → main window focuses the correct pane; suggestion still pending
- [ ] Click option chip / × still behave as before


Made with [Cursor](https://cursor.com)