### PR TITLE
fix: close out the follow-ups from the incremental-render change

### DIFF
--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -1140,7 +1140,12 @@ class TabCoordinator {
     // MARK: - Branch Refresh
 
     private var branchRefreshTick = 0
-    private static let elapsedRefreshEveryTicks = 6
+    /// Every 2nd tick of the 5s timer, i.e. 10s. This is the *only* thing that
+    /// advances the seconds-resolution elapsed labels (ShipLog stopped fanning
+    /// out on roundDuration ticks), so a slower cadence reads as a frozen
+    /// counter. `buildSailorDisplayInfos` is cache-served and the render it
+    /// feeds is now incremental, so the tick is cheap enough to keep at 10s.
+    private static let elapsedRefreshEveryTicks = 2
 
     static func shouldRefreshDashboardElapsedTime(tick: Int) -> Bool {
         guard tick > 0 else { return false }
@@ -1448,10 +1453,30 @@ class TabCoordinator {
     /// not in this set, no pane is using it right now.
     func livePaneSessionNames() -> Set<String> {
         guard runtimeBackend == "zmx" else { return [] }
+        guard allConfiguredReposAreRepresented() else {
+            NSLog("[TabCoordinator] Withholding live pane sessions — a configured repo has no worktrees")
+            return []
+        }
         let names = allWorktrees.flatMap { entry in
             entry.tree.allLeaves.map(\.paneSessionKey)
         }
         return Set(names.filter { !$0.isEmpty })
+    }
+
+    /// Whether every configured repo contributed at least one worktree to
+    /// `allWorktrees`. A repo always has its main worktree, so a repo with none
+    /// means discovery never landed — git lock, unmounted volume, a path that
+    /// vanished. Its panes are live but absent from the trees above, and callers
+    /// treat this set as authoritative, so a partial answer would have the
+    /// orphan sweep force-kill those sessions with their agents inside. Both
+    /// callers skip on an empty set, which is the safe direction to fail.
+    private func allConfiguredReposAreRepresented() -> Bool {
+        let represented = Set(allWorktrees.compactMap { entry in
+            worktreeRepoCache[entry.info.path].map(WorktreeDiscovery.canonicalPath)
+        })
+        return config.workspacePaths.allSatisfy {
+            represented.contains(WorktreeDiscovery.canonicalPath($0))
+        }
     }
 
     // MARK: - Navigation

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -2770,8 +2770,13 @@ final class DashboardOverviewView: NSView {
                 titleLabel.stringValue = PaneTitleResolver.shortenPath(sailor.worktreePath)
             }
 
+            // Unlike the title, a duration must be allowed to disappear: it falls
+            // back to the activity age once the pane stops, and that is "" when
+            // unknown. Holding the last value there would leave a dead pane
+            // reading "12s" next to an idle dot. Only a *running* row keeps its
+            // last known figure, so a live counter never blanks mid-flight.
             let nextRuntime = sailor.currentPaneRunTime.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !nextRuntime.isEmpty {
+            if !nextRuntime.isEmpty || status != .running {
                 timeLabel.stringValue = nextRuntime
             }
 

--- a/Sources/UI/Shared/SpinnerDotView.swift
+++ b/Sources/UI/Shared/SpinnerDotView.swift
@@ -51,6 +51,16 @@ final class SpinnerDotView: NSView {
         arc.frame = layer?.bounds ?? bounds
     }
 
+    /// Dashboard rows outlive a single status now — they keep a spinner around
+    /// and toggle it — so a hidden spinner must stop rather than tick forever
+    /// behind `isHidden`. Every row would otherwise host a permanent animation.
+    override var isHidden: Bool {
+        didSet {
+            guard isHidden != oldValue else { return }
+            if isHidden { arc.removeAnimation(forKey: Self.animationKey) } else { installSpin() }
+        }
+    }
+
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         // Animations are stripped when a layer leaves the window; (re)install
@@ -68,6 +78,7 @@ final class SpinnerDotView: NSView {
     }
 
     private func installSpin() {
+        guard window != nil, !isHidden else { return }
         guard arc.animation(forKey: Self.animationKey) == nil else { return }
         guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else { return }
         let spin = CABasicAnimation(keyPath: "transform.rotation.z")

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -242,6 +242,38 @@ final class DashboardOverviewGroupingTests: XCTestCase {
         }
     }
 
+    /// A duration must clear once the pane stops — the row would otherwise hold
+    /// the last figure forever and read as "12s" next to an idle dot. A row that
+    /// is still running keeps its last value so a live counter never blanks.
+    func testStoppedRowClearsRuntimeButRunningRowKeepsIt() {
+        withDefaults { defaults in
+            let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
+                                             defaults: defaults,
+                                             now: { self.now })
+            func push(_ status: SailorStatus, runtime: String) {
+                view.update([
+                    makeSailor(id: "run", project: "alpha", worktreePath: "/run",
+                               paneStatuses: [status], isMainWorktree: false,
+                               lastActivityAt: now.addingTimeInterval(-10),
+                               currentPaneRunTime: runtime),
+                ])
+            }
+
+            push(.running, runtime: "12s")
+            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "run"), "12s")
+
+            // Still running, value momentarily unavailable — hold the last figure.
+            push(.running, runtime: "")
+            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "run"), "12s")
+
+            // Stopped with no known activity age — the counter must go away.
+            push(.idle, runtime: "")
+            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "run"), "")
+
+            XCTAssertEqual(view.fullRenderCountForTesting, 1, "these should all be incremental")
+        }
+    }
+
     /// Regression: the status dot is a plain `addSubview` child, so it has to opt
     /// out of autoresizing constraints by hand. Without that, the frame-derived
     /// constraints win and the whole text column lays out at zero height — every

