### PR TITLE
fix: speed up Files sidebar search without stalling worktree switches

### DIFF
--- a/Sources/UI/SidePanel/CabinSidePanelViewController.swift
+++ b/Sources/UI/SidePanel/CabinSidePanelViewController.swift
@@ -244,8 +244,11 @@ final class CabinSidePanelViewController: NSViewController {
     }
 
     /// Remember the current worktree's folder expansion before tearing the tree down.
+    /// Skip while filtering — search expands many rows that must not pollute the
+    /// per-worktree expansion memory (or stall worktree switches scanning them).
     private func captureExpansion() {
         guard let path = worktreePath, let controller = fileTreeController else { return }
+        guard !controller.isFiltering else { return }
         expandedByWorktree[path] = controller.currentExpandedPaths()
     }
 

--- a/Sources/UI/SidePanel/FileTreeOutlineController.swift
+++ b/Sources/UI/SidePanel/FileTreeOutlineController.swift
@@ -76,24 +76,42 @@ final class FileTreeOutlineController: NSObject, NSOutlineViewDataSource, NSOutl
     private var rootPath: String?
     private var rootNodes: [FileTreeNode] = []
 
+    /// Flat path table for search. Built off the main thread; nil until ready.
+    private var pathIndex: [WorktreePathEntry] = []
+    private var pathIndexGeneration = 0
+    private let indexQueue = DispatchQueue(label: "seahelm.filetree.index", qos: .userInitiated)
+
     /// Watches the worktree subtree so external file changes (agents writing
     /// files, Finder edits, git) refresh the tree without a manual reload.
     private var watcher: DirectoryWatcher?
     /// Debounces bursts of FSEvents into a single main-thread refresh.
     private var pendingRefresh: DispatchWorkItem?
+    /// Debounces filter keystrokes before applying an in-memory match.
+    private var pendingFilter: DispatchWorkItem?
+    private var filterGeneration = 0
+    private static let filterDebounce: TimeInterval = 0.15
 
     /// When true, dotfiles are listed. Toggled from the side panel / context menu.
     var showHidden: Bool = false {
-        didSet { guard showHidden != oldValue else { return }; reload() }
+        didSet {
+            guard showHidden != oldValue else { return }
+            rebuildPathIndex()
+            reload()
+        }
     }
 
