### PR TITLE
fix: correct the perf monitor's cadence and target; report the memory floor

### DIFF
--- a/scripts/perf/README.md
+++ b/scripts/perf/README.md
@@ -13,11 +13,18 @@ scripts/perf/perfmon.sh report --hours 6    # ...or just the recent window
 scripts/perf/perfmon.sh stop                # stop early
 ```
 
-Sampling is a launchd agent (`com.seahelm.perfmon`), not a foreground loop, so
-it survives closing the pane that started it, Seahelm restarts, and sleep/wake.
-The job removes itself when the deadline passes. Data lands in
-`~/Library/Logs/seahelm-perf/` (`SEAHELM_PERF_DIR` overrides): `samples.jsonl`
-one row per sample, previous runs archived as `samples-<stamp>.jsonl`.
+Sampling runs as a launchd agent (`com.seahelm.perfmon`), so it survives closing
+the pane that started it, Seahelm restarts, and sleep/wake; the job removes
+itself when the deadline passes. The agent keeps its own clock (`--loop N`)
+rather than using `StartInterval`, which launchd coalesced into ~3 minute ticks
+on a machine deep in swap; `KeepAlive` restarts the loop if it dies. Data lands
+in `~/Library/Logs/seahelm-perf/` (`SEAHELM_PERF_DIR` overrides):
+`samples.jsonl` one row per sample, previous runs archived as
+`samples-<stamp>.jsonl`.
+
+`reload` re-copies the sampler into the run's snapshot and restarts the loop
+without touching `state.json` or `samples.jsonl` — use it to fix the sampler
+mid-run, since `start` archives the samples and resets the deadline.
 
 ## What each signal is for
 

--- a/scripts/perf/perfmon.sh
+++ b/scripts/perf/perfmon.sh
@@ -24,6 +24,7 @@ usage() {
 Usage: perfmon.sh <command> [options]
 
   start [--hours N] [--interval S]   start a monitored run (default 48h, 60s)
+  reload                             apply sampler edits, keep window + samples
   stop                               stop early
   status                             job state, deadline, latest sample
   report [--hours H] [--last N] [--json]
@@ -83,11 +84,17 @@ PY
   <array>
     <string>$PYTHON</string>
     <string>$run_sampler</string>
+    <string>--loop</string>
+    <string>$interval</string>
   </array>
   <key>EnvironmentVariables</key>
   <dict><key>SEAHELM_PERF_DIR</key><string>$PERF_DIR</string></dict>
-  <key>StartInterval</key><integer>$interval</integer>
+  <!-- The sampler owns its own clock: launchd's StartInterval coalesced 60s
+       ticks into ~3min ones while the machine was swapping. KeepAlive just
+       restarts the loop if it ever dies. -->
+  <key>KeepAlive</key><true/>
   <key>RunAtLoad</key><true/>
+  <key>ThrottleInterval</key><integer>30</integer>
   <key>Nice</key><integer>5</integer>
   <key>LowPriorityIO</key><true/>
   <key>StandardOutPath</key><string>$PERF_DIR/monitor.log</string>
@@ -103,6 +110,22 @@ EOF
   echo "==> monitoring every ${interval}s for ${hours}h (until $(date -r "$deadline" '+%Y-%m-%d %H:%M'))"
   echo "    samples: $SAMPLES"
   echo "    report:  $SCRIPT_DIR/perfmon.sh report"
+}
+
+cmd_reload() {
+  # Apply sampler changes to a run already in flight. Unlike `start` this leaves
+  # state.json and samples.jsonl alone, so the window and its history survive.
+  if [[ ! -f "$STATE" ]]; then
+    echo "no run in flight — use start" >&2
+    exit 1
+  fi
+  mkdir -p "$PERF_DIR/bin"
+  cp "$SAMPLER" "$PERF_DIR/bin/seahelm_perf_sample.py"
+  cp "$REPORTER" "$PERF_DIR/bin/seahelm_perf_report.py"
+  chmod +x "$PERF_DIR/bin/"*.py
+  launchctl kickstart -k "$DOMAIN/$LABEL" >/dev/null 2>&1 || {
+    echo "failed to restart $LABEL" >&2; exit 1; }
+  echo "==> reloaded sampler, window and samples preserved"
 }
 
 cmd_stop() {
@@ -160,6 +183,7 @@ PY
 
 case "${1:-}" in
   start) shift; cmd_start "$@" ;;
+  reload) cmd_reload ;;
   stop) cmd_stop ;;
   status) cmd_status ;;
   report) shift; "$PYTHON" "$REPORTER" "$@" ;;

--- a/scripts/perf/seahelm_perf_report.py
+++ b/scripts/perf/seahelm_perf_report.py
@@ -305,13 +305,16 @@ def render_text(report, rows):
 
     render = report.get("render") or {}
     out.append("DASHBOARD RENDER (DEBUG telemetry)")
-    out.append("  observed %sh   full %s (%s/h)   incremental %s (%s/h)   full share %s"
-               % (render.get("observed_hours"), render.get("full_renders"), render.get("full_per_hour"),
-                  render.get("incremental_updates"), render.get("incremental_per_hour"),
-                  fmt(render.get("full_share_pct"), "%")))
-    out.append("  last avg: full %s  incremental %s   max rows %s"
-               % (fmt(render.get("full_avg_ms_last"), "ms", digits=2),
-                  fmt(render.get("incr_avg_ms_last"), "ms", digits=2), render.get("rows_max")))
+    if not render.get("rows_max"):
+        out.append("  no renders seen yet — these counters only advance while the dashboard is on screen")
+    else:
+        out.append("  observed %sh   full %s (%s/h)   incremental %s (%s/h)   full share %s"
+                   % (render.get("observed_hours"), render.get("full_renders"),
+                      fmt(render.get("full_per_hour")), render.get("incremental_updates"),
+                      fmt(render.get("incremental_per_hour")), fmt(render.get("full_share_pct"), "%")))
+        out.append("  last avg: full %s  incremental %s   max rows %s"
+                   % (fmt(render.get("full_avg_ms_last"), "ms", digits=2),
+                      fmt(render.get("incr_avg_ms_last"), "ms", digits=2), render.get("rows_max")))
     out.append("")
 
     panes = report.get("panes") or {}

--- a/scripts/perf/seahelm_perf_report.py
+++ b/scripts/perf/seahelm_perf_report.py
@@ -80,6 +80,34 @@ def segments(rows):
     return out
 
 
+def floor_buckets(points, bucket_seconds=1800):
+    """Per-bucket (hours_in, floor, median, ceiling) for a footprint series.
+
+    Footprint swings by hundreds of MB with load — inside one hour this run has
+    seen 216MB and 1250MB — so a fit over the raw samples largely measures how
+    busy the machine was. A leak instead raises the *minimum* the process ever
+    returns to, and load noise cannot lift a floor. So the floor is the honest
+    growth signal and the raw slope is the noisy one.
+    """
+    if len(points) < 6:
+        return []
+    start = points[0][0]
+    buckets = {}
+    for epoch, value in points:
+        buckets.setdefault(int((epoch - start) // bucket_seconds), []).append(value)
+    out = []
+    for key in sorted(buckets):
+        values = sorted(buckets[key])
+        out.append({
+            "hours_in": round(key * bucket_seconds / 3600.0, 2),
+            "floor_mb": values[0],
+            "median_mb": values[len(values) // 2],
+            "ceiling_mb": values[-1],
+            "samples": len(values),
+        })
+    return out
+
+
 def slope_per_hour(points):
     """Least-squares slope of value over time, in units per hour."""
     if len(points) < 3:
@@ -161,6 +189,19 @@ def analyse(rows):
     # it is only reported once a run is long enough to mean something.
     growth = slope_per_hour(seg_foots) if span_hours >= 1.0 else None
     mem["growth_mb_per_hour"] = round(growth, 2) if growth is not None else None
+
+    buckets = floor_buckets(seg_foots)
+    mem["floor_buckets"] = buckets
+    if len(buckets) >= 3:
+        mem["floor_first_mb"] = buckets[0]["floor_mb"]
+        mem["floor_last_mb"] = buckets[-1]["floor_mb"]
+        floor_slope = slope_per_hour([(b["hours_in"] * 3600, b["floor_mb"]) for b in buckets])
+        mem["floor_mb_per_hour"] = round(floor_slope, 2) if floor_slope is not None else None
+        # A floor that only ever rises is the signature; one that comes back down
+        # is the allocator returning memory, i.e. load rather than a leak.
+        falls = sum(1 for a, b in zip(buckets, buckets[1:]) if b["floor_mb"] < a["floor_mb"])
+        mem["floor_declines"] = falls
+        mem["floor_buckets_count"] = len(buckets)
     threads = [dig(r, "app", "threads") for r in live]
     threads = [t for t in threads if t]
     mem["threads_first"] = threads[0] if threads else None
@@ -288,13 +329,35 @@ def render_text(report, rows):
     out.append("  first %s   last %s   max %s" % (fmt(mem.get("first_mb"), "MB"), fmt(mem.get("last_mb"), "MB"),
                                                   fmt(mem.get("max_mb"), "MB")))
     if mem.get("growth_mb_per_hour") is None:
-        out.append("  growth: needs >=1h in one run to trend (longest so far %sh)"
+        out.append("  raw fit: needs >=1h in one run to trend (longest so far %sh)"
                    % mem.get("growth_window_hours"))
     else:
-        out.append("  growth %s per hour over the longest single run (%sh)"
+        out.append("  raw fit %s per hour over the longest single run (%sh) — noisy, see floor"
                    % (fmt(mem.get("growth_mb_per_hour"), "MB", digits=2), mem.get("growth_window_hours")))
+
+    if mem.get("floor_mb_per_hour") is None:
+        out.append("  floor: needs >=3 half-hour buckets in one run")
+    else:
+        declines = mem.get("floor_declines", 0)
+        count = mem.get("floor_buckets_count", 0)
+        verdict = ("ratcheting — the floor almost never falls" if declines <= max(1, count // 10)
+                   else "floor falls back, so this reads as load, not a leak")
+        out.append("  floor %s → %s (%s per hour, %d/%d buckets fell) — %s"
+                   % (fmt(mem.get("floor_first_mb"), "MB", digits=0),
+                      fmt(mem.get("floor_last_mb"), "MB", digits=0),
+                      fmt(mem.get("floor_mb_per_hour"), "MB", digits=1),
+                      declines, max(0, count - 1), verdict))
     out.append("  threads %s → max %s" % (mem.get("threads_first"), mem.get("threads_max")))
     out.append("")
+
+    buckets = mem.get("floor_buckets") or []
+    if len(buckets) >= 3:
+        out.append("MEMORY FLOOR (30-min buckets of the longest run: floor / median / ceiling)")
+        for bucket in buckets:
+            out.append("  +%5.1fh  %6.0f  %6.0f  %6.0f   (n=%d)"
+                       % (bucket["hours_in"], bucket["floor_mb"], bucket["median_mb"],
+                          bucket["ceiling_mb"], bucket["samples"]))
+        out.append("")
 
     cpu = report.get("cpu") or {}
     out.append("CPU (interval average from cumulative time)")

--- a/scripts/perf/seahelm_perf_sample.py
+++ b/scripts/perf/seahelm_perf_sample.py
@@ -56,11 +56,30 @@ def run(cmd, timeout=15):
 
 
 def app_pid():
+    """The process answering our probes.
+
+    More than one Seahelm can be alive at once — the `.build` app, an Xcode
+    DerivedData build, an XCTest host — and only one of them owns the control
+    socket. Resolving by socket owner keeps the ps metrics describing the same
+    process as `app.memory` and `pane.list`; `pgrep` ordering does not.
+    """
+    out = run(["lsof", "-t", SOCKET_PATH], timeout=15).strip()
+    if out:
+        return int(out.split()[0])
     for name in ("Seahelm", "seahelm"):
         out = run(["pgrep", "-x", name], timeout=5).strip()
         if out:
-            return int(out.split()[0])
+            # Prefer the .build bundle: that is what run.sh launches.
+            pids = [int(p) for p in out.split()]
+            for pid in pids:
+                if "/.build/" in run(["ps", "-o", "command=", "-p", str(pid)], timeout=5):
+                    return pid
+            return pids[0]
     return None
+
+
+def binary_path(pid):
+    return run(["ps", "-o", "command=", "-p", str(pid)], timeout=5).strip().split()[0] if pid else None
 
 
 def _seconds(value):
@@ -235,7 +254,10 @@ TELEMETRY_RE = re.compile(
 )
 
 
-def _render_window(window_s):
+def _render_window(window_s, pid):
+    # Scoped to the live app's pid on purpose: the XCTest host is also called
+    # "Seahelm", and each test builds a fresh DashboardOverviewView whose first
+    # render logs — a test run would otherwise masquerade as app render churn.
     out = run(
         [
             "/usr/bin/log",
@@ -245,14 +267,14 @@ def _render_window(window_s):
             "--style",
             "compact",
             "--predicate",
-            'process == "Seahelm" AND eventMessage CONTAINS "[DashboardOverview]"',
+            'processIdentifier == %d AND eventMessage CONTAINS "[DashboardOverview]"' % pid,
         ],
         timeout=60,
     )
     return TELEMETRY_RE.findall(out)
 
 
-def render_metrics(window_s, fallback_s=900):
+def render_metrics(window_s, pid, fallback_s=900):
     """Last DEBUG render telemetry line the app emitted inside the window.
 
     The app only logs when the overview actually renders, and at most once per
@@ -262,9 +284,9 @@ def render_metrics(window_s, fallback_s=900):
     rebuilt; the report treats a negative delta as a reset, not as progress.
     """
     stale = False
-    matches = _render_window(window_s)
+    matches = _render_window(window_s, pid)
     if not matches:
-        matches = _render_window(fallback_s)
+        matches = _render_window(fallback_s, pid)
         stale = True
     if not matches:
         return None
@@ -325,7 +347,8 @@ def stop_launchd_job():
 # ---------------------------------------------------------------- main
 
 
-def main():
+def sample_once():
+    """One pass. Returns True when the run has reached its deadline."""
     os.makedirs(PERF_DIR, exist_ok=True)
     now = time.time()
     state = load_state()
@@ -344,9 +367,10 @@ def main():
         if metrics is None:
             row["app_down"] = True
         else:
+            metrics["binary"] = binary_path(pid)
             row["app"] = metrics
             row.update(probe())
-            row["render"] = render_metrics(interval + 20)
+            row["render"] = render_metrics(interval + 20, pid)
 
     row["zmx"] = zmx_metrics()
     row["sys"] = system_metrics()
@@ -401,8 +425,44 @@ def main():
         with open(SAMPLES_PATH, "a") as handle:
             handle.write(json.dumps({"ts": row["ts"], "epoch": int(now), "event": "monitor_stopped"}) + "\n")
         stop_launchd_job()
-        return
+        return True
     save_state(state)
+    return False
+
+
+def loop(interval):
+    """Sample on a drift-corrected schedule until the deadline.
+
+    launchd's StartInterval turned out to be advisory: on a machine deep in swap
+    it coalesced 60s ticks into 3-minute ones. Owning the clock here keeps the
+    cadence honest and skips a python start-up per sample.
+    """
+    started = time.monotonic()
+    tick = 0
+    while True:
+        try:
+            if sample_once():
+                return 0
+        except Exception as exc:  # one bad pass must not end a 48h run
+            sys.stderr.write("sample failed: %s: %s\n" % (type(exc).__name__, exc))
+            sys.stderr.flush()
+        tick += 1
+        target = started + tick * interval
+        # After a system sleep the target may be far in the past; skip the
+        # missed ticks rather than firing a burst to catch up.
+        while target < time.monotonic():
+            tick += 1
+            target = started + tick * interval
+        time.sleep(max(0.0, target - time.monotonic()))
+
+
+def main():
+    if "--loop" in sys.argv:
+        index = sys.argv.index("--loop")
+        interval = float(sys.argv[index + 1]) if len(sys.argv) > index + 1 else 60.0
+        return loop(interval)
+    sample_once()
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes found by running the 48h monitor from #38 against itself, plus the analysis change that made its memory numbers trustworthy.

## Three defects in the sampler

**Cadence.** launchd's `StartInterval` is advisory: on a machine deep in swap it coalesced 60s ticks into ~193s ones, so the run sampled at a third of its stated resolution. The sampler now keeps its own clock (`--loop N`) under `KeepAlive`, which also drops a python start-up per sample.

**Target process.** More than one process is named `Seahelm` — the `.build` app, an Xcode DerivedData build, an XCTest host — and only one owns the control socket. `ps` metrics were resolved by `pgrep` ordering while `app.memory`/`pane.list` came from whoever answered the socket, so a single row could describe two different processes. Now resolved by socket owner, with the binary path recorded in each row.

**Render source.** Telemetry matched on process name, and the XCTest host is also called `Seahelm` — every test builds a fresh `DashboardOverviewView` whose first render logs. Every render row collected before this fix was test noise. The predicate is now scoped to the live app's pid.

Also adds `reload`, which applies sampler fixes to a run already in flight — `start` archives the samples and resets the deadline, which is the wrong trade 14 hours into a 48h window.

## Memory floor

Footprint swings by hundreds of MB with load (216MB and 1250MB inside one hour), so a least-squares fit over raw samples largely measures how busy the machine was — that is how a 1.15h window produced a confident "+358 MB/h".

A leak has a shape load noise cannot fake: it raises the *minimum* the process ever returns to. The report now buckets the longest single run by half hours and reports the floor, using the count of buckets whose floor fell as the verdict:

```
raw fit 58.60MB per hour over the longest single run (14.7h) — noisy, see floor
floor 414MB → 1486MB (57.7MB per hour, 0/29 buckets fell) — ratcheting
```

0 of 29 buckets falling over 14.7h is a leak. A series that merely tracks load drops back between peaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)