### PR TITLE
feat: show the focused pane's session memory in the chrome header

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -1741,6 +1741,57 @@ dashboard.stationManager = terminalCoordinator.stationManager
         }
         windowChrome?.updateTerminalTitle(repo: repo, pane: paneTitle)
         windowChrome?.updateCabinContext(Self.cabinContext(repo: repo, sailor: agent))
+        refreshHeaderMemory(sessionKey: focusedPaneSessionKey(worktreePath: path))
+    }
+
+    // MARK: - Header memory readout
+
+    private static let headerMemoryTTL: TimeInterval = 5
+    private let headerMemoryQueue = DispatchQueue(label: "seahelm.header-memory", qos: .utility)
+    private var headerMemoryCache: [String: UInt64] = [:]
+    private var headerMemoryProbedAt: [String: Date] = [:]
+    private var headerMemoryInFlight: Set<String> = []
+
+    private func focusedPaneSessionKey(worktreePath: String) -> String? {
+        let tree = terminalCoordinator.stationManager.tree(forPath: worktreePath)
+        guard let stationId = PaneTitleResolver.focusedStationId(in: tree) else { return nil }
+        return StationRegistry.shared.station(forId: stationId)?.paneSessionKey
+    }
+
+    /// Paint the cached figure at once, then re-probe at most every
+    /// `headerMemoryTTL` seconds. The probe forks `zmx list` and `ps`, so it runs
+    /// off the main thread and is rate-limited — this is called on every title
+    /// refresh, which includes the 5s chrome tick and every focus change.
+    private func refreshHeaderMemory(sessionKey: String?) {
+        guard let sessionKey, !sessionKey.isEmpty else {
+            windowChrome?.updateTerminalMemory(nil)
+            return
+        }
+        windowChrome?.updateTerminalMemory(headerMemoryCache[sessionKey])
+
+        let last = headerMemoryProbedAt[sessionKey] ?? .distantPast
+        guard Date().timeIntervalSince(last) >= Self.headerMemoryTTL,
+              !headerMemoryInFlight.contains(sessionKey) else { return }
+        headerMemoryInFlight.insert(sessionKey)
+        headerMemoryProbedAt[sessionKey] = Date()
+
+        headerMemoryQueue.async { [weak self] in
+            let bytes = ProcessRunner.output([ZmxLocator.executable(), "list"]).flatMap {
+                ProcessProbe.sessionResidentBytes(paneSessionKey: sessionKey, zmxListOutput: $0)
+            }
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.headerMemoryInFlight.remove(sessionKey)
+                guard let bytes else { return }
+                self.headerMemoryCache[sessionKey] = bytes
+                // Focus may have moved while the probe ran; painting then would
+                // label the new pane with the old pane's number.
+                guard let agent = self.tabCoordinator.selectedSailor,
+                      self.focusedPaneSessionKey(worktreePath: agent.worktreePath) == sessionKey
+                else { return }
+                self.windowChrome?.updateTerminalMemory(bytes)
+            }
+        }
     }
 
     /// `repo · branch`, skipping either half when it is missing or would repeat the

--- a/Sources/Status/ProcessProbe.swift
+++ b/Sources/Status/ProcessProbe.swift
@@ -216,6 +216,26 @@ enum ProcessProbe {
         kinfoProcs().map { Proc(pid: $0.kp_proc.p_pid, ppid: $0.kp_eproc.e_ppid, argv: []) }
     }
 