-    /// Case-insensitive name filter. Empty shows the full tree.
+    /// Case-insensitive name filter. Empty shows the full (lazy) tree.
     var filterText: String = "" {
         didSet {
             let trimmed = filterText.trimmingCharacters(in: .whitespaces)
             guard trimmed != oldValue.trimmingCharacters(in: .whitespaces) else { return }
-            reload()
+            scheduleFilterApply()
         }
+    }
+
+    /// True while a non-empty filter is active (including debounce wait).
+    var isFiltering: Bool {
+        !filterText.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     init(rootPath: String) {
@@ -126,8 +144,87 @@ final class FileTreeOutlineController: NSObject, NSOutlineViewDataSource, NSOutl
 
     func setRoot(_ path: String?) {
         rootPath = path
+        pendingFilter?.cancel()
+        pendingFilter = nil
+        rebuildPathIndex()
         reload()
         startWatching(path)
+    }
+
+    private func scheduleFilterApply() {
+        pendingFilter?.cancel()
+        filterGeneration += 1
+        let generation = filterGeneration
+        let work = DispatchWorkItem { [weak self] in
+            self?.startFilterCompute(generation: generation)
+        }
+        pendingFilter = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.filterDebounce, execute: work)
+    }
+
+    private func rebuildPathIndex() {
+        pathIndexGeneration += 1
+        let generation = pathIndexGeneration
+        guard let path = rootPath else {
+            pathIndex = []
+            return
+        }
+        let root = URL(fileURLWithPath: path)
+        let showHidden = self.showHidden
+        indexQueue.async { [weak self] in
+            let entries = WorktreePathIndex.enumerate(root: root, showHidden: showHidden)
+            DispatchQueue.main.async {
+                guard let self, self.pathIndexGeneration == generation else { return }
+                self.pathIndex = entries
+                if self.isFiltering {
+                    self.filterGeneration += 1
+                    self.startFilterCompute(generation: self.filterGeneration)
+                }
+            }
+        }
+    }
+
+    /// Match + tree build off the main thread; only swap outline data on main.
+    private func startFilterCompute(generation: Int) {
+        guard let path = rootPath else {
+            rootNodes = []
+            outlineView.reloadData()
+            return
+        }
+        let needle = filterText.trimmingCharacters(in: .whitespaces)
+        if needle.isEmpty {
+            // Back to lazy browse mode — one directory listing of the root.
+            let url = URL(fileURLWithPath: path)
+            rootNodes = FileTreeOutlineController.childNodes(of: url, showHidden: showHidden)
+            outlineView.reloadData()
+            return
+        }
+
+        let entries = pathIndex
+        let root = URL(fileURLWithPath: path)
+        indexQueue.async { [weak self] in
+            let matched = WorktreePathIndex.matching(entries: entries, needle: needle)
+            let tree = WorktreePathIndex.buildFilteredTree(root: root, matched: matched)
+            DispatchQueue.main.async {
+                guard let self, self.filterGeneration == generation else { return }
+                // Needle may have cleared while we were computing.
+                guard self.isFiltering else { return }
+                self.rootNodes = tree
+                self.outlineView.reloadData()
+                // Filtered tree is already capped; one expand-all is cheaper than
+                // hundreds of individual expandItem calls.
+                if !tree.isEmpty {
+                    self.outlineView.expandItem(nil, expandChildren: true)
+                }
+            }
+        }
+    }
+
+    /// Apply the current filter against the in-memory path index (main thread
+    /// entry used by reload/refresh; heavy work still hops to `indexQueue`).
+    private func applyFilterFromIndex() {
+        filterGeneration += 1
+        startFilterCompute(generation: filterGeneration)
     }
 
     // MARK: - Filesystem watching
@@ -160,34 +257,34 @@ final class FileTreeOutlineController: NSObject, NSOutlineViewDataSource, NSOutl
     }
 
     private func refreshFromDisk() {
-        let expanded = currentExpandedPaths()
+        rebuildPathIndex()
+        let expanded = isFiltering ? [] : currentExpandedPaths()
         let selectedPath = (outlineView.item(atRow: outlineView.selectedRow) as? FileTreeNode)?
             .url.standardizedFileURL.path
         for node in rootNodes { node.children = nil }
         reload()
-        restoreExpansion(expanded)
-        if let selectedPath, let node = findNode(for: URL(fileURLWithPath: selectedPath)) {
-            let row = outlineView.row(forItem: node)
-            if row >= 0 { outlineView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false) }
+        if !isFiltering {
+            restoreExpansion(expanded)
+            if let selectedPath, let node = findNode(for: URL(fileURLWithPath: selectedPath)) {
+                let row = outlineView.row(forItem: node)
+                if row >= 0 { outlineView.selectRowIndexes(IndexSet(integer: row), byExtendingSelection: false) }
+            }
         }
     }
 
     private func reload() {
+        if isFiltering {
+            applyFilterFromIndex()
+            return
+        }
         guard let path = rootPath else {
             rootNodes = []
             outlineView.reloadData()
             return
         }
         let url = URL(fileURLWithPath: path)
-        rootNodes = childNodesFiltered(of: url)
+        rootNodes = FileTreeOutlineController.childNodes(of: url, showHidden: showHidden)
         outlineView.reloadData()
-        if isFiltering {
-            outlineView.expandItem(nil, expandChildren: true)
-        }
-    }
-
-    private var isFiltering: Bool {
-        !filterText.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     // MARK: - Expansion state (persisted per worktree)
@@ -222,30 +319,7 @@ final class FileTreeOutlineController: NSObject, NSOutlineViewDataSource, NSOutl
         }
     }
 
-    // MARK: - Listing / filtering
-
-    /// Children of `directory` honouring `showHidden` and the current filter.
-    /// When filtering, directories are kept only if a descendant matches.
-    private func childNodesFiltered(of directory: URL) -> [FileTreeNode] {
-        let all = FileTreeOutlineController.childNodes(of: directory, showHidden: showHidden)
-        let needle = filterText.trimmingCharacters(in: .whitespaces).lowercased()
-        guard !needle.isEmpty else { return all }
-
-        var result: [FileTreeNode] = []
-        for node in all {
-            let nameMatches = node.url.lastPathComponent.lowercased().contains(needle)
-            if node.isDirectory {
-                let kids = childNodesFiltered(of: node.url)
-                if nameMatches || !kids.isEmpty {
-                    node.children = kids
-                    result.append(node)
-                }
-            } else if nameMatches {
-                result.append(node)
-            }
-        }
-        return result
-    }
+    // MARK: - Listing
 
     /// Lists the contents of `directory`, with directories first and each group
     /// sorted alphabetically by lastPathComponent. Dotfiles hidden unless `showHidden`.
