### PR TITLE
fix: reap orphaned zmx client processes at startup

### DIFF
--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -126,6 +126,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if !cleaned.isEmpty {
                 NSLog("[App] Cleaned %d orphan zmx session(s)", cleaned.count)
             }
+            // Separate from the session sweep above: these are client processes,
+            // not sessions. They survive the app that spawned them and spin at
+            // 20-70% CPU indefinitely, so each restart adds a few more.
+            let clients = SessionManager.cleanupOrphanZmxClients()
+            if !clients.isEmpty {
+                NSLog("[App] Killed %d orphan zmx client process(es)", clients.count)
+            }
         }
     }
 

--- a/Sources/Core/SessionManager.swift
+++ b/Sources/Core/SessionManager.swift
@@ -167,6 +167,69 @@ enum SessionManager {
         }
     }
 
+    // MARK: - Orphan zmx client processes
+
+    /// One `zmx` process as the client sweep sees it.
+    struct ZmxProcess: Equatable {
+        let pid: Int32
+        let ppid: Int32
+        let command: String
+    }
+
+    /// `zmx attach`/`run` clients that no longer have anyone to serve.
+    ///
+    /// These do not exit when Seahelm dies — they spin at 20-70% CPU forever,
+    /// and every restart leaves a few more (20 were found holding 4.3 cores
+    /// after a day of restarts). The test is deliberately *not* "does the target
+    /// session still exist": the two worst offenders found were spinning against
+    /// sessions that were perfectly alive, and `zmx list` showed `clients=1`,
+    /// i.e. they had never attached at all. What identifies them is having no
+    /// live parent while not being a session daemon themselves.
+    static func orphanZmxClientPids(processes: [ZmxProcess], daemonPids: Set<Int32>) -> [Int32] {
+        // Without a daemon list every session daemon looks like an orphan, and
+        // killing those ends the agents inside them. Refuse rather than guess.
+        guard !daemonPids.isEmpty else { return [] }
+        return processes.compactMap { proc in
+            guard !daemonPids.contains(proc.pid) else { return nil }   // session daemon
+            guard proc.ppid == 1 else { return nil }                   // has a live parent
+            return proc.pid
+        }
+    }
+
+    /// Parse `ps -axo pid=,ppid=,command=` down to the zmx processes.
+    static func parseZmxProcesses(psOutput: String) -> [ZmxProcess] {
+        psOutput.components(separatedBy: .newlines).compactMap { line in
+            let parts = line.split(maxSplits: 2, whereSeparator: \.isWhitespace)
+            guard parts.count == 3,
+                  let pid = Int32(parts[0]),
+                  let ppid = Int32(parts[1]) else { return nil }
+            let command = String(parts[2])
+            // Match the vendored binary's path, not a bare "zmx": an agent's own
+            // command line can mention zmx without being one.
+            guard command.contains("/bin/zmx ") || command.hasSuffix("/bin/zmx") else { return nil }
+            return ZmxProcess(pid: pid, ppid: ppid, command: command)
+        }
+    }
+
+    /// Kill orphaned zmx clients. Returns the pids reaped. Safe to call at
+    /// startup: sessions and their daemons are left alone.
+    @discardableResult
+    static func cleanupOrphanZmxClients(listOutput: String? = nil, psOutput: String? = nil) -> [Int32] {
+        let list = listOutput ?? ProcessRunner.output([ZmxLocator.executable(), "list"]) ?? ""
+        let daemonPids = Set(list.components(separatedBy: .newlines).compactMap { line -> Int32? in
+            guard let value = zmxListField(line, "pid=") else { return nil }
+            return Int32(value)
+        })
+        let ps = psOutput ?? ProcessRunner.output(["ps", "-axo", "pid=,ppid=,command="]) ?? ""
+        let orphans = orphanZmxClientPids(processes: parseZmxProcesses(psOutput: ps), daemonPids: daemonPids)
+        for pid in orphans {
+            // SIGKILL, not SIGTERM: the spin loop never reaches a signal handler,
+            // so a terminate is simply ignored.
+            kill(pid, SIGKILL)
+        }
+        return orphans
+    }
+
     /// Extract a `key=value` field (value runs up to the next whitespace) from a
     /// `zmx list` line, or nil if absent.
     private static func zmxListField(_ line: String, _ key: String) -> String? {

--- a/Sources/Terminal/GhosttyNSView.swift
+++ b/Sources/Terminal/GhosttyNSView.swift
@@ -620,7 +620,7 @@ class GhosttyNSView: NSView, NSTextInputClient {
         guard ghostty_surface_has_selection(surface) else { return nil }
         var text = ghostty_text_s()
         guard ghostty_surface_read_selection(surface, &text) else { return nil }
-        defer { ghostty_surface_free_text(surface, &text) }
+        defer { ghostty_surface_free_text(&text) }
         guard let cString = text.text else { return nil }
         let s = String(cString: cString)
         return s.isEmpty ? nil : s
@@ -883,7 +883,7 @@ class GhosttyNSView: NSView, NSTextInputClient {
             rectangle: false
         )
         guard ghostty_surface_read_text(surface, sel, &text) else { return nil }
-        defer { ghostty_surface_free_text(surface, &text) }
+        defer { ghostty_surface_free_text(&text) }
         guard let cString = text.text else { return nil }
         return String(cString: cString)
     }

--- a/Sources/Terminal/Station.swift
+++ b/Sources/Terminal/Station.swift
@@ -457,7 +457,14 @@ class Station {
                         bytes = Array(UnsafeBufferPointer(start: $0, count: Int(text.text_len)))
                     }
                 }
