### PR TITLE
fix: stop leaking a viewport buffer on every ghostty_surface_read_text

### DIFF
--- a/Sources/Terminal/GhosttyNSView.swift
+++ b/Sources/Terminal/GhosttyNSView.swift
@@ -620,7 +620,7 @@ class GhosttyNSView: NSView, NSTextInputClient {
         guard ghostty_surface_has_selection(surface) else { return nil }
         var text = ghostty_text_s()
         guard ghostty_surface_read_selection(surface, &text) else { return nil }
-        defer { ghostty_surface_free_text(surface, &text) }
+        defer { ghostty_surface_free_text(&text) }
         guard let cString = text.text else { return nil }
         let s = String(cString: cString)
         return s.isEmpty ? nil : s
@@ -883,7 +883,7 @@ class GhosttyNSView: NSView, NSTextInputClient {
             rectangle: false
         )
         guard ghostty_surface_read_text(surface, sel, &text) else { return nil }
-        defer { ghostty_surface_free_text(surface, &text) }
+        defer { ghostty_surface_free_text(&text) }
         guard let cString = text.text else { return nil }
         return String(cString: cString)
     }

--- a/Sources/Terminal/Station.swift
+++ b/Sources/Terminal/Station.swift
@@ -457,7 +457,14 @@ class Station {
                         bytes = Array(UnsafeBufferPointer(start: $0, count: Int(text.text_len)))
                     }
                 }
-                ghostty_surface_free_text(surface, &text)
+                // No surface argument: libghostty implements this as
+                // `free_text(ptr: *Text)` and reads the struct straight out of
+                // x0, so the surface-first form upstream's header declares made
+                // it dereference the surface, find nothing to free, and return.
+                // This poll runs per pane every 2s, so that no-op leaked a
+                // viewport buffer each time — 105 MB/h across 19 panes.
+                // scripts/check-ghostty-abi.py guards the declaration.
+                ghostty_surface_free_text(&text)
             }
         }
         ghosttyLock.unlock()

--- a/ghostty.h
+++ b/ghostty.h
@@ -1130,7 +1130,7 @@ bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 bool ghostty_surface_read_text(ghostty_surface_t,
                                ghostty_selection_s,
                                ghostty_text_s*);
-void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
+void ghostty_surface_free_text(ghostty_text_s*);
 
 #ifdef __APPLE__
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);