--- a/Tests/TabCoordinatorTests.swift
+++ b/Tests/TabCoordinatorTests.swift
@@ -166,11 +166,43 @@ final class TabCoordinatorTests: XCTestCase {
         XCTAssertEqual(Set(coordinator.workspaceManager.tabs[tabIndex].worktrees.map(\.path)), Set([main.path, added.path]))
     }
 
-    func testShouldRefreshDashboardElapsedTimeUsesSlowCadence() {
+    /// 10s on the 5s timer. This tick is the only thing advancing the elapsed
+    /// labels, so it has to stay fast enough that a seconds readout doesn't
+    /// visibly freeze.
+    func testShouldRefreshDashboardElapsedTimeEveryTenSeconds() {
+        XCTAssertFalse(TabCoordinator.shouldRefreshDashboardElapsedTime(tick: 0))
         XCTAssertFalse(TabCoordinator.shouldRefreshDashboardElapsedTime(tick: 1))
+        XCTAssertTrue(TabCoordinator.shouldRefreshDashboardElapsedTime(tick: 2))
         XCTAssertFalse(TabCoordinator.shouldRefreshDashboardElapsedTime(tick: 3))
-        XCTAssertFalse(TabCoordinator.shouldRefreshDashboardElapsedTime(tick: 5))
-        XCTAssertTrue(TabCoordinator.shouldRefreshDashboardElapsedTime(tick: 6))
-        XCTAssertTrue(TabCoordinator.shouldRefreshDashboardElapsedTime(tick: 12))
+        XCTAssertTrue(TabCoordinator.shouldRefreshDashboardElapsedTime(tick: 4))
+    }
+
+    /// Regression: the orphan sweep treats this set as authoritative, so a repo
+    /// whose discovery never landed must withhold the whole set rather than
+    /// report a partial one — otherwise its live sessions read as orphans.
+    func testLivePaneSessionNamesWithheldWhenARepoHasNoWorktrees() {
+        var config = Config()
+        config.workspacePaths = ["/tmp/repo-a", "/tmp/repo-b"]
+        let coordinator = TabCoordinator(config: config)
+        coordinator.terminalCoordinator = TerminalCoordinator(config: config, activeSplitContainer: { nil })
+        coordinator.runtimeBackend = "zmx"
+
+        let info = WorktreeInfo(path: "/tmp/repo-a", branch: "main", commitHash: "", isMainWorktree: true)
+        let tree = SplitTree(worktreePath: info.path, rootLeafId: "leaf-a",
+                             stationId: "station-a", paneSessionKey: "seahelm-repo-a-main")
+        coordinator.allWorktrees = [(info: info, tree: tree)]
+        coordinator.worktreeRepoCache[info.path] = "/tmp/repo-a"
+
+        XCTAssertTrue(coordinator.livePaneSessionNames().isEmpty,
+                      "repo-b contributed no worktrees — the set must be withheld")
+
+        let infoB = WorktreeInfo(path: "/tmp/repo-b", branch: "main", commitHash: "", isMainWorktree: true)
+        let treeB = SplitTree(worktreePath: infoB.path, rootLeafId: "leaf-b",
+                              stationId: "station-b", paneSessionKey: "seahelm-repo-b-main")
+        coordinator.allWorktrees.append((info: infoB, tree: treeB))
+        coordinator.worktreeRepoCache[infoB.path] = "/tmp/repo-b"
+
+        XCTAssertEqual(coordinator.livePaneSessionNames(),
+                       ["seahelm-repo-a-main", "seahelm-repo-b-main"])
     }
 }


### PR DESCRIPTION
The four follow-ups listed in #36, all consequences of rows and timers no longer being rebuilt from scratch on every poll.

| Follow-up | Fix |
|---|---|
| Elapsed refresh went 10s → 30s | Back to 10s (`elapsedRefreshEveryTicks` 6 → 2) |
| `timeLabel` held a stale duration | Clears once the pane stops; running rows keep their last figure |
| Hidden spinners animated forever | Animation torn down on `isHidden`, not just on leaving the window |
| Transient-discovery guard had no replacement | `livePaneSessionNames()` withholds a partial set |

**Cadence.** That tick is the only thing advancing a seconds-resolution readout — ShipLog stopped fanning out on roundDuration ticks — so 30s read as a frozen counter. The cost that motivated slowing it down is gone: git stats come from an 8s cache with an off-main refresh, titles from an async cache, and the render it feeds is now incremental (0.45ms).

**Stale duration.** `currentPaneRunTime` falls back to the activity age once a pane stops, and that is `""` when unknown, so holding the last non-empty value left a dead pane reading "12s" next to an idle dot. A row that is still running keeps its last figure so a live counter never blanks mid-flight. The title keeps its own anti-blank guard — that one is deliberate.

**Discovery guard.** `expectedSessionNames` used to skip the whole sweep when any repo's discovery came back empty; nothing replaced that when live panes became the source of truth. A repo always has its main worktree, so no worktrees means discovery never landed (git lock, unmounted volume) — and since callers treat this set as authoritative, a partial answer would reap those live sessions with their agents inside. Both callers skip on an empty set, which is the safe direction to fail. Paths are canonicalised on both sides before comparison.

## Testing

41 tests pass across `DashboardOverviewGroupingTests`, `TabCoordinatorTests`, and `SessionManagerTests`. Two new: `testLivePaneSessionNamesWithheldWhenARepoHasNoWorktrees` and `testStoppedRowClearsRuntimeButRunningRowKeepsIt` (which also asserts all three updates stay on the incremental path). The cadence test was renamed and its assertions updated.

Still `Refs` rather than `Closes` — the 48h sampler from #36 is mid-run and is what actually confirms the long-run slowdown is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)