-                ghostty_surface_free_text(surface, &text)
+                // No surface argument: libghostty implements this as
+                // `free_text(ptr: *Text)` and reads the struct straight out of
+                // x0, so the surface-first form upstream's header declares made
+                // it dereference the surface, find nothing to free, and return.
+                // This poll runs per pane every 2s, so that no-op leaked a
+                // viewport buffer each time — 105 MB/h across 19 panes.
+                // scripts/check-ghostty-abi.py guards the declaration.
+                ghostty_surface_free_text(&text)
             }
         }
         ghosttyLock.unlock()

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -193,4 +193,52 @@ class SessionManagerTests: XCTestCase {
         XCTAssertTrue(SessionManager.parseZmxSessions(listOutput: "\n  \n").isEmpty)
     }
 
+    // MARK: - Orphan zmx client processes
+
+    private let daemons: Set<Int32> = [100, 200]
+
+    private func proc(_ pid: Int32, _ ppid: Int32, _ cmd: String = "/App/Contents/Resources/bin/zmx attach s") -> SessionManager.ZmxProcess {
+        SessionManager.ZmxProcess(pid: pid, ppid: ppid, command: cmd)
+    }
+
+    func testOrphanClientIsReaped() {
+        let pids = SessionManager.orphanZmxClientPids(processes: [proc(300, 1)], daemonPids: daemons)
+        XCTAssertEqual(pids, [300])
+    }
+
+    /// Session daemons are ppid 1 by design; reaping one ends the agent inside.
+    func testSessionDaemonIsNeverReaped() {
+        let pids = SessionManager.orphanZmxClientPids(processes: [proc(100, 1), proc(200, 1)], daemonPids: daemons)
+        XCTAssertEqual(pids, [])
+    }
+
+    func testClientWithLiveParentIsKept() {
+        let pids = SessionManager.orphanZmxClientPids(processes: [proc(300, 9478)], daemonPids: daemons)
+        XCTAssertEqual(pids, [])
+    }
+
+    /// Without a daemon list every daemon looks orphaned, so the sweep must
+    /// refuse rather than guess.
+    func testEmptyDaemonListReapsNothing() {
+        let pids = SessionManager.orphanZmxClientPids(processes: [proc(300, 1)], daemonPids: [])
+        XCTAssertEqual(pids, [])
+    }
+
+    /// The two worst offenders found were spinning against live sessions, so a
+    /// "target session is gone" test would have missed them entirely.
+    func testOrphanAgainstLiveSessionIsStillReaped() {
+        let live = proc(300, 1, "/App/Contents/Resources/bin/zmx attach seahelm-workspace-saas-mono")
+        XCTAssertEqual(SessionManager.orphanZmxClientPids(processes: [live], daemonPids: daemons), [300])
+    }
+
+    func testParsePsOutputPicksOnlyZmxBinaries() {
+        let ps = """
+          300     1 /Volumes/x/Seahelm.app/Contents/Resources/bin/zmx attach seahelm-a
+          301  9478 /Volumes/x/Seahelm.app/Contents/Resources/bin/zmx run seahelm-b /bin/zsh
+          302     1 /usr/bin/node --flag zmx-ish-name
+          303     1 claude --resume zmx
+        """
+        let parsed = SessionManager.parseZmxProcesses(psOutput: ps)
+        XCTAssertEqual(parsed.map(\.pid), [300, 301], "only the vendored zmx binary counts")
+    }
 }

--- a/ghostty.h
+++ b/ghostty.h
@@ -1130,7 +1130,7 @@ bool ghostty_surface_read_selection(ghostty_surface_t, ghostty_text_s*);
 bool ghostty_surface_read_text(ghostty_surface_t,
                                ghostty_selection_s,
                                ghostty_text_s*);