@@ -285,7 +359,8 @@ final class FileTreeOutlineController: NSObject, NSOutlineViewDataSource, NSOutl
         }
         guard let node = item as? FileTreeNode, node.isDirectory else { return 0 }
         if node.children == nil {
-            node.children = childNodesFiltered(of: node.url)
+            // Browse mode: lazy disk listing. Filter mode already materialised children.
+            node.children = FileTreeOutlineController.childNodes(of: node.url, showHidden: showHidden)
         }
         return node.children?.count ?? 0
     }
@@ -296,7 +371,7 @@ final class FileTreeOutlineController: NSObject, NSOutlineViewDataSource, NSOutl
         }
         let node = item as! FileTreeNode
         if node.children == nil {
-            node.children = childNodesFiltered(of: node.url)
+            node.children = FileTreeOutlineController.childNodes(of: node.url, showHidden: showHidden)
         }
         return node.children![index]
     }

--- a/Sources/UI/SidePanel/WorktreePathIndex.swift
+++ b/Sources/UI/SidePanel/WorktreePathIndex.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// One path under a worktree root, relative to that root (no leading slash).
+struct WorktreePathEntry: Equatable {
+    let relativePath: String
+    /// Pre-lowercased basename for fast substring matching while typing.
+    let basenameLowercased: String
+    let isDirectory: Bool
+
+    init(relativePath: String, isDirectory: Bool) {
+        self.relativePath = relativePath
+        self.basenameLowercased = (relativePath as NSString).lastPathComponent.lowercased()
+        self.isDirectory = isDirectory
+    }
+
+    init(relativePath: String, basenameLowercased: String, isDirectory: Bool) {
+        self.relativePath = relativePath
+        self.basenameLowercased = basenameLowercased
+        self.isDirectory = isDirectory
+    }
+}
+
+/// Flat path table for Files-tab search. Enumerate once (with prune), filter in
+/// memory, then rebuild a slim ancestor tree for the outline.
+enum WorktreePathIndex {
+    /// Soft cap on match count so short needles (e.g. "a") cannot rebuild a
+    /// multi-thousand-node outline on every keystroke.
+    static let defaultMatchLimit = 250
+
+    /// Directory basenames skipped during enumeration (and always, even when
+    /// showing hidden files).
+    static let prunedDirectoryNames: Set<String> = [
+        ".git", ".build", ".next", ".venv", ".turbo", ".cache",
+        "node_modules", "Pods", "DerivedData", "build", "dist", "target",
+        "__pycache__", "Carthage",
+    ]
+
+    static func shouldPruneDirectory(named name: String) -> Bool {
+        prunedDirectoryNames.contains(name)
+    }
+
+    /// Walk `root` and return every file and directory entry (relative paths),
+    /// honouring `showHidden` and `prunedDirectoryNames`.
+    static func enumerate(root: URL, showHidden: Bool) -> [WorktreePathEntry] {
+        let fm = FileManager.default
+        let rootPath = root.standardizedFileURL.path
+        guard let enumerator = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+            options: [.skipsPackageDescendants]
+        ) else { return [] }
+
+        var entries: [WorktreePathEntry] = []
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+
+        while let item = enumerator.nextObject() as? URL {
+            let name = item.lastPathComponent
+            let values = try? item.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            let isDir = values?.isDirectory ?? false
+            let isSymlink = values?.isSymbolicLink ?? false
+
+            if isDir, shouldPruneDirectory(named: name) {
+                enumerator.skipDescendants()
+                continue
+            }
+            if !showHidden, name.hasPrefix(".") {
+                if isDir { enumerator.skipDescendants() }
+                continue
+            }
+            // Don't follow symlinked directories into arbitrary trees.
+            if isDir, isSymlink {
+                enumerator.skipDescendants()
+                continue
+            }
+
+            let full = item.standardizedFileURL.path
+            guard full.hasPrefix(prefix) else { continue }
+            let relative = String(full.dropFirst(prefix.count))
+            guard !relative.isEmpty else { continue }
+            entries.append(WorktreePathEntry(
+                relativePath: relative,
+                basenameLowercased: name.lowercased(),
+                isDirectory: isDir
+            ))
+        }
+        return entries
+    }
+
+    /// Basename substring match (case-insensitive). Empty / whitespace needle → no hits
+    /// (caller treats that as "not filtering"). Stops after `limit` hits.
+    static func matching(
+        entries: [WorktreePathEntry],
+        needle: String,
+        limit: Int = defaultMatchLimit
+    ) -> [WorktreePathEntry] {
+        let trimmed = needle.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty, limit > 0 else { return [] }
+        var hits: [WorktreePathEntry] = []
+        hits.reserveCapacity(min(limit, entries.count))
+        for entry in entries {
+            if entry.basenameLowercased.contains(trimmed) {
+                hits.append(entry)
+                if hits.count >= limit { break }
+            }
+        }
+        return hits
+    }
+
+    /// Build root-level `FileTreeNode`s whose subtrees contain only `matched` paths
+    /// and the ancestor directories needed to reach them.
+    static func buildFilteredTree(root: URL, matched: [WorktreePathEntry]) -> [FileTreeNode] {
+        guard !matched.isEmpty else { return [] }
+
+        var allPaths = Set<String>()
+        var directoryPaths = Set<String>()
+
+        for entry in matched {
+            allPaths.insert(entry.relativePath)
+            if entry.isDirectory {
+                directoryPaths.insert(entry.relativePath)
+            }
+            // Every proper ancestor is a directory that must appear.
+            var parts = entry.relativePath.split(separator: "/").map(String.init)
+            while parts.count > 1 {
+                parts.removeLast()
+                let parent = parts.joined(separator: "/")
+                allPaths.insert(parent)
+                directoryPaths.insert(parent)
+            }
+        }
+
+        var nodes: [String: FileTreeNode] = [:]
+        nodes.reserveCapacity(allPaths.count)
+        for relative in allPaths {
+            let isDir = directoryPaths.contains(relative)
+            let node = FileTreeNode(
+                url: root.appendingPathComponent(relative),
+                isDirectory: isDir
+            )
+            node.children = isDir ? [] : nil
+            nodes[relative] = node
+        }
+
+        var roots: [FileTreeNode] = []
+        for relative in allPaths {
+            guard let node = nodes[relative] else { continue }
+            if let slash = relative.lastIndex(of: "/") {
+                let parentPath = String(relative[..<slash])
+                guard let parent = nodes[parentPath] else { continue }
+                parent.children?.append(node)
+            } else {
+                roots.append(node)
+            }
+        }
+
+        func sortLevel(_ list: inout [FileTreeNode]?) {
+            guard var kids = list else { return }
+            kids.sort(by: Self.outlineOrder)
+            for kid in kids where kid.isDirectory {
+                sortLevel(&kid.children)
+            }
+            list = kids
+        }
+        for rootNode in roots where rootNode.isDirectory {
+            sortLevel(&rootNode.children)
+        }
+        roots.sort(by: Self.outlineOrder)
+        return roots
+    }
+
+    private static func outlineOrder(_ a: FileTreeNode, _ b: FileTreeNode) -> Bool {
+        if a.isDirectory != b.isDirectory { return a.isDirectory && !b.isDirectory }
+        return a.url.lastPathComponent.localizedStandardCompare(b.url.lastPathComponent) == .orderedAscending
+    }
+}

