### PR TITLE
perf: sleep at most one pane per auto-sleep tick

### DIFF
--- a/Sources/App/TerminalCoordinator.swift
+++ b/Sources/App/TerminalCoordinator.swift
@@ -418,20 +418,32 @@ class TerminalCoordinator {
         var since = offscreenSince
         for id in visible { since.removeValue(forKey: id) }
 
-        var sleepIds: [String] = []
+        var due: [(id: String, firstSeen: Date)] = []
         for id in sleepable where !visible.contains(id) {
             guard let firstSeen = since[id] else {
                 since[id] = now
                 continue
             }
             if now.timeIntervalSince(firstSeen) >= idleAfter {
-                sleepIds.append(id)
-                since.removeValue(forKey: id)
+                due.append((id, firstSeen))
             }
         }
+
+        // One per tick. `Station.sleep()` frees a Metal surface on the main
+        // thread, and sleeping a batch in a single pass produced 13-20s of main
+        // thread stall — the app looks dead. The threshold is minutes, so a
+        // backlog drains a pane every tick with nobody waiting on it. Oldest
+        // first, so the queue is deterministic rather than dictionary order.
+        guard let chosen = due.min(by: { $0.firstSeen < $1.firstSeen })?.id else {
+            let known = visible.union(sleepable)
+            return ([], since.filter { known.contains($0.key) })
+        }
+        // Only the chosen pane's clock is cleared; the rest stay due and are
+        // picked up on following ticks.
+        since.removeValue(forKey: chosen)
         // Closed panes would otherwise keep their entry forever.
         let known = visible.union(sleepable)
-        return (sleepIds, since.filter { known.contains($0.key) })
+        return ([chosen], since.filter { known.contains($0.key) })
     }
 
     /// Sleep panes that have stayed off screen past `idleAfter`. Main thread.

--- a/Tests/TerminalCoordinatorTests.swift
+++ b/Tests/TerminalCoordinatorTests.swift
@@ -61,6 +61,43 @@ final class TerminalCoordinatorTests: XCTestCase {
         XCTAssertNil(plan.offscreenSince["a"], "a slept pane's clock is meaningless")
     }
 
+    /// `Station.sleep()` frees a Metal surface on the main thread; doing a batch
+    /// in one pass measured 13-20s of main-thread stall, which reads as a hang.
+    func testOnlyOnePaneSleepsPerTick() {
+        let plan = TerminalCoordinator.autoSleepPlan(
+            visible: [], sleepable: ["a", "b", "c", "d"],
+            offscreenSince: ["a": t0, "b": t0, "c": t0, "d": t0],
+            idleAfter: 600, now: t0.addingTimeInterval(6000))
+        XCTAssertEqual(plan.sleep.count, 1, "a backlog must drain one pane per tick")
+    }
+
+    /// Oldest first, so a backlog drains in a defined order rather than whatever
+    /// the dictionary happens to yield.
+    func testOldestOffscreenPaneSleepsFirst() {
+        let plan = TerminalCoordinator.autoSleepPlan(
+            visible: [], sleepable: ["new", "old", "mid"],
+            offscreenSince: ["new": t0.addingTimeInterval(200),
+                             "old": t0,
+                             "mid": t0.addingTimeInterval(100)],
+            idleAfter: 600, now: t0.addingTimeInterval(6000))
+        XCTAssertEqual(plan.sleep, ["old"])
+    }
+
+    /// The panes not chosen keep their clocks, or a backlog would restart its
+    /// timer every tick and never drain.
+    func testUnchosenPanesKeepTheirClocks() {
+        let plan = TerminalCoordinator.autoSleepPlan(
+            visible: [], sleepable: ["a", "b"], offscreenSince: ["a": t0, "b": t0],
+            idleAfter: 600, now: t0.addingTimeInterval(6000))
+        let remaining = plan.sleep == ["a"] ? "b" : "a"
+        XCTAssertEqual(plan.offscreenSince[remaining], t0, "the queue must not reset")
+
+        let next = TerminalCoordinator.autoSleepPlan(
+            visible: [], sleepable: [remaining], offscreenSince: plan.offscreenSince,
+            idleAfter: 600, now: t0.addingTimeInterval(6060))
+        XCTAssertEqual(next.sleep, [remaining], "and it drains on the following tick")
+    }
+
     /// The reason the clock is stored rather than accumulated: a pane the user
     /// keeps returning to must never reach the threshold by adding up gaps.
     func testReturningToScreenResetsTheClock() {


### PR DESCRIPTION
`Station.sleep()` frees a Metal surface on the main thread, and `autoSleepPlan` returned every due pane at once — so the first tick after a batch came due tore them all down in a single pass.

## Evidence

The two worst main-thread stalls in 46h of monitoring both landed on such a tick:

| sample | main-thread block | threads before → after |
|---|---|---|
| 08-10 13:23 | **19533 ms** | 91 → 27 |
| 08-10 13:41 | **13504 ms** | 48 → 28 |

Twenty seconds of frozen UI reads as a hang. (Both also coincided with a swap burst, which is the other half of why they were so long — but the thread-count cliff is this code.)

## Fix

One pane per tick. Nothing is waiting on this work: the threshold is minutes, so draining one pane per 5s tick is fast enough to be invisible while never blocking the main thread for more than a single surface teardown.

Two properties matter and both are easy to break silently, so both are pinned by tests:

- **Oldest first** — a backlog drains in a defined order rather than dictionary order.
- **Unchosen panes keep their clocks** — clearing them would restart the timer every tick and the backlog would never drain at all.

`auto_sleep` is off by default, so this only affects users who turned it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)