### PR TITLE
fix: improve editor and agent status workflows

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -2415,8 +2415,7 @@ extension MainWindowController {
         // Equality-gate every assignment: this runs on a 2s timer, and an
         // ungated @Observable set re-evaluates the SwiftUI island every tick
         // even when nothing changed.
-        let orders = tabCoordinator.pendingOrders.all()
-            .filter { $0.action.kind == .suggestNextOrder }
+        let orders = IslandModel.newestSuggestions(from: tabCoordinator.pendingOrders.all())
         if model.orders != orders { model.orders = orders }
 
         // A new suggestion is actionable — expand so the card is visible

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -107,6 +107,12 @@ class TabCoordinator {
         )
         ShipLog.shared.onOutcome = { [weak self] outcome in
             guard let self else { return }
+            switch outcome.event.source {
+            case .scan:
+                break
+            case .hook, .mcp, .shell:
+                self.statusPublisher.invalidateScanCache(terminalID: outcome.info.id)
+            }
             self.firstMate?.handle(outcome)
             // Feed the worktree aggregator from ShipLog's arbitrated status
             // (scan + hook + OSC), so the dashboard reflects hook/OSC-driven

--- a/Sources/Core/PendingOrdersQueue.swift
+++ b/Sources/Core/PendingOrdersQueue.swift
@@ -52,10 +52,11 @@ final class PendingOrdersQueue {
         let order = PendingOrder(id: id, action: action)
         if let idx = orders.firstIndex(where: { $0.id == id }) {
             guard orders[idx] != order else { return }
-            orders[idx] = order
-        } else {
-            orders.append(order)
+            orders.remove(at: idx)
         }
+        // Preserve arrival order. Replacing a pane's suggestion is a new arrival,
+        // so consumers that show newest-first can move it back to the top.
+        orders.append(order)
         notify()
     }
 

--- a/Sources/Status/StatusPublisher.swift
+++ b/Sources/Status/StatusPublisher.swift
@@ -26,6 +26,9 @@ class StatusPublisher {
     /// (~6s at a 2s interval) rather than every cycle, and stagger panes by an
     /// id-derived offset so they don't all fork on the same tick.
     private let backendCaptureStride: Int = 3
+    /// Even a stable viewport is periodically decoded again. This bounds how
+    /// long a missed cache invalidation can leave ShipLog on a stale scan state.
+    private let unchangedFrameRecheckStride = 15
     private var preferredPaths: Set<String> = []
     private var pollCycle: Int = 0
 
@@ -163,6 +166,15 @@ class StatusPublisher {
         schedulePoll()
     }
 
+    /// Hook/lifecycle events can change ShipLog's arbitration while the terminal
+    /// frame stays unchanged. Force that pane through detection on the next poll
+    /// instead of letting the viewport hash preserve an obsolete scan component.
+    func invalidateScanCache(terminalID: String) {
+        lock.lock()
+        lastViewportHashes.removeValue(forKey: terminalID)
+        lock.unlock()
+    }
+
     private func schedulePoll() {
         // Capture surfaces snapshot under lock, then poll on background
         lock.lock()
@@ -217,9 +229,22 @@ class StatusPublisher {
 
             lock.lock()
             let lastHash = lastViewportHashes[terminalID]
+            let committedScanStatus = trackers[terminalID]?.currentStatus
             lock.unlock()
 
-            if let lastHash, lastHash == contentHash { continue }
+            let publishedScanStatus = ShipLog.shared.sailor(for: terminalID)?.scanStatus
+            let forceRecheck = Self.shouldBackendCapture(
+                pollCycle: pollCycle,
+                offset: Int(truncatingIfNeeded: terminalID.stableHash),
+                stride: unchangedFrameRecheckStride)
+            if Self.shouldSkipUnchangedFrame(
+                lastHash: lastHash,
+                contentHash: contentHash,
+                committedScanStatus: committedScanStatus,
+                publishedScanStatus: publishedScanStatus,
+                forceRecheck: forceRecheck) {
+                continue
+            }
 
             lock.lock()
             lastViewportHashes[terminalID] = contentHash
@@ -419,6 +444,17 @@ class StatusPublisher {
     static func shouldBackendCapture(pollCycle: Int, offset: Int, stride: Int) -> Bool {
         let s = max(1, stride)
         return ((pollCycle &+ offset) % s + s) % s == 0
+    }
+
+    static func shouldSkipUnchangedFrame(
+        lastHash: UInt64?,
+        contentHash: UInt64,
+        committedScanStatus: SailorStatus?,
+        publishedScanStatus: SailorStatus?,
+        forceRecheck: Bool
+    ) -> Bool {
+        guard lastHash == contentHash, !forceRecheck else { return false }
+        return committedScanStatus != nil && committedScanStatus == publishedScanStatus
     }
 
     deinit {

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -479,6 +479,9 @@ class DashboardViewController: NSViewController {
     func selectSailor(byWorktreePath path: String, focusTerminal: Bool = true) {
         guard let agent = agents.first(where: { $0.worktreePath == path }) else { return }
         let changed = agent.id != selectedSailorId
+        if changed {
+            dismissCenterOverlay()
+        }
         selectedSailorId = agent.id
         detachTerminals()
         embedSplitContainerForSelectedSailor(focusTerminal: focusTerminal)
@@ -1295,6 +1298,7 @@ class DashboardViewController: NSViewController {
     /// What the fleet list — and the First Mate panel that renders it — is
     /// currently highlighting, which is not always the selected sailor.
     var overviewSelectedIdForTesting: String { overviewView.selectedId }
+    var hasCenterOverlayForTesting: Bool { centerOverlay != nil }
 
     /// Pane row click in "Group by Sailor": drill into the worktree, then focus
     /// the clicked pane's leaf. The split container may still be settling, so the

--- a/Sources/UI/Island/IslandModel.swift
+++ b/Sources/UI/Island/IslandModel.swift
@@ -54,6 +54,12 @@ final class IslandModel {
     /// and are not mirrored here.
     var orders: [PendingOrder] = []
 
+    static func newestSuggestions(from orders: [PendingOrder]) -> [PendingOrder] {
+        Array(orders.lazy
+            .filter { $0.action.kind == .suggestNextOrder }
+            .reversed())
+    }
+
     /// Screen geometry, set by the panel controller.
     var notchWidth: CGFloat = 190
     var notchHeight: CGFloat = 38

--- a/Sources/UI/SidePanel/CodeEditorView.swift
+++ b/Sources/UI/SidePanel/CodeEditorView.swift
@@ -15,6 +15,7 @@ final class CodeEditorModel: ObservableObject {
 
     let fileURL: URL
     let language: CodeLanguage
+    let scrollCoordinator = CodeEditorScrollCoordinator()
 
     var isDirty: Bool { text != savedText }
 
@@ -51,8 +52,28 @@ private struct CodeEditorSwiftUIView: View {
                     showFoldingRibbon: false
                 )
             ),
-            state: $model.editorState
+            state: $model.editorState,
+            coordinators: [model.scrollCoordinator]
         )
+    }
+}
+
+/// CodeEditSourceEditor enables horizontal scrolling when wrapping is off, but
+/// its overlay scrollers inherit macOS's auto-hide behavior. Keep the horizontal
+/// thumb visible so long configuration lines remain discoverable and draggable.
+final class CodeEditorScrollCoordinator: TextViewCoordinator {
+    func prepareCoordinator(controller: TextViewController) {}
+
+    func controllerDidAppear(controller: TextViewController) {
+        Self.configure(controller.scrollView)
+    }
+
+    static func configure(_ scrollView: NSScrollView) {
+        scrollView.hasHorizontalScroller = true
+        scrollView.horizontalScrollElasticity = .automatic
+        scrollView.autohidesScrollers = false
+        scrollView.scrollerStyle = .overlay
+        scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 }
 

--- a/Tests/DashboardViewControllerClickTests.swift
+++ b/Tests/DashboardViewControllerClickTests.swift
@@ -59,6 +59,33 @@ final class DashboardViewControllerClickTests: XCTestCase {
         XCTAssertEqual(vc.selectedSailorId, "agent-b")
     }
 
+    func testRowClickClosesEditorOverlayWhenSwitchingWorktrees() {
+        let vc = DashboardViewController()
+        vc.dashboardDelegate = DashboardDelegateSpy()
+        vc.loadViewIfNeeded()
+        vc.updateSailors([
+            makeSailor(id: "agent-a", worktreePath: "/repo/a"),
+            makeSailor(id: "agent-b", worktreePath: "/repo/b"),
+        ])
+        vc.showCenterOverlay(NSView(), title: "file.env")
+        XCTAssertTrue(vc.hasCenterOverlayForTesting)
+
+        vc.handleWorktreeRowClickForTesting(path: "/repo/b")
+
+        XCTAssertEqual(vc.selectedSailorId, "agent-b")
+        XCTAssertFalse(vc.hasCenterOverlayForTesting)
+    }
+
+    func testCodeEditorKeepsHorizontalScrollerVisible() {
+        let scrollView = NSScrollView()
+
+        CodeEditorScrollCoordinator.configure(scrollView)
+
+        XCTAssertTrue(scrollView.hasHorizontalScroller)
+        XCTAssertFalse(scrollView.autohidesScrollers)
+        XCTAssertEqual(scrollView.scrollerStyle, .overlay)
+    }
+
     func testRowClickNotifiesSelectionChange() {
         let vc = DashboardViewController()
         let spy = DashboardDelegateSpy()

--- a/Tests/PendingOrdersQueueTests.swift
+++ b/Tests/PendingOrdersQueueTests.swift
@@ -27,6 +27,30 @@ final class PendingOrdersQueueTests: XCTestCase {
         XCTAssertEqual(q.all().count, 2)
     }
 
+    func testReplacingSuggestionMovesItToLatestPosition() {
+        let q = PendingOrdersQueue()
+        q.upsert(action(.suggestNextOrder, wt: "/wt/a"))
+        q.upsert(action(.suggestNextOrder, wt: "/wt/b"))
+        let replacement = FirstMateAction(
+            kind: .suggestNextOrder, zone: .red, worktreePath: "/wt/a",
+            branch: "b", project: "p", terminalID: "t", message: "new")
+
+        q.upsert(replacement)
+
+        XCTAssertEqual(q.all().map(\.action.worktreePath), ["/wt/b", "/wt/a"])
+        XCTAssertEqual(q.all().last?.action.message, "new")
+    }
+
+    func testIslandSuggestionsAreNewestFirst() {
+        let q = PendingOrdersQueue()
+        q.upsert(action(.suggestNextOrder, wt: "/wt/a"))
+        q.upsert(action(.suggestNextOrder, wt: "/wt/b"))
+
+        let orders = IslandModel.newestSuggestions(from: q.all())
+
+        XCTAssertEqual(orders.map(\.action.worktreePath), ["/wt/b", "/wt/a"])
+    }
+
     func testResolveRemovesAndAllowsReenqueue() {
         let q = PendingOrdersQueue()
         q.enqueue(action(.suggestNextOrder))

--- a/Tests/StatusPublisherThreadTests.swift
+++ b/Tests/StatusPublisherThreadTests.swift
@@ -44,6 +44,33 @@ class StatusPublisherThreadTests: XCTestCase {
         XCTAssertEqual(fires.count, 1)
     }
 
+    func testUnchangedFrameSkipsWhenScanStateIsSynchronized() {
+        XCTAssertTrue(StatusPublisher.shouldSkipUnchangedFrame(
+            lastHash: 42,
+            contentHash: 42,
+            committedScanStatus: .idle,
+            publishedScanStatus: .idle,
+            forceRecheck: false))
+    }
+
+    func testUnchangedFrameDoesNotSkipStalePublishedScanState() {
+        XCTAssertFalse(StatusPublisher.shouldSkipUnchangedFrame(
+            lastHash: 42,
+            contentHash: 42,
+            committedScanStatus: .idle,
+            publishedScanStatus: .running,
+            forceRecheck: false))
+    }
+
+    func testPeriodicRecheckDoesNotSkipSynchronizedFrame() {
+        XCTAssertFalse(StatusPublisher.shouldSkipUnchangedFrame(
+            lastHash: 42,
+            contentHash: 42,
+            committedScanStatus: .idle,
+            publishedScanStatus: .idle,
+            forceRecheck: true))
+    }
+
     func testAgentDefSelectionUsesExistingCodexType() {
         let content = "Would you like to run the following command?"
         let candidates = SailorDetectConfig.default.agents.map { ($0.name.lowercased(), $0) }


### PR DESCRIPTION
## Summary

- keep the code editor horizontal scrollbar visible and close it when switching worktrees
- show newest Island suggestions first, including replacements from the same pane
- reconcile stale pane scan state so completed agents do not remain Running

## Validation

- DashboardViewControllerClickTests: 11 passed
- PendingOrdersQueueTests and SuggestOrderTests: 17 passed
- StatusPublisherThreadTests and ShipLogIngestOutcomeTests: 19 passed
- `git diff --check`