--- a/Tests/WorktreePathIndexTests.swift
+++ b/Tests/WorktreePathIndexTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import seahelm
+
+final class WorktreePathIndexTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-path-index-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+        root = nil
+    }
+
+    private func touch(_ relative: String, isDirectory: Bool = false) throws {
+        let url = root.appendingPathComponent(relative)
+        if isDirectory {
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        } else {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try Data().write(to: url)
+        }
+    }
+
+    func testPrunesNoiseDirectories() {
+        XCTAssertTrue(WorktreePathIndex.shouldPruneDirectory(named: "node_modules"))
+        XCTAssertTrue(WorktreePathIndex.shouldPruneDirectory(named: "build"))
+        XCTAssertTrue(WorktreePathIndex.shouldPruneDirectory(named: ".git"))
+        XCTAssertTrue(WorktreePathIndex.shouldPruneDirectory(named: ".build"))
+        XCTAssertFalse(WorktreePathIndex.shouldPruneDirectory(named: "Sources"))
+    }
+
+    func testEnumerateSkipsPrunedTreesAndHiddenWhenDisabled() throws {
+        try touch("Sources/App.swift")
+        try touch("node_modules/pkg/index.js")
+        try touch("build/out.o")
+        try touch(".hidden/secret.swift")
+        try touch("Sources/.env")
+
+        let entries = WorktreePathIndex.enumerate(root: root, showHidden: false)
+        let paths = Set(entries.map(\.relativePath))
+
+        XCTAssertTrue(paths.contains("Sources/App.swift"))
+        XCTAssertFalse(paths.contains("node_modules/pkg/index.js"))
+        XCTAssertFalse(paths.contains("build/out.o"))
+        XCTAssertFalse(paths.contains(".hidden/secret.swift"))
+        XCTAssertFalse(paths.contains("Sources/.env"))
+    }
+
+    func testEnumerateIncludesHiddenWhenEnabled() throws {
+        try touch("Sources/.env")
+        try touch(".config/settings.json")
+
+        let entries = WorktreePathIndex.enumerate(root: root, showHidden: true)
+        let paths = Set(entries.map(\.relativePath))
+
+        XCTAssertTrue(paths.contains("Sources/.env"))
+        XCTAssertTrue(paths.contains(".config/settings.json"))
+        // Still prune even when showing hidden.
+        try touch(".git/config")
+        let again = WorktreePathIndex.enumerate(root: root, showHidden: true)
+        XCTAssertFalse(again.map(\.relativePath).contains(".git/config"))
+    }
+
+    func testMatchingKeepsBasenameHitsAndDirectoryNameHits() throws {
+        try touch("Sources/Foo.swift")
+        try touch("Sources/Bar.swift")
+        try touch("Tests/FooTests.swift")
+        try touch("Extras/lib/util.swift")
+
+        let entries = WorktreePathIndex.enumerate(root: root, showHidden: false)
+        let hits = WorktreePathIndex.matching(entries: entries, needle: "foo")
+        let paths = Set(hits.map(\.relativePath))
+
+        XCTAssertEqual(paths, Set(["Sources/Foo.swift", "Tests/FooTests.swift"]))
+    }
+
+    func testMatchingDirectoryNameIncludesTheDirectoryEntry() throws {
+        try touch("Sources/App", isDirectory: true)
+        try touch("Sources/App/Main.swift")
+
+        let entries = WorktreePathIndex.enumerate(root: root, showHidden: false)
+        let hits = WorktreePathIndex.matching(entries: entries, needle: "app")
+        let paths = Set(hits.map(\.relativePath))
+
+        // Basename match only — same as the previous tree filter: a matching
+        // directory appears even when none of its children match the needle.
+        XCTAssertTrue(paths.contains("Sources/App"))
+        XCTAssertFalse(paths.contains("Sources/App/Main.swift"))
+    }
+
+    func testBuildFilteredTreeKeepsAncestorsOnly() throws {
+        let matched = [
+            WorktreePathEntry(relativePath: "Sources/UI/Foo.swift", isDirectory: false),
+            WorktreePathEntry(relativePath: "Sources/Core/Bar.swift", isDirectory: false),
+        ]
+        let roots = WorktreePathIndex.buildFilteredTree(root: root, matched: matched)
+        XCTAssertEqual(roots.count, 1)
+        XCTAssertEqual(roots[0].url.lastPathComponent, "Sources")
+        let kids = try XCTUnwrap(roots[0].children)
+        let names = Set(kids.map { $0.url.lastPathComponent })
+        XCTAssertEqual(names, Set(["UI", "Core"]))
+    }
+
+    func testEmptyNeedleReturnsNoFilterNeeded() {
+        XCTAssertTrue(WorktreePathIndex.matching(entries: [
+            WorktreePathEntry(relativePath: "a.swift", isDirectory: false)
+        ], needle: "   ").isEmpty)
+    }
+
+    func testMatchingRespectsLimit() {
+        let entries = (0..<50).map {
+            WorktreePathEntry(relativePath: "f\($0).swift", isDirectory: false)
+        }
+        let hits = WorktreePathIndex.matching(entries: entries, needle: "f", limit: 10)
+        XCTAssertEqual(hits.count, 10)
+    }
+
+    func testBuildFilteredTreeMarksAncestorsAsDirectories() throws {
+        let matched = [
+            WorktreePathEntry(relativePath: "a/b/c.swift", isDirectory: false),
+        ]
+        let roots = WorktreePathIndex.buildFilteredTree(root: root, matched: matched)
+        XCTAssertEqual(roots.count, 1)
+        XCTAssertTrue(roots[0].isDirectory)
+        let b = try XCTUnwrap(roots[0].children?.first)
+        XCTAssertEqual(b.url.lastPathComponent, "b")
+        XCTAssertTrue(b.isDirectory)
+        let file = try XCTUnwrap(b.children?.first)
+        XCTAssertEqual(file.url.lastPathComponent, "c.swift")
+        XCTAssertFalse(file.isDirectory)
+    }
+}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1F17BE40E11A063D21FD2B1C /* ControlSocketServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536A8D31229E4F3D3D5D4DE8 /* ControlSocketServerTests.swift */; };
 		1F8744F999963A2E2F376171 /* IslandRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543222F7078995AB79534CD4 /* IslandRootView.swift */; };
 		2016934685236AC44DC4F54F /* UpdateDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E8C45661088CE99AA27E805 /* UpdateDriver.swift */; };