--- a/scripts/check-ghostty-abi.py
+++ b/scripts/check-ghostty-abi.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Fail the build when ghostty.h declares a function libghostty implements
+differently.
+
+C lets a caller pass more arguments than the callee reads, so an over-declared
+parameter is silent at compile time and wrong at run time: upstream commit
+c5f921bb0 declared `ghostty_surface_free_text(surface, text)` for an
+implementation that takes only `text`, and the arm64 build reads its argument
+from x0. Every call therefore handed it the surface, it found nothing to free,
+and each `ghostty_surface_read_text` buffer leaked — 105 MB/h across 19 panes,
+invisible for 15 months.
+
+Comparing the header against the framework's own copy would not have caught it:
+all three copies are byte-identical and all three are wrong. The invariant worth
+enforcing is header-vs-implementation, so this compares the declarations in
+`ghostty.h` with the `export fn` signatures in the vendored Zig source.
+
+Usage: check-ghostty-abi.py [header] [zig-source-root]
+Exit 0 when every shared symbol agrees, 1 on any mismatch, 2 when inputs are
+missing (treated as a hard failure: an unrunnable check must not read as a pass).
+"""
+
+import glob
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_HEADER = os.path.join(REPO, "ghostty.h")
+DEFAULT_ZIG_ROOT = os.path.join(REPO, "ghostty", "src")
+
+# A local patch to the vendored header is legitimate — it is how a wrong upstream
+# declaration gets corrected — so the check reads what is actually compiled and
+# never assumes the header matches upstream.
+DECL = re.compile(r"\b\w+[\s*]+(ghostty_\w+)\s*\(([^;]*?)\)\s*;", re.S)
+EXPORT = re.compile(r"export fn (ghostty_\w+)\s*\(([^)]*)\)", re.S)
+
+
+def count_args(text):
+    """Parameters in a C or Zig parameter list.
+
+    Splits on top-level commas and drops empty segments: Zig permits a trailing
+    comma in a multi-line parameter list, and counting commas instead of
+    parameters reported every such function as one argument too many.
+    """
+    text = text.strip()
+    if text in ("", "void"):
+        return 0
+    parts, depth, current = [], 0, ""
+    for char in text:
+        if char in "(<[":
+            depth += 1
+        elif char in ")>]":
+            depth -= 1
+        if char == "," and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += char
+    parts.append(current)
+    return len([p for p in parts if p.strip()])
+
+
+def parse_header(path):
+    source = re.sub(r"//[^\n]*", "", open(path, errors="ignore").read())
+    return {m.group(1): count_args(m.group(2)) for m in DECL.finditer(source)}
+
+
+def parse_zig(root):
+    out = {}
+    for path in glob.glob(os.path.join(root, "**", "*.zig"), recursive=True):
+        for m in EXPORT.finditer(open(path, errors="ignore").read()):
+            out[m.group(1)] = (count_args(m.group(2)), os.path.relpath(path, REPO))
+    return out
+
+
+def main():
+    header = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_HEADER
+    zig_root = sys.argv[2] if len(sys.argv) > 2 else DEFAULT_ZIG_ROOT
+
+    if not os.path.exists(header):
+        sys.stderr.write("ghostty ABI check: header not found: %s\n" % header)
+        return 2
+    if not os.path.isdir(zig_root):
+        sys.stderr.write(
+            "ghostty ABI check: zig source not found: %s\n"
+            "  the submodule is needed to verify declarations; run scripts/setup.sh\n" % zig_root
+        )
+        return 2
+
+    declared = parse_header(header)
+    implemented = parse_zig(zig_root)
+    shared = sorted(set(declared) & set(implemented))
+    if not shared:
+        sys.stderr.write("ghostty ABI check: parsed no shared symbols — check is not working\n")
+        return 2
+
+    bad = [(k, declared[k], implemented[k][0], implemented[k][1])
+           for k in shared if declared[k] != implemented[k][0]]
+    if not bad:
+        print("ghostty ABI check: %d symbols agree" % len(shared))
+        return 0
+
+    sys.stderr.write("ghostty ABI check: %d of %d symbols disagree\n" % (len(bad), len(shared)))
+    for name, want, got, path in bad:
+        sys.stderr.write(
+            "  %s: header declares %d arg(s), %s implements %d\n" % (name, want, path, got)
+        )
+    sys.stderr.write(
+        "\nA caller compiled against the header will pass arguments the implementation\n"
+        "never reads. Correct the declaration in ghostty.h to match the implementation\n"
+        "(and every call site), or re-vendor a header that matches the linked binary.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -48,6 +48,27 @@ XC_HEADER="$REPO_ROOT/GhosttyKit.xcframework/macos-arm64_x86_64/Headers/ghostty.
 if [ -f "$XC_HEADER" ]; then
     cp "$XC_HEADER" "$REPO_ROOT/ghostty.h"
     echo "==> Synced ghostty.h from GhosttyKit.xcframework"
+
+    # Re-apply corrections to declarations upstream got wrong, because this sync
+    # would otherwise silently restore them. Upstream c5f921bb0 declares a
+    # surface parameter `ghostty_surface_free_text` does not take; calling it
+    # that way makes the free a no-op and leaks every read_text buffer (measured
+    # at 105 MB/h across 19 panes). Idempotent: matches only the upstream form.
+    /usr/bin/sed -i '' \
+        's|^void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s\*);|void ghostty_surface_free_text(ghostty_text_s*);|' \
+        "$REPO_ROOT/ghostty.h"
+    echo "==> Re-applied local ghostty.h declaration fixes"
+fi
+
+# The sync above is the moment a wrong upstream declaration enters the build, so
+# verify here rather than trusting it. Comparing headers would not help — the
+# framework ships the same wrong header — so this compares each declaration
+# against the Zig implementation it is supposed to describe.
+if [ -f "$REPO_ROOT/scripts/check-ghostty-abi.py" ]; then
+    if ! /usr/bin/python3 "$REPO_ROOT/scripts/check-ghostty-abi.py"; then
+        echo "==> ghostty.h disagrees with libghostty — see above. Setup aborted." >&2
+        exit 1
+    fi
 fi
 
 # Copy Ghostty resources for app bundle


### PR DESCRIPTION
`ghostty_surface_free_text` has been a no-op since upstream c5f921bb0. Every `ghostty_surface_read_text` buffer leaked — 97% of all heap growth, 105 MB/h across 19 panes.

## The bug

libghostty implements it as `free_text(ptr: *Text)` — **one** argument, read from `x0`. `ghostty.h` declares it as `(ghostty_surface_t, ghostty_text_s*)` — **two**. C lets a caller pass an argument the callee never reads, so this was silent at compile time and wrong at run time.

Disassembling the linked `libghostty.a` (both slices):

```asm
_ghostty_surface_free_text:
    ldr  x1, [x0, #0x18]      ; reads the struct out of the FIRST argument
    cbz  x1, ...ret           ; surface+0x18 is null → return, freeing nothing
```

Callers passed `(surface, &text)`, so `x0` was the surface. The free dereferenced it, found nothing, and returned.

## How it was found

The status poll reads a viewport per pane every 2s, and the leak rate tracked poll volume exactly: ~10 blocks/s at ~1.4KB each, 599,115 live `non-object` allocations totalling 1.52GB after 15.5h. `heap` snapshots 3 minutes apart attributed 97% of growth to raw malloc rather than any Swift or ObjC class, which pointed at the C boundary.

## Verification

Measured by **footprint floor** per bucket, not a fit through the raw samples: load moves the ceiling by hundreds of MB, but only a leak raises the minimum the process returns to.

Both windows are single uninterrupted processes with no restarts, steady state only (first 4h discarded as start-up ramp):

| | before (pid 50428) | after (pid 92807) |
|---|---|---|
| window | 11.5h / 19 panes | 10.0h / 13 panes |
| floor | 1522 → **2680 MB** | 825 → **866 MB** |
| per-pane rate | **+5.30 MB/h** | **+0.32 MB/h** |
| buckets whose floor fell | **0 / 23 (0%)** | **11 / 20 (55%)** |

**16.5× lower per pane, and the ratchet is gone.** Pane count held at exactly 13.0 for 13 consecutive hours in the after-window, so the per-pane normalisation is not carrying the result.

Hour by hour after the fix — 13 hours, net **+47 MB** (the baseline gained +1158 MB over the same span):

```
+2h  819   -0      +8h  840   -1
+3h  824   +6      +9h  844   +4
+4h  825   +0     +10h  841   -3
+5h  845  +20     +11h  867  +26
+6h  842   -3     +12h  857  -10
+7h  841   -2     +13h  851   -6
```

The noisy raw fit agrees for the first time (**+0.12 MB/h**), and the report's own verdict flips:

```
floor 373MB → 866MB (10.1MB per hour, 14/28 buckets fell)
  — floor falls back, so this reads as load, not a leak
```

(The 10.1 MB/h there includes the +446MB start-up ramp in hour 0→1; steady state is flat.)

## No regression from the free path finally executing

p95 **0.5ms** across the 14h window. Five samples exceeded 500ms (max 19.2s), between 48 and 76 minutes after launch.

They are not the free path. Every one coincides with a system-wide swap burst — swap jumping 1.3–1.5 GB inside a single sample interval with free memory at 99–455 MB — and Seahelm's own CPU was *low* at those moments (5.2%, 11.6%, 14.0%), i.e. the main thread was waiting on paging rather than working. A broken free would stall in proportion to poll volume, continuously, not in step with the machine running out of memory.

(An earlier revision of this description claimed these stalls clustered in the first 20 minutes and blamed start-up surface restore. That was wrong — measured against process start they spread across 11–126 minutes, with only 2 of 12 inside 20 minutes.)

## Why a header diff would not catch this

All three copies of `ghostty.h` — repo root, vendored, and the one shipped inside `GhosttyKit.xcframework` — are **byte-identical, and all three are wrong**. The invariant worth enforcing is declaration-vs-implementation, so `scripts/check-ghostty-abi.py` compares every `ghostty_*` declaration against its `export fn` signature. 88 symbols; this was the only mismatch.

`setup.sh` copies the framework's header over the repo's, which would silently restore the wrong declaration, so it now re-applies the correction after that sync and fails if the check does not pass.

Fixes the memory half of #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