+    /// Resident bytes of one session's whole process tree, root included.
+    ///
+    /// Deliberately not `memory(rootPid:in:manifests:)`: that splits the total
+    /// into an agent share, which needs argv on every process to match manifests
+    /// — the read that used to pin a core. A headline figure only needs the tree
+    /// shape (sysctl) and an rss map (one `ps`), so this stays cheap enough to
+    /// sit on a UI refresh.
+    static func sessionResidentBytes(paneSessionKey: String, zmxListOutput: String) -> UInt64? {
+        guard let root = sessionPid(paneSessionKey: paneSessionKey, zmxListOutput: zmxListOutput) else {
+            return nil
+        }
+        let rss = residentBytesByPid()
+        let table = processTable().map {
+            Proc(pid: $0.pid, ppid: $0.ppid, argv: [], residentBytes: rss[$0.pid])
+        }
+        let tree = (table.first { $0.pid == root }.map { [$0] } ?? []) + descendants(of: root, in: table)
+        guard !tree.isEmpty else { return nil }
+        return uniqueMemoryBytes(tree)
+    }
+
     /// Read argv for a chosen few, reusing one buffer across the batch.
     static func withArgv(_ procs: [Proc]) -> [Proc] {
         guard !procs.isEmpty else { return [] }

--- a/Sources/UI/Chrome/TerminalHeaderView.swift
+++ b/Sources/UI/Chrome/TerminalHeaderView.swift
@@ -10,6 +10,10 @@ final class TerminalHeaderView: NSView {
     let trafficLightSlot = NSView()
 
     private let titleLabel = NSTextField(labelWithString: "")
+    /// Focused pane's session memory. Pinned to the leading edge rather than
+    /// trailing the title: the title is centred and truncates from the tail, so
+    /// a suffix would both drift as the title changes and be the first thing cut.
+    private let memoryLabel = NSTextField(labelWithString: "")
     private let iconCluster = ChromeIconClusterView()
     private let expandButton = ChromeIconButton()
     private let editModeButton = ChromeIconButton()
@@ -21,6 +25,9 @@ final class TerminalHeaderView: NSView {
     /// edit mode, so both are kept rather than read back off the label.
     private var paneTitle = ""
     private var cabinContext = ""
+    /// Kept rather than read back off the label, so collapse/expand can re-render
+    /// it without the caller having to push the value again.
+    private var paneMemoryBytes: UInt64?
 
     /// Edit mode's two column tab strips live here permanently rather than being
     /// moved up from the columns: reparenting a strip left its clip view seated at a
@@ -80,6 +87,35 @@ final class TerminalHeaderView: NSView {
         applyTitleText()
     }
 
+    /// Resident memory of the focused pane's session tree, or nil to clear.
+    func setPaneMemory(_ bytes: UInt64?) {
+        paneMemoryBytes = bytes
+        applyMemoryText()
+    }
+
+    /// Short by design — this shares a row with a centred title, so it trades
+    /// precision for a width that does not move as the number changes.
+    static func formatMemory(bytes: UInt64) -> String {
+        let mb = Double(bytes) / 1_048_576
+        if mb < 1 { return "<1 MB" }
+        if mb < 1024 { return String(format: "%.0f MB", mb) }
+        return String(format: "%.1f GB", mb / 1024)
+    }
+
+    var memoryLabelIsHiddenForTesting: Bool { memoryLabel.isHidden }
+    var memoryTextForTesting: String { memoryLabel.stringValue }
+
+    private func applyMemoryText() {
+        // Collapsed puts traffic lights, icons and the title on this row already;
+        // there is no leading space left to hold a number steady.
+        guard !isCollapsed, let bytes = paneMemoryBytes, bytes > 0 else {
+            memoryLabel.isHidden = true
+            return
+        }
+        memoryLabel.stringValue = Self.formatMemory(bytes: bytes)
+        memoryLabel.isHidden = false
+    }
+
     /// `animated` is passed through from the chrome's collapse animation so the
     /// icons this header owns while collapsed fade across the hand-off with the
     /// sidebar instead of popping in at frame 0.
@@ -128,6 +164,19 @@ final class TerminalHeaderView: NSView {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         addSubview(titleLabel)
 
+        memoryLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        memoryLabel.textColor = Theme.textSecondary
+        memoryLabel.maximumNumberOfLines = 1
+        memoryLabel.cell?.usesSingleLineMode = true
+        // Never steals width from the title, and never gets compressed itself —
+        // a half-rendered number is worse than none.
+        memoryLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        memoryLabel.setContentHuggingPriority(.required, for: .horizontal)
+        memoryLabel.setAccessibilityIdentifier("chrome.terminalMemory")
+        memoryLabel.translatesAutoresizingMaskIntoConstraints = false
+        memoryLabel.isHidden = true
+        addSubview(memoryLabel)
+
         configureExpandButton()
         addSubview(expandButton)
 
@@ -154,11 +203,17 @@ final class TerminalHeaderView: NSView {
             editModeButton.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
 
-        // Expanded: true horizontal center in the terminal column.
+        // Expanded: true horizontal center in the terminal column. The memory
+        // readout sits at the leading edge and the title's minimum-leading now
+        // clears it, so a long title is truncated rather than overlapping it —
+        // the title keeps its exact centring while it fits.
         expandedConstraints = [
+            memoryLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            memoryLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+
             titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
             titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 12),
+            titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: memoryLabel.trailingAnchor, constant: 8),
             titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: editModeButton.leadingAnchor, constant: -8),
             editModeButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
         ]
@@ -248,6 +303,7 @@ final class TerminalHeaderView: NSView {
     private func applyCollapsedState(animated: Bool = false) {
         stripLeadingCollapsed?.isActive = isCollapsed
         stripLeadingExpanded?.isActive = !isCollapsed
+        applyMemoryText()
         if isCollapsed {
             NSLayoutConstraint.deactivate(expandedConstraints)
             NSLayoutConstraint.activate(collapsedConstraints)

--- a/Sources/UI/Chrome/WindowChromeController.swift
+++ b/Sources/UI/Chrome/WindowChromeController.swift
@@ -106,6 +106,11 @@ final class WindowChromeController: NSViewController {
         }
     }
 
+    /// Resident memory of the focused pane's session tree, or nil to clear.
+    func updateTerminalMemory(_ bytes: UInt64?) {
+        terminalHeader.setPaneMemory(bytes)
+    }
+
     /// Drive the chrome title from a center overlay (file / changelog). Pass
     /// `nil` to restore the live pane title.
     func setOverlayTitle(_ title: String?) {

--- a/Tests/TerminalHeaderViewTests.swift
+++ b/Tests/TerminalHeaderViewTests.swift
@@ -149,4 +149,28 @@ final class TerminalHeaderViewTests: XCTestCase {
         XCTAssertEqual(header.editTerminalStrip.clipOriginYForTesting, 0)
         XCTAssertTrue(header.editTerminalStrip.firstTabIsVisibleForTesting)
     }
+
+    // MARK: - Memory readout
+
+    /// The readout shares a row with a centred title, so it is formatted for a
+    /// stable narrow width rather than precision.
+    func testMemoryFormatting() {
+        XCTAssertEqual(TerminalHeaderView.formatMemory(bytes: 512), "<1 MB")
+        XCTAssertEqual(TerminalHeaderView.formatMemory(bytes: 340 * 1_048_576), "340 MB")
+        XCTAssertEqual(TerminalHeaderView.formatMemory(bytes: 1023 * 1_048_576), "1023 MB")
+        XCTAssertEqual(TerminalHeaderView.formatMemory(bytes: 1024 * 1_048_576), "1.0 GB")
+        XCTAssertEqual(TerminalHeaderView.formatMemory(bytes: 2560 * 1_048_576), "2.5 GB")
+    }
+
+    /// Zero/nil means "not measured", which must read as blank rather than 0 MB.
+    func testMemoryLabelHiddenWithoutAValue() {
+        let header = makeHeader()
+        header.setPaneMemory(nil)
+        XCTAssertTrue(header.memoryLabelIsHiddenForTesting)
+        header.setPaneMemory(0)
+        XCTAssertTrue(header.memoryLabelIsHiddenForTesting)
+        header.setPaneMemory(340 * 1_048_576)
+        XCTAssertFalse(header.memoryLabelIsHiddenForTesting)
+        XCTAssertEqual(header.memoryTextForTesting, "340 MB")
+    }
 }


### PR DESCRIPTION
Focus a pane, read its memory. Previously this was only answerable from the Settings session monitor, a table away from the pane you are actually looking at.

<img width="600" alt="header showing 353 MB at the leading edge with the title centred" src="https://github.com/user-attachments/assets/placeholder" />

## Placement

Leading edge, not after the title. The expanded title is centred and truncates from the tail, so a suffix would both drift as the title changes length and be the first thing cut. At the leading edge the number holds still and the title keeps its exact centring — only its minimum-leading now clears the readout. Collapsed hides it: traffic lights, icons and the title already own that row.

## Cost

The probe is deliberately **not** `ProcessProbe.memory(rootPid:in:manifests:)`. Splitting a session's total into an agent share needs argv for every process on the machine — the read that pinned a core in #38. A headline figure only needs tree shape (sysctl) plus one `ps` for rss, so the new `sessionResidentBytes` skips argv entirely.

Refresh is rate-limited to 5s per session and runs off the main thread; it is driven from the title refresh, which fires on every focus change and on the 5s chrome tick. A late probe re-checks that focus has not moved before painting, so a slow read cannot label the new pane with the old pane's number.

## Verification

Built and run; the readout shows live per-pane figures matching `pane.list --memory`. Unit tests cover the formatter thresholds and that a missing value renders blank rather than `0 MB`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)