### PR TITLE
perf: stop reading argv for every process on the machine, per pane, per poll

### DIFF
--- a/Sources/Status/ProcessProbe.swift
+++ b/Sources/Status/ProcessProbe.swift
@@ -85,13 +85,39 @@ enum ProcessProbe {
         probeSession(paneSessionKey: paneSessionKey).agentId
     }
 
+    /// Everything a probe needs from the system, captured once and shared by every
+    /// pane in a poll cycle. Both halves are identical for all panes, and paying
+    /// for them per pane — one `zmx list` fork plus one full process walk each —
+    /// was what pinned a core with the app idle.
+    struct ProbeContext {
+        let zmxListOutput: String
+        let table: [Proc]
+
+        static func capture() -> ProbeContext? {
+            guard let out = ProcessRunner.output([ZmxLocator.executable(), "list"]) else { return nil }
+            return ProbeContext(zmxListOutput: out, table: processTable())
+        }
+    }
+
     /// One sysctl walk: agent identity (if any) + foreground command line.
     static func probeSession(paneSessionKey: String) -> (agentId: String?, commandLine: String?) {
-        guard let out = ProcessRunner.output([ZmxLocator.executable(), "list"]),
-              let root = sessionPid(paneSessionKey: paneSessionKey, zmxListOutput: out) else {
+        guard let context = ProbeContext.capture() else { return (nil, nil) }
+        return probeSession(paneSessionKey: paneSessionKey, context: context)
+    }
+
+    /// As above, against a context already captured for this cycle.
+    static func probeSession(
+        paneSessionKey: String,
+        context: ProbeContext
+    ) -> (agentId: String?, commandLine: String?) {
+        guard let root = sessionPid(paneSessionKey: paneSessionKey,
+                                    zmxListOutput: context.zmxListOutput) else {
             return (nil, nil)
         }
-        let descendants = descendants(of: root, in: allProcesses())
+        // argv is read only for this session's own descendants — a handful —
+        // rather than for every process on the machine, almost all of which the
+        // very next line would have discarded.
+        let descendants = withArgv(descendants(of: root, in: context.table))
         guard !descendants.isEmpty else { return (nil, nil) }
         let agentId = identify(procs: descendants, manifests: ManifestStore.shared.all.map(\.manifest))
         return (agentId, foregroundCommandLine(from: descendants))
@@ -169,48 +195,96 @@ enum ProcessProbe {
         return result
     }
 
-    /// Enumerate all processes with pid/ppid/argv via sysctl.
+    /// Enumerate all processes with pid/ppid/argv (plus rss) via sysctl. Callers
+    /// that only need the tree shape should use `processTable()` — this reads
+    /// argv for every process on the machine and forks `ps` for the rss map.
     static func allProcesses() -> [Proc] {
-        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0]
-        var size = 0
-        guard sysctl(&mib, 4, nil, &size, nil, 0) == 0, size > 0 else { return [] }
-        let count = size / MemoryLayout<kinfo_proc>.stride
-        var procs = [kinfo_proc](repeating: kinfo_proc(), count: count)
-        guard sysctl(&mib, 4, &procs, &size, nil, 0) == 0 else { return [] }
-        let actual = size / MemoryLayout<kinfo_proc>.stride
         let rss = residentBytesByPid()
-        return procs.prefix(actual).map { kp in
+        var buffer = [CChar](repeating: 0, count: argMax)
+        return kinfoProcs().map { kp in
             let pid = kp.kp_proc.p_pid
-            let ppid = kp.kp_eproc.e_ppid
-            return Proc(pid: pid, ppid: ppid, argv: argv(of: pid), residentBytes: rss[pid])
+            return Proc(pid: pid,
+                        ppid: kp.kp_eproc.e_ppid,
+                        argv: argv(of: pid, buffer: &buffer),
+                        residentBytes: rss[pid])
         }
     }
 
+    /// pid/ppid only. Walking the tree needs neither argv nor rss, so this skips
+    /// both the per-process `KERN_PROCARGS2` reads and the `ps` fork.
+    static func processTable() -> [Proc] {
+        kinfoProcs().map { Proc(pid: $0.kp_proc.p_pid, ppid: $0.kp_eproc.e_ppid, argv: []) }
+    }
+
+    /// Read argv for a chosen few, reusing one buffer across the batch.
+    static func withArgv(_ procs: [Proc]) -> [Proc] {
+        guard !procs.isEmpty else { return [] }
+        var buffer = [CChar](repeating: 0, count: argMax)
+        return procs.map {
+            Proc(pid: $0.pid,
+                 ppid: $0.ppid,
+                 argv: argv(of: $0.pid, buffer: &buffer),
+                 residentBytes: $0.residentBytes)
+        }
+    }
+
+    private static func kinfoProcs() -> [kinfo_proc] {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0]
+        var size = 0
+        guard sysctl(&mib, 4, nil, &size, nil, 0) == 0, size > 0 else { return [] }
+        var procs = [kinfo_proc](repeating: kinfo_proc(), count: size / MemoryLayout<kinfo_proc>.stride)
+        guard sysctl(&mib, 4, &procs, &size, nil, 0) == 0 else { return [] }
+        return Array(procs.prefix(size / MemoryLayout<kinfo_proc>.stride))
+    }
+
+    /// `kern.argmax` is fixed for the life of the boot (1 MB on current macOS).
+    /// It used to be re-read on every `argv(of:)` call.
+    private static let argMax: Int = {
+        var value = 0
+        var mib: [Int32] = [CTL_KERN, KERN_ARGMAX]
+        var size = MemoryLayout<Int>.size
+        guard sysctl(&mib, 2, &value, &size, nil, 0) == 0, value > 0 else { return 256 * 1024 }
+        return value
+    }()
+
     /// Read a process's argv via KERN_PROCARGS2. Returns [] on failure.
     static func argv(of pid: Int32) -> [String] {
-        var argmax = 0
-        var mibMax: [Int32] = [CTL_KERN, KERN_ARGMAX]
-        var maxSize = MemoryLayout<Int>.size
-        guard sysctl(&mibMax, 2, &argmax, &maxSize, nil, 0) == 0, argmax > 0 else { return [] }
+        var buffer = [CChar](repeating: 0, count: argMax)
+        return argv(of: pid, buffer: &buffer)
+    }
 
-        var buf = [CChar](repeating: 0, count: argmax)
-        var size = argmax
+    /// Parses straight out of `buffer`. The previous version allocated a fresh
+    /// 1 MB zero-filled buffer per process and then copied the whole thing again
+    /// to reinterpret it as bytes — together the top entry of every CPU profile.
+    private static func argv(of pid: Int32, buffer: inout [CChar]) -> [String] {
+        var size = buffer.count
         var mib: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
-        guard sysctl(&mib, 3, &buf, &size, nil, 0) == 0, size >= MemoryLayout<Int32>.size else { return [] }
+        guard sysctl(&mib, 3, &buffer, &size, nil, 0) == 0,
+              size >= MemoryLayout<Int32>.size else { return [] }
+        let byteCount = size
+        return buffer.withUnsafeBufferPointer { raw in
+            guard let base = raw.baseAddress else { return [] }
+            return base.withMemoryRebound(to: UInt8.self, capacity: byteCount) {
+                parseProcArgs2($0, count: byteCount)
+            }
+        }
+    }
 
-        let bytes = buf.prefix(size).map { UInt8(bitPattern: $0) }
-        let argc = bytes.withUnsafeBytes { $0.load(as: Int32.self) }
-        // Layout: [argc:4][exec_path\0][padding\0...][argv0\0 argv1\0 ...]
+    /// Layout: `[argc:4][exec_path\0][padding\0...][argv0\0 argv1\0 ...]`.
+    private static func parseProcArgs2(_ bytes: UnsafePointer<UInt8>, count: Int) -> [String] {
+        let argc = Int(UnsafeRawPointer(bytes).loadUnaligned(as: Int32.self))
+        guard argc > 0 else { return [] }
         var result: [String] = []
         var i = MemoryLayout<Int32>.size
-        while i < bytes.count && bytes[i] != 0 { i += 1 }      // skip exec_path
-        while i < bytes.count && bytes[i] == 0 { i += 1 }      // skip padding NULs
-        var collected: Int32 = 0
-        while i < bytes.count && collected < argc {
+        while i < count && bytes[i] != 0 { i += 1 }      // skip exec_path
+        while i < count && bytes[i] == 0 { i += 1 }      // skip padding NULs
+        var collected = 0
+        while i < count && collected < argc {
             let start = i
-            while i < bytes.count && bytes[i] != 0 { i += 1 }
+            while i < count && bytes[i] != 0 { i += 1 }
             if i > start {
-                result.append(String(decoding: bytes[start..<i], as: UTF8.self))
+                result.append(String(decoding: UnsafeBufferPointer(start: bytes + start, count: i - start),
+                                     as: UTF8.self))
             }
             i += 1
             collected += 1

--- a/Sources/Status/StatusPublisher.swift
+++ b/Sources/Status/StatusPublisher.swift
@@ -225,6 +225,20 @@ class StatusPublisher {
     }
 
     private func pollAll(_ surfaceSnapshot: [String: Station], preferredPaths: Set<String>, pollCycle: Int, paths: [String: String]) {
+        // One `zmx list` fork and one process-table walk for the whole cycle,
+        // captured on first use so a cycle where every pane's probe is still
+        // fresh pays nothing at all. The failure is memoised too — a missing zmx
+        // must not have each pane retry the fork.
+        var captured: ProcessProbe.ProbeContext?
+        var didCapture = false
+        let probeContext: () -> ProcessProbe.ProbeContext? = {
+            if !didCapture {
+                didCapture = true
+                captured = ProcessProbe.ProbeContext.capture()
+            }
+            return captured
+        }
+
         for (terminalID, surface) in surfaceSnapshot {
             let worktreePath = paths[terminalID] ?? ""
             guard Self.shouldPollPath(worktreePath, preferredPaths: preferredPaths, pollCycle: pollCycle, nonPreferredStride: self.nonPreferredPollStride) else {
@@ -298,7 +312,8 @@ class StatusPublisher {
             // Prefer process-tree identification over screen-text scraping; it is
             // robust to wrappers (node→codex) and to agents that clear their name
             // off screen. Falls back to text detection when the probe is unsure.
-            let probe = probedSession(terminalID: terminalID, paneSessionKey: surface.paneSessionKey, pollCycle: pollCycle)
+            let probe = probedSession(terminalID: terminalID, paneSessionKey: surface.paneSessionKey,
+                                      pollCycle: pollCycle, context: probeContext)
             let probedType = probe.agentType
             let commandLine = probe.commandLine
             let detectedSailorType = probedType != .unknown ? probedType : SailorType.detect(fromLowercased: lowerContent)
@@ -377,7 +392,8 @@ class StatusPublisher {
     private func probedSession(
         terminalID: String,
         paneSessionKey: String?,
-        pollCycle: Int
+        pollCycle: Int,
+        context: () -> ProcessProbe.ProbeContext?
     ) -> (agentType: SailorType, commandLine: String?) {
         guard let paneSessionKey else { return (.unknown, nil) }
         lock.lock()
@@ -395,7 +411,10 @@ class StatusPublisher {
                 return (cachedType ?? .unknown, cachedCmd)
             }
         }
-        let probe = ProcessProbe.probeSession(paneSessionKey: paneSessionKey)
+        // No context means `zmx list` failed this cycle — the same miss the probe
+        // itself used to report, so fall through with the same bookkeeping.
+        let probe = context().map { ProcessProbe.probeSession(paneSessionKey: paneSessionKey, context: $0) }
+            ?? (agentId: nil, commandLine: nil)
         let type = SailorType.fromManifestId(probe.agentId)
         lock.lock()
         // Never downgrade a known identity to unknown on a transient probe miss.

--- a/Tests/ProcessProbeTests.swift
+++ b/Tests/ProcessProbeTests.swift
@@ -148,4 +148,40 @@ final class ProcessProbeTests: XCTestCase {
         let procs = [p(3, 2, ["/bin/zsh"]), p(4, 3, ["bash"])]
         XCTAssertNil(ProcessProbe.foregroundCommandLine(from: procs))
     }
+
+    // MARK: - Live sysctl reads
+    //
+    // `argv(of:)` parses the KERN_PROCARGS2 blob through a raw pointer now, so
+    // these run it against this very process — the one argv whose shape the test
+    // can predict.
+
+    func testArgvReadsOwnProcess() {
+        let argv = ProcessProbe.argv(of: getpid())
+        XCTAssertFalse(argv.isEmpty, "argv for the running test process must parse")
+        XCTAssertFalse(argv[0].isEmpty, "argv0 must not be blank")
+        XCTAssertEqual(argv, ProcessProbe.argv(of: getpid()), "parse must be stable across calls")
+    }
+
+    func testArgvIsStableWhenABufferIsReusedAcrossProcesses() {
+        // The batch path reuses one buffer, so a long argv followed by a short one
+        // must not leave the earlier process's bytes visible in the second result.
+        let table = ProcessProbe.processTable()
+        XCTAssertFalse(table.isEmpty)
+        let sampled = Array(table.prefix(40))
+        let batch = ProcessProbe.withArgv(sampled)
+        for proc in batch {
+            XCTAssertEqual(proc.argv, ProcessProbe.argv(of: proc.pid),
+                           "pid \(proc.pid) parsed differently in the batch than on its own")
+        }
+    }
+
+    func testProcessTableCarriesTreeShapeWithoutArgv() {
+        let table = ProcessProbe.processTable()
+        guard let own = table.first(where: { $0.pid == getpid() }) else {
+            return XCTFail("own pid missing from the process table")
+        }
+        XCTAssertEqual(own.ppid, getppid())
+        XCTAssertTrue(own.argv.isEmpty, "processTable must not pay for argv")
+        XCTAssertNil(own.residentBytes, "processTable must not fork ps for rss")
+    }
 }


### PR DESCRIPTION
Fixes the CPU half of #38.

Seahelm burned **~71% of a core with the app idle** and nothing on screen. All of it was `ProcessProbe`: `probeSession` walked the entire process table and read argv for *every* process, then immediately narrowed to the handful descended from the pane's zmx session and threw the rest away. argv is read into a buffer sized to `kern.argmax` — **1 MB** here — so one walk allocated and zeroed ~800 MB, and each of 12 panes paid for its own walk *plus* its own `zmx list` fork.

## Result

Same machine, same idle state:

| | CPU |
|---|---|
| before | 14.25s over 20s = **71.3%** |
| after | 3.00s over 30s = **10.0%** |

`Array.init(repeating:count:)` was the top non-blocking frame of every profile (2875 samples). After the change it is **absent from the profile entirely** — a fresh 15s `sample` shows only blocking syscalls at the top of stack, and `CFStringFindWithOptionsAndLocale` / `_StringBreadcrumbs` are gone with it.

## Changes

Against #38's fix list, plus one it didn't call out:

1. **`ProbeContext`** captures one `zmx list` and one process table per poll cycle for all panes to share. The `zmx list` fork was also per-pane — not in #38's list. Capture is lazy, so a cycle where every pane's probe is still fresh pays nothing, and a failed capture is memoised so panes don't each retry the fork.
2. **`processTable()`** reads pid/ppid only. Building the tree needs neither argv nor rss, so it also skips the `ps -axo` fork `allProcesses()` does for its resident-size map. argv comes from **`withArgv()`** for the chosen descendants only — 833 reads down to single digits.
3. **One buffer reused** across a batch instead of 1 MB per process, and `kern.argmax` is now read once (it is a boot constant).
4. **KERN_PROCARGS2 parsed in place** — the old code copied the whole buffer a second time just to reinterpret `CChar` as `UInt8`.

`allProcesses()` keeps its full behaviour for the control socket and `SessionManager`, which genuinely need argv and rss for every process; they pick up the buffer reuse and the cheaper parse.

## Testing

`ProcessProbeTests` 17/17. Three are new and target the rewritten pointer parsing, which is the risky part: argv against our own pid, a batch run asserting a reused buffer never leaks one process's bytes into the next result, and the tree shape from `processTable`.

Full unit suite: 1513 tests, 1 failure — `WorktreeDeleterTests/testDeleteMainWorktreeThrows`, which **fails identically on a clean `main`** (verified by stashing this branch's changes and re-running). Unrelated to this change; looks like a test/impl mismatch left by 8b8bf5b.

## Not covered

`Refs` rather than `Closes`: #38 also reports ~55 MB/h memory growth, and that link is still inference. Confirming it needs a long window with no restarts. #38's item 5 (an idle-baseline regression test) is also still open.

The second hot path found in the same profile — `PaneTitleResolver` re-reading Claude transcripts on the main thread — is filed separately as #39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)