+		20E2EBC04F95373F1C01B374 /* WorktreePathIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEA99C114F0948D9400F86C /* WorktreePathIndex.swift */; };
 		214EF21A61FB0B70604BD208 /* OnboardingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DE87C61D1D418F812C8795 /* OnboardingWindowController.swift */; };
 		216DCA58D600EA88B333A324 /* Station.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CAD3E9929AC9E5E32EBA9F /* Station.swift */; };
 		2215E8F6A1F2571870A122F6 /* TabCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2913334B3D03D7CCD3E80D /* TabCoordinatorTests.swift */; };
@@ -176,6 +177,7 @@
 		7F9546C174F5D5E52457F7A8 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7558A8D72AFCE237E39E401 /* MarkdownRendererTests.swift */; };
 		8080334C2591CD6DAEE35749 /* KeyboardSubstateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081CE1B8C53AC598217B30B7 /* KeyboardSubstateController.swift */; };
 		82716362C00AE8D58C2C0C97 /* ChromeHeaderPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4048B5F3E4C7759600A8DD /* ChromeHeaderPage.swift */; };
+		831980CBE1E33D059A978E82 /* WorktreePathIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1E76E23951B9F8DB873E3C /* WorktreePathIndexTests.swift */; };
 		844747226335348450B94EEA /* PtyGridAbsorbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C4FA6FDE7FEC53DDB662BD /* PtyGridAbsorbTests.swift */; };
 		8579DC09CEA0D01A125D5273 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C282D98A9A6117C70B06D3F1 /* NotificationManager.swift */; };
 		859DBEFE2BAE0BA0C975FD3E /* TaskProgressParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EE31EC02520149C8E193C0 /* TaskProgressParser.swift */; };
