### PR TITLE
fix: compare resolved paths when guarding the main worktree

### DIFF
--- a/Sources/Git/WorktreeDeleter.swift
+++ b/Sources/Git/WorktreeDeleter.swift
@@ -62,7 +62,13 @@ enum WorktreeDeleter {
         if let firstLine = listOutput.components(separatedBy: "\n").first,
            firstLine.hasPrefix("worktree ") {
             let mainPath = String(firstLine.dropFirst("worktree ".count))
-            if worktreePath == mainPath {
+            // Compare resolved paths: git reports the real path while a caller
+            // can hold one that reaches it through a symlink (any path under
+            // /var, which is /private/var, and every macOS temporary directory).
+            // String equality let those through to git, which rejects them too —
+            // but with a message this class then has to pattern-match back into
+            // meaning, and only after attempting the delete.
+            if Self.samePath(worktreePath, mainPath) {
                 throw WorktreeDeleterError.isMainWorktree
             }
         }
@@ -237,6 +243,16 @@ enum WorktreeDeleter {
             result.stderr.trimmingCharacters(in: .whitespacesAndNewlines),
             result.stdout
         )
+    }
+
+    /// Whether two paths name the same directory once symlinks are resolved.
+    /// Pure and internal so the symlink case can be tested without a repo.
+    static func samePath(_ lhs: String, _ rhs: String) -> Bool {
+        guard lhs != rhs else { return true }
+        let resolve = { (p: String) in
+            URL(fileURLWithPath: p).resolvingSymlinksInPath().standardizedFileURL.path
+        }
+        return resolve(lhs) == resolve(rhs)
     }
 
     private static func classifyWorktreeRemoveError(_ stderr: String, path: String) -> String {

--- a/Tests/WorktreeDeleterTests.swift
+++ b/Tests/WorktreeDeleterTests.swift
@@ -110,8 +110,12 @@ final class WorktreeDeleterTests: XCTestCase {
             switch delError {
             case .isMainWorktree:
                 break // Expected
-            case .gitFailed(let msg) where msg.contains("main working tree"):
-                break // Also acceptable — git caught it
+            case .gitFailed(let msg) where msg.contains("main worktree"):
+                // Fallback only. This used to match git's raw "is a main working
+                // tree", which classifyWorktreeRemoveError had already rewritten,
+                // so the case never fired and the guard's symlink bug hid behind
+                // an "Unexpected error" instead of being reported as one.
+                XCTFail("guard should have caught this before git: \(msg)")
             default:
                 XCTFail("Unexpected error: \(delError)")
             }
@@ -255,5 +259,25 @@ final class WorktreeDeleterTests: XCTestCase {
 
     private func lastPathComponent(_ path: String) -> String {
         URL(fileURLWithPath: path).lastPathComponent
+    }
+
+    /// The guard compared path strings, so any caller holding a path that
+    /// reaches the repo through a symlink — every macOS temp dir, since /var is
+    /// /private/var — slipped past it and was caught by git instead.
+    func testSamePathResolvesSymlinks() {
+        // Real directories on purpose: resolvingSymlinksInPath leaves a path
+        // that does not exist untouched, so a fabricated /var vs /private/var
+        // pair would test nothing and pass for the wrong reason.
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("samepath-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let viaSymlink = dir.path                    // /var/folders/...
+        let real = "/private" + dir.path             // /private/var/folders/...
+        XCTAssertTrue(FileManager.default.fileExists(atPath: real), "precondition: /var is /private/var")
+        XCTAssertTrue(WorktreeDeleter.samePath(viaSymlink, real),
+                      "git reports the real path; a caller may hold the symlinked one")
+        XCTAssertTrue(WorktreeDeleter.samePath(viaSymlink, viaSymlink))
+        XCTAssertFalse(WorktreeDeleter.samePath(viaSymlink, dir.deletingLastPathComponent().path))
     }
 }


### PR DESCRIPTION
`WorktreeDeleter` refused to delete the main worktree by comparing path strings:

```swift
if worktreePath == mainPath { throw .isMainWorktree }
```

`git worktree list --porcelain` reports the **real** path, while a caller can hold one that reaches the same directory through a symlink. On macOS that is every path under `/var` — which is `/private/var` — so it covers every temporary directory.

## Why it looked fine

When the comparison missed, git rejected the delete anyway, so the operation still failed. But the two paths are not equivalent: git's refusal arrives as raw stderr that `classifyWorktreeRemoveError` has to pattern-match back into meaning, and only *after* a delete has been attempted.

## Why the test did not catch it

`testDeleteMainWorktreeThrows` accepted either outcome, with the fallback matching git's raw wording:

```swift
case .gitFailed(let msg) where msg.contains("main working tree"):
    break // Also acceptable — git caught it
```

But `classifyWorktreeRemoveError` had already replaced that with `"Cannot delete the main worktree."`, so the case could never fire. The guard's failure surfaced as `Unexpected error: gitFailed("Cannot delete the main worktree.")` — an unexplained failure rather than the regression it actually was.

That branch now calls `XCTFail`: reaching git at all means the guard did not do its job.

## On the new test

`samePath` is tested against **real** directories. `resolvingSymlinksInPath()` leaves a path that does not exist untouched, so a fabricated `/var` vs `/private/var` pair tests nothing and passes for the wrong reason — the first version of this test did exactly that and failed until it was rewritten to create the directory first.

Full unit suite: 1536 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)