### PR TITLE
fix: make Wake restore panes after re-embed

### DIFF
--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -1167,6 +1167,14 @@ class TabCoordinator {
                ShipLog.shared.allSailors().contains(where: { $0.status == .running }) {
                 self.dashboardVC?.updateSailors(self.buildSailorDisplayInfos())
             }
+            // Rides this timer rather than starting its own: the policy only
+            // needs to notice minutes-scale absences, and a 5s tick is already
+            // far finer than that.
+            if self.config.autoSleep.enabled {
+                self.terminalCoordinator?.sleepIdleOffscreenPanes(
+                    idleAfter: self.config.autoSleep.effectiveAfterSeconds
+                )
+            }
         }
     }
 

--- a/Sources/App/TerminalCoordinator.swift
+++ b/Sources/App/TerminalCoordinator.swift
@@ -397,6 +397,60 @@ class TerminalCoordinator {
         stations(matching: targetStationId).compactMap { $0.sleep() ? $0.id : nil }
     }
 
+    // MARK: - Auto sleep
+
+    /// When each off-screen pane was first seen off screen. Only panes absent
+    /// from the displayed tree get an entry; coming back on screen clears it, so
+    /// the timer measures one continuous absence rather than accumulated time.
+    private var offscreenSince: [String: Date] = [:]
+
+    /// Which panes have been off screen long enough to sleep, and the updated
+    /// clock. Pure so the policy is testable without stations, a window, or a
+    /// real clock — the part that can silently sleep a pane the user is looking
+    /// at is exactly the part worth pinning down in tests.
+    static func autoSleepPlan(
+        visible: Set<String>,
+        sleepable: [String],
+        offscreenSince: [String: Date],
+        idleAfter: TimeInterval,
+        now: Date
+    ) -> (sleep: [String], offscreenSince: [String: Date]) {
+        var since = offscreenSince
+        for id in visible { since.removeValue(forKey: id) }
+
+        var sleepIds: [String] = []
+        for id in sleepable where !visible.contains(id) {
+            guard let firstSeen = since[id] else {
+                since[id] = now
+                continue
+            }
+            if now.timeIntervalSince(firstSeen) >= idleAfter {
+                sleepIds.append(id)
+                since.removeValue(forKey: id)
+            }
+        }
+        // Closed panes would otherwise keep their entry forever.
+        let known = visible.union(sleepable)
+        return (sleepIds, since.filter { known.contains($0.key) })
+    }
+
+    /// Sleep panes that have stayed off screen past `idleAfter`. Main thread.
+    /// Returns the ids actually slept. Nothing wakes automatically: a slept pane
+    /// renders as a placeholder with a Wake button, which is the existing
+    /// contract for panes whose surface is gone.
+    @discardableResult
+    func sleepIdleOffscreenPanes(idleAfter: TimeInterval, now: Date = Date()) -> [String] {
+        let visible = Set(activeSplitContainer()?.tree?.allLeaves.map(\.stationId) ?? [])
+        let sleepable = StationRegistry.shared.allStations().filter(\.canSleep).map(\.id)
+        let plan = Self.autoSleepPlan(visible: visible,
+                                      sleepable: sleepable,
+                                      offscreenSince: offscreenSince,
+                                      idleAfter: idleAfter,
+                                      now: now)
+        offscreenSince = plan.offscreenSince
+        return plan.sleep.filter { StationRegistry.shared.station(forId: $0)?.sleep() == true }
+    }
+
     /// Wake a slept pane by station id (nil = every slept pane). Main thread.
     @discardableResult
     func wakePane(targetStationId: String?) -> [String] {

--- a/Sources/Core/Config.swift
+++ b/Sources/Core/Config.swift
@@ -57,6 +57,8 @@ struct Config: Codable {
     var confirmBeforeQuit: Bool
     /// Protect the machine from runaway Claude/Codex process trees.
     var agentMemoryGuard: AgentMemoryGuardConfig
+    /// Reclaim the render cost of panes that have been off screen a while.
+    var autoSleep: AutoSleepConfig
 
     enum CodingKeys: String, CodingKey {
         case workspacePaths = "workspace_paths"
@@ -94,6 +96,7 @@ struct Config: Codable {
         case notificationSound = "notification_sound"
         case confirmBeforeQuit = "confirm_before_quit"
         case agentMemoryGuard = "agent_memory_guard"
+        case autoSleep = "auto_sleep"
     }
 
     init() {
@@ -132,6 +135,7 @@ struct Config: Codable {
         notificationSound = "default"
         confirmBeforeQuit = true
         agentMemoryGuard = .default
+        autoSleep = .default
     }
 
     init(from decoder: Decoder) throws {
@@ -180,6 +184,7 @@ struct Config: Codable {
         notificationSound = try container.decodeIfPresent(String.self, forKey: .notificationSound) ?? "default"
         confirmBeforeQuit = try container.decodeIfPresent(Bool.self, forKey: .confirmBeforeQuit) ?? true
         agentMemoryGuard = try container.decodeIfPresent(AgentMemoryGuardConfig.self, forKey: .agentMemoryGuard) ?? .default
+        autoSleep = try container.decodeIfPresent(AutoSleepConfig.self, forKey: .autoSleep) ?? .default
     }
 
     static let configDir = FileManager.default.homeDirectoryForCurrentUser
@@ -312,6 +317,30 @@ struct AgentMemoryGuardConfig: Codable, Equatable {
     var warnBytes: UInt64 { UInt64(max(0, warnMB)) * 1_048_576 }
     var stopBytes: UInt64 { UInt64(max(0, stopMB)) * 1_048_576 }
     var killBytes: UInt64 { UInt64(max(0, killMB)) * 1_048_576 }
+}
+
+/// Policy for reclaiming the render cost of panes nobody is looking at. Only
+/// the ghostty surface goes away (Metal drawables, screen buffer, the four
+/// per-surface threads) — the zmx session and the agent inside it keep running,
+/// and the pane comes back through the placeholder's Wake button.
+struct AutoSleepConfig: Codable, Equatable {
+    var enabled: Bool
+    /// How long a pane must stay off screen before it is eligible.
+    var afterSeconds: Double
+
+    /// Off by default: sleeping is visible (the pane becomes a placeholder), so
+    /// it should be something the user turns on, not something that surprises
+    /// them the first time they scroll back to an old worktree.
+    static let `default` = AutoSleepConfig(enabled: false, afterSeconds: 15 * 60)
+
+    enum CodingKeys: String, CodingKey {
+        case enabled
+        case afterSeconds = "after_seconds"
+    }
+
+    /// Guards against a config that would sleep panes the moment they lose
+    /// focus, which reads as panes randomly dying.
+    var effectiveAfterSeconds: Double { max(60, afterSeconds) }
 }
 
 struct SailorDetectConfig: Codable {

--- a/Sources/Terminal/Station.swift
+++ b/Sources/Terminal/Station.swift
@@ -7,10 +7,16 @@ protocol StationDelegate: AnyObject {
     /// Called after a station tore its surface down to sleep. The delegate should
     /// drop the now-dead view registration so layout skips the leaf.
     func stationDidSleep(_ station: Station)
+    /// A live view a woken station can be created into when the container it
+    /// slept in is gone. Placement is not this view's job — `stationDidRecover`
+    /// fires immediately afterwards and lays the surface out properly — so any
+    /// view still in the hierarchy will do.
+    func stationContainer(for station: Station) -> NSView?
 }
 
 extension StationDelegate {
     func stationDidSleep(_ station: Station) {}
+    func stationContainer(for station: Station) -> NSView? { nil }
 }
 
 /// Manages a single Ghostty terminal surface (NSView + PTY + Metal renderer).
@@ -591,6 +597,38 @@ class Station {
         surface != nil && !isAsleep && backend == "zmx" && !(paneSessionKey ?? "").isEmpty
     }
 
+    /// Pins the post-`sleep()` flag without a live Ghostty surface, so layout /
+    /// Wake wiring can be unit-tested. Precondition: no surface (same as after
+    /// a real sleep).
+    func adoptAsleepStateForTesting() {
+        precondition(surface == nil, "adoptAsleepStateForTesting requires no surface")
+        isAsleep = true
+    }
+
+    /// Whether an embed/restore pass should call `create`. Asleep panes keep
+    /// `surface == nil` on purpose; recreating one while leaving `isAsleep`
+    /// set makes the Wake button a no-op (`wake()` used to require
+    /// `surface == nil`).
+    static func shouldCreateSurfaceOnEmbed(hasSurface: Bool, isAsleep: Bool) -> Bool {
+        !hasSurface && !isAsleep
+    }
+
+    /// How `wake()` should proceed. Pure so the "Wake does nothing" regressions
+    /// are pin-downable without a live Ghostty surface.
+    enum WakePlan: Equatable {
+        case noop
+        /// Surface already exists (embed incorrectly recreated it while asleep).
+        case adoptExisting
+        /// Need to recreate into the given container.
+        case recreate
+    }
+
+    static func wakePlan(isAsleep: Bool, hasSurface: Bool, hasContainer: Bool) -> WakePlan {
+        guard isAsleep else { return .noop }
+        if hasSurface { return .adoptExisting }
+        return hasContainer ? .recreate : .noop
+    }
+
     /// Free the ghostty surface (Metal drawables + screen buffer) while leaving
     /// the backend session running. Main thread. Returns false if not eligible.
     @discardableResult
@@ -609,20 +647,48 @@ class Station {
     /// uses. Main thread. Returns false if the station wasn't asleep.
     @discardableResult
     func wake() -> Bool {
-        guard isAsleep, surface == nil,
-              let container = sleepContainer,
-              let app = GhosttyBridge.shared.app else { return false }
-        isAsleep = false
-        _createWithCommand(
-            app: app,
-            container: container,
-            workingDirectory: initialWorkingDirectory,
-            command: paneSessionKey.map { Self.zmxAttachCommand(paneSessionKey: $0) },
-            initialFrame: sleepFrame
-        )
-        guard surface != nil else { return false }
-        delegate?.stationDidRecover(self)
-        return true
+        // `sleepContainer` is weak, and a pane can stay asleep long enough for
+        // the container it slept in to be torn down (worktree switch, layout
+        // rebuild). Without a fallback such a pane is stranded: `wake()` bails,
+        // and with `surface == nil` it can never be slept or woken again either.
+        let originalContainer = sleepContainer
+        let container = originalContainer ?? delegate?.stationContainer(for: self)
+        switch Self.wakePlan(isAsleep: isAsleep, hasSurface: surface != nil, hasContainer: container != nil) {
+        case .noop:
+            return false
+        case .adoptExisting:
+            // Embed recreated the surface while we were still marked asleep —
+            // clear the flag and re-register so the placeholder goes away.
+            isAsleep = false
+            sleepContainer = nil
+            sleepFrame = nil
+            delegate?.stationDidRecover(self)
+            return true
+        case .recreate:
+            guard let container, let app = GhosttyBridge.shared.app else { return false }
+            _createWithCommand(
+                app: app,
+                container: container,
+                workingDirectory: initialWorkingDirectory,
+                command: paneSessionKey.map { Self.zmxAttachCommand(paneSessionKey: $0) },
+                // The captured frame only means anything inside the container it was
+                // captured from; a substitute container lays out from its own bounds.
+                initialFrame: originalContainer != nil ? sleepFrame : nil
+            )
+            // Stay asleep if the surface did not come back, so the pane keeps the one
+            // state `wake()` accepts and the next attempt can retry. Clearing the flag
+            // first left a failed wake as `!isAsleep && surface == nil`, which neither
+            // `sleep()` nor `wake()` will touch again.
+            guard surface != nil else { return false }
+            // Before `stationDidRecover`, which registers the new view: `layoutTree`
+            // hides the surface view of a leaf it still believes is asleep, and only
+            // the placeholder is ever un-hidden.
+            isAsleep = false
+            sleepContainer = nil
+            sleepFrame = nil
+            delegate?.stationDidRecover(self)
+            return true
+        }
     }
 
     /// Destroy the surface and clean up

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -989,8 +989,12 @@ class DashboardViewController: NSViewController {
         var surfaceViews: [String: NSView] = [:]
         for leaf in tree.allLeaves {
             if let station = StationRegistry.shared.station(forId: leaf.stationId) {
-                // Ensure station is created
-                if station.surface == nil {
+                // Asleep panes keep surface nil on purpose — recreating here while
+                // leaving isAsleep set made Wake a no-op. The placeholder's Wake
+                // button is the only way back.
+                if Station.shouldCreateSurfaceOnEmbed(
+                    hasSurface: station.surface != nil, isAsleep: station.isAsleep
+                ) {
                     let stationId = leaf.stationId
                     _ = station.create(in: container, workingDirectory: worktreePath, paneSessionKey: station.paneSessionKey) { [weak splitView] in
                         // Async backend: register the view once creation finishes

--- a/Sources/UI/Split/SplitContainerView.swift
+++ b/Sources/UI/Split/SplitContainerView.swift
@@ -174,6 +174,10 @@ class SplitContainerView: NSView, DividerDelegate {
                   let station = StationRegistry.shared.station(forId: leaf.stationId),
                   station.isAsleep else { continue }
             activeIds.insert(leaf.id)
+            // layoutTree skips delegate wiring for asleep leaves (no surfaceViews
+            // entry), so pin it here — Wake needs the container fallback when
+            // sleepContainer has gone stale.
+            station.delegate = self
             let view = asleepViews[leaf.id] ?? AsleepPaneView()
             if asleepViews[leaf.id] == nil {
                 asleepViews[leaf.id] = view
@@ -547,6 +551,11 @@ extension SplitContainerView: StationDelegate {
         surfaceViews.removeValue(forKey: station.id)
         layoutTree()
     }
+
+    /// Leaf views are added to this view (see `layoutTree`), so it is both the
+    /// container a pane slept in and the right substitute when that reference
+    /// has gone stale.
+    func stationContainer(for station: Station) -> NSView? { self }
 
     /// Swap in a recovered view for `stationId`, relayout (which reparents it into
     /// this container), and restore keyboard focus if that leaf was focused.

--- a/Tests/SplitContainerRecoveryTests.swift
+++ b/Tests/SplitContainerRecoveryTests.swift
@@ -44,4 +44,94 @@ final class SplitContainerRecoveryTests: XCTestCase {
         XCTAssertTrue(newView.superview === split,
                       "recovered view must be reparented into the container")
     }
+
+    /// `Station.sleepContainer` is weak, so a pane that stays asleep across a
+    /// layout rebuild loses it and `wake()` used to bail — stranding the pane
+    /// with no surface and no way back. The displaying container is the
+    /// substitute, since leaf views are added to it anyway.
+    func testContainerOffersItselfAsWakeFallback() {
+        let split = SplitContainerView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let station = Station()
+
+        XCTAssertTrue(split.stationContainer(for: station) === split,
+                      "the displaying container must offer itself for a woken station")
+    }
+
+    /// Delegates that do not display panes keep the no-op default, so the
+    /// fallback stays opt-in rather than resurrecting a pane into a random view.
+    func testDelegateFallbackDefaultsToNil() {
+        final class BareDelegate: StationDelegate {
+            func stationDidRecover(_ station: Station) {}
+        }
+
+        XCTAssertNil(BareDelegate().stationContainer(for: Station()),
+                     "the protocol default must not invent a container")
+    }
+
+    /// Laying out an asleep leaf must wire the station delegate even though
+    /// there is no surfaceViews entry — otherwise Wake has no container once
+    /// the weak sleepContainer goes stale.
+    func testLayoutAsleepViewsWiresStationDelegate() {
+        let split = SplitContainerView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        let station = Station()
+        StationRegistry.shared.register(station)
+        defer { StationRegistry.shared.unregister(station.id) }
+
+        // Post-sleep state without needing a live Ghostty surface.
+        station.adoptAsleepStateForTesting()
+
+        let tree = SplitTree(worktreePath: "/wt", rootLeafId: "leaf1",
+                             stationId: station.id, paneSessionKey: "seahelm-wt-1")
+        split.tree = tree   // didSet → layoutTree() → layoutAsleepViews
+
+        XCTAssertTrue(station.delegate === split,
+                      "asleep layout must wire the station delegate for Wake fallback")
+    }
+}
+
+// MARK: - Sleep / Wake plan (embed + Wake button)
+
+final class StationSleepWakePlanTests: XCTestCase {
+
+    /// The exact bug behind "Wake does nothing": returning to a worktree saw
+    /// `surface == nil`, called `create`, left `isAsleep` set, and `wake()`
+    /// then required `surface == nil` — a permanent no-op.
+    func testAsleepPaneMustNotBeRecreatedOnEmbed() {
+        XCTAssertFalse(
+            Station.shouldCreateSurfaceOnEmbed(hasSurface: false, isAsleep: true),
+            "embed must leave asleep panes alone so Wake can recreate them"
+        )
+        XCTAssertTrue(
+            Station.shouldCreateSurfaceOnEmbed(hasSurface: false, isAsleep: false),
+            "a never-created pane still needs create on first embed"
+        )
+        XCTAssertFalse(
+            Station.shouldCreateSurfaceOnEmbed(hasSurface: true, isAsleep: false)
+        )
+    }
+
+    /// If embed already put a surface back while isAsleep stayed true, Wake
+    /// must adopt it rather than bail.
+    func testWakeAdoptsSurfaceCreatedWhileAsleep() {
+        XCTAssertEqual(
+            Station.wakePlan(isAsleep: true, hasSurface: true, hasContainer: false),
+            .adoptExisting
+        )
+    }
+
+    func testWakeRecreatesWhenSurfaceGoneAndContainerAvailable() {
+        XCTAssertEqual(
+            Station.wakePlan(isAsleep: true, hasSurface: false, hasContainer: true),
+            .recreate
+        )
+        XCTAssertEqual(
+            Station.wakePlan(isAsleep: true, hasSurface: false, hasContainer: false),
+            .noop,
+            "no container and no surface → nothing Wake can do"
+        )
+        XCTAssertEqual(
+            Station.wakePlan(isAsleep: false, hasSurface: false, hasContainer: true),
+            .noop
+        )
+    }
 }

--- a/Tests/TerminalCoordinatorTests.swift
+++ b/Tests/TerminalCoordinatorTests.swift
@@ -36,4 +36,58 @@ final class TerminalCoordinatorTests: XCTestCase {
         coordinator.cleanup()
         XCTAssertNil(coordinator.controlSocketServer)
     }
+
+    // MARK: - Auto sleep policy
+
+    private let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+    func testOffscreenPaneIsNotSleptBeforeTheThreshold() {
+        let first = TerminalCoordinator.autoSleepPlan(
+            visible: [], sleepable: ["a"], offscreenSince: [:], idleAfter: 600, now: t0)
+        XCTAssertEqual(first.sleep, [], "the first sighting only starts the clock")
+        XCTAssertEqual(first.offscreenSince["a"], t0)
+
+        let later = TerminalCoordinator.autoSleepPlan(
+            visible: [], sleepable: ["a"], offscreenSince: first.offscreenSince,
+            idleAfter: 600, now: t0.addingTimeInterval(599))
+        XCTAssertEqual(later.sleep, [])
+    }
+
+    func testOffscreenPaneSleepsOnceThresholdPasses() {
+        let plan = TerminalCoordinator.autoSleepPlan(
+            visible: [], sleepable: ["a"], offscreenSince: ["a": t0],
+            idleAfter: 600, now: t0.addingTimeInterval(600))
+        XCTAssertEqual(plan.sleep, ["a"])
+        XCTAssertNil(plan.offscreenSince["a"], "a slept pane's clock is meaningless")
+    }
+
+    /// The reason the clock is stored rather than accumulated: a pane the user
+    /// keeps returning to must never reach the threshold by adding up gaps.
+    func testReturningToScreenResetsTheClock() {
+        let seen = TerminalCoordinator.autoSleepPlan(
+            visible: [], sleepable: ["a"], offscreenSince: [:], idleAfter: 600, now: t0)
+        let back = TerminalCoordinator.autoSleepPlan(
+            visible: ["a"], sleepable: ["a"], offscreenSince: seen.offscreenSince,
+            idleAfter: 600, now: t0.addingTimeInterval(300))
+        XCTAssertNil(back.offscreenSince["a"], "being visible clears the clock")
+
+        let away = TerminalCoordinator.autoSleepPlan(
+            visible: [], sleepable: ["a"], offscreenSince: back.offscreenSince,
+            idleAfter: 600, now: t0.addingTimeInterval(700))
+        XCTAssertEqual(away.sleep, [], "the clock restarts from the moment it left again")
+    }
+
+    func testVisiblePaneIsNeverSlept() {
+        let plan = TerminalCoordinator.autoSleepPlan(
+            visible: ["a"], sleepable: ["a"], offscreenSince: ["a": t0],
+            idleAfter: 600, now: t0.addingTimeInterval(6000))
+        XCTAssertEqual(plan.sleep, [], "a pane on screen must not be slept, however stale its clock")
+    }
+
+    func testClosedPanesDropOutOfTheClock() {
+        let plan = TerminalCoordinator.autoSleepPlan(
+            visible: ["a"], sleepable: ["a"], offscreenSince: ["a": t0, "gone": t0],
+            idleAfter: 600, now: t0.addingTimeInterval(10))
+        XCTAssertNil(plan.offscreenSince["gone"], "ids that no longer exist must not accumulate")
+    }
 }


### PR DESCRIPTION
## Summary
- Returning to a slept worktree was recreating the Ghostty surface while leaving `isAsleep` set, so the Wake button no-oped (`wake()` required `surface == nil`).
- Skip `create` for asleep panes on embed; if a surface already exists in that inconsistent state, Wake adopts it and clears sleep.
- Also wires optional auto-sleep for off-screen panes (`auto_sleep` config) and keeps the station delegate pinned on asleep layout for Wake's container fallback.

## Test plan
- [ ] Sleep a pane (or enable `auto_sleep`), switch away long enough for the placeholder to appear, switch back, click **Wake** — terminal should reattach
- [ ] Confirm a pane that was already stuck asleep+surface still wakes on one click
- [ ] `xcodebuild … test -only-testing:seahelmTests/StationSleepWakePlanTests -only-testing:seahelmTests/SplitContainerRecoveryTests`


Made with [Cursor](https://cursor.com)