@@ -558,6 +560,7 @@
 		693DBDBBFD25BEA5D9BE4E26 /* UsageSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageSummary.swift; sourceTree = "<group>"; };
 		69B9E6C47E654692C3AC6D42 /* StatusPublisherThreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPublisherThreadTests.swift; sourceTree = "<group>"; };
 		6A912279D16E32ED9BADB27B /* UsageSummaryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageSummaryStore.swift; sourceTree = "<group>"; };
+		6C1E76E23951B9F8DB873E3C /* WorktreePathIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathIndexTests.swift; sourceTree = "<group>"; };
 		6C827E67B268966037EEDC48 /* AgentSessionRefTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionRefTests.swift; sourceTree = "<group>"; };
 		6D9670C14DA62CDEE9828F5C /* StationRegistryConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationRegistryConcurrencyTests.swift; sourceTree = "<group>"; };
 		6D98DA93A28B692784539710 /* seahelmTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = seahelmTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -672,6 +675,7 @@
 		BB4AD78048C5DC1D7D1D5E3F /* ChromeDividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeDividerView.swift; sourceTree = "<group>"; };
 		BB9854E3679A7AF9524F5077 /* LayoutNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutNode.swift; sourceTree = "<group>"; };
 		BBA707703AD383C078C3DFC3 /* SeahelmSkillInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmSkillInstallerTests.swift; sourceTree = "<group>"; };
+		BBEA99C114F0948D9400F86C /* WorktreePathIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathIndex.swift; sourceTree = "<group>"; };
 		BCEA8A4A0AA60C531F684B87 /* KeyboardHelpOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardHelpOverlay.swift; sourceTree = "<group>"; };
 		BCEC0119082025691BCED456 /* DashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewController.swift; sourceTree = "<group>"; };
 		BD4237377AB298C49CC68D6D /* SuggestOrderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestOrderTests.swift; sourceTree = "<group>"; };
@@ -1023,6 +1027,7 @@
 				A657EAE120C252D650A7961B /* FileTreeOutlineController.swift */,
 				E0CD4486C05DC41B6EBC51CC /* MarkdownPreviewView.swift */,
 				DAFE8F526F75CD13158309C6 /* MediaPreviewView.swift */,