-void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s*);
+void ghostty_surface_free_text(ghostty_text_s*);
 
 #ifdef __APPLE__
 void ghostty_surface_set_display_id(ghostty_surface_t, uint32_t);

--- a/run.sh
+++ b/run.sh
@@ -56,8 +56,15 @@ echo "==> Killing existing Seahelm..."
 # PRODUCT_NAME is Seahelm; kill both casings.
 # Do NOT pkill `zmx attach` processes here: SIGTERM to an attach client kills
 # its session daemon (and the agent running inside) — that was the "restart
-# loses all pane content" bug. Orphaned attach clients are harmless; the app
-# re-attaches alongside them.
+# loses all pane content" bug.
+#
+# The clients left behind are NOT harmless, as this comment used to claim. They
+# never exit; launchd adopts them and they spin at 20-70% CPU forever, so every
+# restart adds a few more (20 were found holding ~4.3 cores after a day of
+# restarts). They cannot be reaped from here either — this script has no way to
+# tell an orphan from the attach client of a session that is still in use.
+# `SessionManager.cleanupOrphanZmxClients` does it at app startup instead, where
+# `zmx list` identifies the session daemons that must survive. See #44.
 killall Seahelm seahelm 2>/dev/null || true
 sleep 1
 

--- a/scripts/check-ghostty-abi.py
+++ b/scripts/check-ghostty-abi.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Fail the build when ghostty.h declares a function libghostty implements
+differently.
+
+C lets a caller pass more arguments than the callee reads, so an over-declared
+parameter is silent at compile time and wrong at run time: upstream commit
+c5f921bb0 declared `ghostty_surface_free_text(surface, text)` for an
+implementation that takes only `text`, and the arm64 build reads its argument
+from x0. Every call therefore handed it the surface, it found nothing to free,
+and each `ghostty_surface_read_text` buffer leaked — 105 MB/h across 19 panes,
+invisible for 15 months.
+
+Comparing the header against the framework's own copy would not have caught it:
+all three copies are byte-identical and all three are wrong. The invariant worth
+enforcing is header-vs-implementation, so this compares the declarations in
+`ghostty.h` with the `export fn` signatures in the vendored Zig source.
+
+Usage: check-ghostty-abi.py [header] [zig-source-root]
+Exit 0 when every shared symbol agrees, 1 on any mismatch, 2 when inputs are
+missing (treated as a hard failure: an unrunnable check must not read as a pass).
+"""
+
+import glob
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_HEADER = os.path.join(REPO, "ghostty.h")
+DEFAULT_ZIG_ROOT = os.path.join(REPO, "ghostty", "src")
+
+# A local patch to the vendored header is legitimate — it is how a wrong upstream
+# declaration gets corrected — so the check reads what is actually compiled and
+# never assumes the header matches upstream.
+DECL = re.compile(r"\b\w+[\s*]+(ghostty_\w+)\s*\(([^;]*?)\)\s*;", re.S)
+EXPORT = re.compile(r"export fn (ghostty_\w+)\s*\(([^)]*)\)", re.S)
+
+
+def count_args(text):
+    """Parameters in a C or Zig parameter list.
+
+    Splits on top-level commas and drops empty segments: Zig permits a trailing
+    comma in a multi-line parameter list, and counting commas instead of
+    parameters reported every such function as one argument too many.
+    """
+    text = text.strip()
+    if text in ("", "void"):
+        return 0
+    parts, depth, current = [], 0, ""
+    for char in text:
+        if char in "(<[":
+            depth += 1
+        elif char in ")>]":
+            depth -= 1
+        if char == "," and depth == 0:
+            parts.append(current)
+            current = ""
+        else:
+            current += char
+    parts.append(current)
+    return len([p for p in parts if p.strip()])
+
+
+def parse_header(path):
+    source = re.sub(r"//[^\n]*", "", open(path, errors="ignore").read())
+    return {m.group(1): count_args(m.group(2)) for m in DECL.finditer(source)}
+
+
+def parse_zig(root):
+    out = {}
+    for path in glob.glob(os.path.join(root, "**", "*.zig"), recursive=True):
+        for m in EXPORT.finditer(open(path, errors="ignore").read()):
+            out[m.group(1)] = (count_args(m.group(2)), os.path.relpath(path, REPO))
+    return out
+
+
+def main():
+    header = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_HEADER
+    zig_root = sys.argv[2] if len(sys.argv) > 2 else DEFAULT_ZIG_ROOT
+
+    if not os.path.exists(header):
+        sys.stderr.write("ghostty ABI check: header not found: %s\n" % header)
+        return 2
+    if not os.path.isdir(zig_root):
+        sys.stderr.write(
+            "ghostty ABI check: zig source not found: %s\n"
+            "  the submodule is needed to verify declarations; run scripts/setup.sh\n" % zig_root
+        )
+        return 2
+
+    declared = parse_header(header)
+    implemented = parse_zig(zig_root)
+    shared = sorted(set(declared) & set(implemented))
+    if not shared:
+        sys.stderr.write("ghostty ABI check: parsed no shared symbols — check is not working\n")
+        return 2
+
+    bad = [(k, declared[k], implemented[k][0], implemented[k][1])
+           for k in shared if declared[k] != implemented[k][0]]
+    if not bad:
+        print("ghostty ABI check: %d symbols agree" % len(shared))
+        return 0
+
+    sys.stderr.write("ghostty ABI check: %d of %d symbols disagree\n" % (len(bad), len(shared)))
+    for name, want, got, path in bad:
+        sys.stderr.write(
+            "  %s: header declares %d arg(s), %s implements %d\n" % (name, want, path, got)
+        )
+    sys.stderr.write(
+        "\nA caller compiled against the header will pass arguments the implementation\n"
+        "never reads. Correct the declaration in ghostty.h to match the implementation\n"
+        "(and every call site), or re-vendor a header that matches the linked binary.\n"
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -48,6 +48,27 @@ XC_HEADER="$REPO_ROOT/GhosttyKit.xcframework/macos-arm64_x86_64/Headers/ghostty.
 if [ -f "$XC_HEADER" ]; then
     cp "$XC_HEADER" "$REPO_ROOT/ghostty.h"
     echo "==> Synced ghostty.h from GhosttyKit.xcframework"
+
+    # Re-apply corrections to declarations upstream got wrong, because this sync
+    # would otherwise silently restore them. Upstream c5f921bb0 declares a
+    # surface parameter `ghostty_surface_free_text` does not take; calling it
+    # that way makes the free a no-op and leaks every read_text buffer (measured
+    # at 105 MB/h across 19 panes). Idempotent: matches only the upstream form.
+    /usr/bin/sed -i '' \
+        's|^void ghostty_surface_free_text(ghostty_surface_t, ghostty_text_s\*);|void ghostty_surface_free_text(ghostty_text_s*);|' \
+        "$REPO_ROOT/ghostty.h"
+    echo "==> Re-applied local ghostty.h declaration fixes"
+fi
+
+# The sync above is the moment a wrong upstream declaration enters the build, so
+# verify here rather than trusting it. Comparing headers would not help — the
+# framework ships the same wrong header — so this compares each declaration
+# against the Zig implementation it is supposed to describe.
+if [ -f "$REPO_ROOT/scripts/check-ghostty-abi.py" ]; then
+    if ! /usr/bin/python3 "$REPO_ROOT/scripts/check-ghostty-abi.py"; then
+        echo "==> ghostty.h disagrees with libghostty — see above. Setup aborted." >&2
+        exit 1
+    fi
 fi
 
 # Copy Ghostty resources for app bundle


### PR DESCRIPTION
Closes the actionable half of #44.

`zmx attach`/`run` clients do not exit when the Seahelm that spawned them dies. They are adopted by launchd and spin at 20-70% CPU indefinitely, so every restart leaves a few more behind.

Found alive after one day of restarts: **20 processes, oldest 2d3h, together ~4.3 cores**. Reaping them moved the 1-minute load average **44.87 → 18.12**.

## The test is not "is the target session gone"

That was my first hypothesis and it is wrong. The two heaviest offenders — 64.8% and 63.8% CPU — were spinning against sessions that were **perfectly alive**. `zmx list` reported `clients=1` for both, and that one client was the running app, so the orphans had never attached at all.

An implementation using session existence as the predicate would miss exactly the worst cases. What identifies an orphan is **no live parent, and not a session daemon**:

```
for each process whose command is the vendored /bin/zmx:
    pid ∈ daemon pids from `zmx list`  → keep
    ppid != 1                          → keep
    otherwise                          → SIGKILL
```

## Safety

- Session daemons are `ppid == 1` by design, so daemon pids are excluded explicitly.
- If `zmx list` returns nothing, the sweep **does nothing** rather than treat every daemon as an orphan — failing open there would end every agent.
- `SIGKILL` is required: the spin loop never reaches a signal handler, so these ignore `SIGTERM` (verified).
- Only the vendored `/bin/zmx` path matches, so an agent command line that merely mentions zmx is not swept.

Verified by hand before writing the code: each kill was followed by a check that all 8 sessions survived, and for the two orphans whose sessions were live, `pane.read` returned **byte-identical** content afterwards with `clients=1` unchanged.

## Not covered here

The root cause is in zmx — an attach client should exit when its parent goes away instead of busy-looping. This PR is the containment. #44 also notes that the `run.sh:57` comment calling orphaned attach clients "harmless" is wrong; that is left for whoever fixes the zmx side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)