+				BBEA99C114F0948D9400F86C /* WorktreePathIndex.swift */,
 			);
 			path = SidePanel;
 			sourceTree = "<group>";
@@ -1274,6 +1279,7 @@
 				3A85CAE555196AE450DDD90E /* WorktreeCreatorTests.swift */,
 				810968D6A752BC9C5B9C5F27 /* WorktreeDeleterTests.swift */,
 				22DBAC51DE05D73135AD2889 /* WorktreeDiscoveryTests.swift */,
+				6C1E76E23951B9F8DB873E3C /* WorktreePathIndexTests.swift */,
 				03EF8621D5464BAE7F393215 /* WrappedPathAtClickTests.swift */,
 				063BC4CAFB28A7B7DEA60474 /* ZmxLocatorTests.swift */,
 			);
@@ -1740,6 +1746,7 @@
 				303FCEA37D46939EB9451358 /* WorktreeCreatorTests.swift in Sources */,
 				BAC8750B961A40953BC4841F /* WorktreeDeleterTests.swift in Sources */,
 				02D9F0D1B7092AAE247A22A1 /* WorktreeDiscoveryTests.swift in Sources */,
+				831980CBE1E33D059A978E82 /* WorktreePathIndexTests.swift in Sources */,
 				28F64A45113C9031DE991377 /* WrappedPathAtClickTests.swift in Sources */,
 				5F7CEFC99E339F7621D6509A /* ZmxLocatorTests.swift in Sources */,
 			);
@@ -1974,6 +1981,7 @@
 				D27F424356DE8B506B1C7C05 /* WorktreeDeleter.swift in Sources */,
 				56D7FA05EEF91495A4DCED81 /* WorktreeDiscovery.swift in Sources */,
 				3A5FD6063BF092FB51DC280A /* WorktreeGitStats.swift in Sources */,
+				20E2EBC04F95373F1C01B374 /* WorktreePathIndex.swift in Sources */,
 				0E3AA9FF166CC516F1B7264B /* ZmxChannel.swift in Sources */,
 				608A71AD329F3222B8668A1E /* ZmxLocator.swift in Sources */,
 				539E3AA254683CFEB1515713 /* ZmxSessionRecovery.swift in Sources */,


### PR DESCRIPTION
## 改动

Files 侧边栏的搜索之前会在主线程上边走文件系统边过滤，输入时卡顿，还会拖住 First Mate 切 cabin。

- 新增 `WorktreePathIndex`：worktree 下的路径一次性枚举成扁平表，枚举时剪掉 `.git`、`node_modules`、`DerivedData`、`.build`、`Pods` 等目录，basename 预先转小写供输入时子串匹配。
- 匹配数设 250 条软上限 —— 否则输入单个 `a` 这种短 needle，每次按键都要重建几千节点的大纲。
- 过滤挪到主线程之外；搜索期间跳过展开状态捕获，cabin 切换因此不再被拖住。
- 命中后重建一棵只含祖先链的精简树给 outline view。

带 `WorktreePathIndexTests`（9 个用例，覆盖枚举/剪枝/隐藏文件/祖先树重建/空 needle）。

## 说明

原提交 10 小时前推出，已 rebase 到最新 main（落后 5 个提交）。`seahelm.xcodeproj/project.pbxproj` 两边都新增了文件条目，rebase 自动合上了，我用 `xcodegen generate` 重新生成核对过，结果与自动合并完全一致。

构建通过；`WorktreePathIndexTests` + 相邻的 `PaneTitleResolverTests` / `UsageReadoutTests` / `CodexUsageSummaryProviderTests` 共 52 个用例全过。

**未验证**：搜索的实际手感（输入延迟、切 cabin 的响应）需要在真机交互中确认，运行环境无屏幕录制权限。

🤖 Generated with [Claude Code](https://claude.com/claude-code)