### PR TITLE
refactor: roll a worktree's status up from its most recently changed pane

### DIFF
--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -344,12 +344,14 @@ class TabCoordinator {
             } ?? [station]
 
             let ws = statusAggregator.status(for: agent.worktreePath)
-            // Roll up EVERY pane's ShipLog status for this worktree (authoritative,
-            // arbitrated). A multi-pane worktree must reflect its busiest pane, so
-            // don't collapse to the aggregator's list or a single sailor here.
+            // Every pane's ShipLog status, in leaf order — these draw the per-pane
+            // dots. The worktree's own status is NOT derived from them here: the
+            // aggregator already picked the most recently changed pane, and
+            // re-deriving it would let the row and the tab badge disagree.
             let shipLogPaneStatuses = (agentsByWorktree[agent.worktreePath] ?? []).map(\.status)
             let paneStatuses = !shipLogPaneStatuses.isEmpty ? shipLogPaneStatuses
                 : (ws?.statuses ?? [agent.status])
+            let rolledUpStatus = ws?.rolledUpStatus ?? agent.status
             let mostRecentMessage = ws?.mostRecentMessage ?? (agent.lastMessage.isEmpty ? "No active task." : agent.lastMessage)
             let mostRecentUserPrompt = ws?.mostRecentUserPrompt ?? agent.lastUserPrompt
             let mostRecentPaneIndex = ws?.mostRecentPaneIndex ?? 1
@@ -432,6 +434,7 @@ class TabCoordinator {
                 project: agent.project,
                 thread: worktreeName,
                 paneStatuses: paneStatuses,
+                rolledUpStatus: rolledUpStatus,
                 mostRecentMessage: mostRecentMessage,
                 lastUserPrompt: mostRecentUserPrompt,
                 mostRecentPaneIndex: mostRecentPaneIndex,

--- a/Sources/Status/CabinStatusAggregator.swift
+++ b/Sources/Status/CabinStatusAggregator.swift
@@ -89,6 +89,9 @@ class CabinStatusAggregator {
         let effectivePrompt = lastUserPrompt.isEmpty ? (oldPaneState?.lastUserPrompt ?? "") : lastUserPrompt
         // Preserve a known agent type across updates that report .unknown.
         let effectiveType = agentType == .unknown ? (oldPaneState?.agentType ?? .unknown) : agentType
+        // Only a real status change advances `statusChangedAt`; the rollup picks
+        // the most recently changed pane, so message-only updates must not move it.
+        let statusChangedAt = statusChanged ? now : (oldPaneState?.statusChangedAt ?? now)
         let newPaneState = PaneStatus(
             paneIndex: paneIndex,
             terminalID: terminalID,
@@ -96,6 +99,7 @@ class CabinStatusAggregator {
             lastMessage: lastMessage,
             lastUserPrompt: effectivePrompt,
             lastUpdated: now,
+            statusChangedAt: statusChangedAt,
             agentType: effectiveType
         )
         paneStates[terminalID] = newPaneState
@@ -136,6 +140,7 @@ class CabinStatusAggregator {
                     lastMessage: pane.lastMessage,
                     lastUserPrompt: pane.lastUserPrompt,
                     lastUpdated: pane.lastUpdated,
+                    statusChangedAt: pane.statusChangedAt,
                     agentType: pane.agentType
                 )
                 paneStates[tid] = pane
@@ -145,10 +150,10 @@ class CabinStatusAggregator {
 
         guard !panes.isEmpty else { return }
 
-        // Representative pane = highest rollup rank (AI agents outrank shell tasks,
-        // then status priority). Status and message both come from it, so the tab
-        // badge and its message always describe the same pane.
-        let representative = panes.max { $0.rollupRank < $1.rollupRank } ?? panes[0]
+        // Representative pane = whichever changed status most recently. Status and
+        // message both come from it, so the tab badge and its message always
+        // describe the same pane.
+        let representative = panes.max { $0.statusChangedAt < $1.statusChangedAt } ?? panes[0]
 
         let ws = CabinStatus(
             worktreePath: worktreePath,

--- a/Sources/Status/PaneStatus.swift
+++ b/Sources/Status/PaneStatus.swift
@@ -7,14 +7,12 @@ struct PaneStatus: Equatable {
     var lastMessage: String
     var lastUserPrompt: String
     var lastUpdated: Date     // When status or message last changed
+    /// When `status` last changed — not advanced by message-only updates. The
+    /// worktree rollup picks the pane that changed most recently, so a pane
+    /// merely printing output must not take the badge from one that just went
+    /// waiting.
+    var statusChangedAt: Date
     var agentType: SailorType = .unknown
-
-    /// Rollup rank: an AI agent's state outranks a shell task's at the same
-    /// status priority, so a long-running `npm run dev` never masks a blocked
-    /// agent in the same worktree.
-    var rollupRank: (UInt8, UInt8) {
-        (agentType.isAIAgent ? 1 : 0, status.priority)
-    }
 }
 
 struct CabinStatus: Equatable {
@@ -32,14 +30,20 @@ struct CabinStatus: Equatable {
         panes.contains { $0.status.isUrgent }
     }
 
-    /// The pane that speaks for the worktree: highest rollup rank (AI agents win
-    /// ties over shell tasks). Status AND message come from this same pane so the
-    /// badge and the text can never disagree.
+    /// The pane that speaks for the worktree: whichever changed status most
+    /// recently. Status AND message come from this same pane so the badge and
+    /// the text can never disagree.
+    ///
+    /// This used to be a priority ranking (waiting > error > … , agents over
+    /// shell tasks). Recency is the simpler rule and matches what the row is
+    /// read as — "what is this worktree doing now" — at the cost that a pane
+    /// which went waiting an hour ago no longer holds the badge against a pane
+    /// that just started running.
     var representative: PaneStatus? {
-        panes.max { $0.rollupRank < $1.rollupRank }
+        panes.max { $0.statusChangedAt < $1.statusChangedAt }
     }
 
-    var highestPriority: SailorStatus {
+    var rolledUpStatus: SailorStatus {
         representative?.status ?? .unknown
     }
 }

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -33,7 +33,9 @@ struct SailorDisplayInfo {
     let name: String        // display name like "Agent-Alpha"
     let project: String     // repo display name
     let thread: String      // branch name
-    let paneStatuses: [SailorStatus]     // per-pane statuses
+    let paneStatuses: [SailorStatus]     // per-pane statuses, in leaf order
+    /// Worktree-level status from the aggregator (most recently changed pane).
+    let rolledUpStatus: SailorStatus
     let mostRecentMessage: String       // message from most recently updated pane
     let lastUserPrompt: String          // most recent user prompt text
     let mostRecentPaneIndex: Int
@@ -56,12 +58,12 @@ struct SailorDisplayInfo {
     /// Per-pane rows for the expanded "Group by Sailor" mode (leaf order).
     var panes: [PaneDisplayInfo] = []
 
-    /// Rolled-up status for display/grouping: the highest-priority pane, so a
-    /// worktree whose first pane is idle but a later pane is running still reads
-    /// as running (waiting > error > exited > running > idle). Using `.first`
-    /// here made a multi-pane worktree show the first pane's state only.
+    /// Rolled-up status for display/grouping. Computed once by the aggregator —
+    /// the pane that changed status most recently — and carried here rather than
+    /// re-derived, so the dashboard row and the tab badge cannot disagree about
+    /// what the same worktree is doing.
     var status: String {
-        SailorStatus.highestPriority(paneStatuses).rawValue.lowercased()
+        rolledUpStatus.rawValue.lowercased()
     }
 
     /// Convenience: backward-compatible lastMessage
@@ -2224,7 +2226,7 @@ final class DashboardOverviewView: NSView {
     }
 
     private func render(_ sailors: [SailorDisplayInfo], revealSelection: Bool) {
-        let running = sailors.filter { SailorStatus.highestPriority($0.paneStatuses) == .running }.count
+        let running = sailors.filter { $0.rolledUpStatus == .running }.count
         // Tight enough to survive the 300pt docked column next to two buttons:
         // total count, then only the running slice.
         headerSub.stringValue = running > 0 ? "\(sailors.count) · \(running) running" : "\(sailors.count)"

--- a/Tests/CabinStatusAggregatorTests.swift
+++ b/Tests/CabinStatusAggregatorTests.swift
@@ -50,10 +50,12 @@ final class CabinStatusAggregatorTests: XCTestCase {
         let ws = mockDelegate.lastUpdatedStatus!
         XCTAssertEqual(ws.panes.count, 2)
         XCTAssertEqual(ws.statuses, [.running, .idle])
-        // Representative pane = highest rollup rank (running t1 beats idle t2),
-        // so status/message/index all describe that pane.
-        XCTAssertEqual(ws.mostRecentMessage, "building")
-        XCTAssertEqual(ws.mostRecentPaneIndex, 1)
+        // Representative pane = the one that changed status most recently, so
+        // t2 speaks even though t1 is the busier of the two. Status, message and
+        // index all describe that same pane.
+        XCTAssertEqual(ws.rolledUpStatus, .idle)
+        XCTAssertEqual(ws.mostRecentMessage, "done")
+        XCTAssertEqual(ws.mostRecentPaneIndex, 2)
     }
 
     func testStatusChangeFiresPaneCallback() {

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -324,6 +324,7 @@ private func makeSailor(
         project: project,
         thread: "feature",
         paneStatuses: paneStatuses,
+        rolledUpStatus: paneStatuses.first ?? .unknown,
         mostRecentMessage: "Working",
         lastUserPrompt: "Implement grouping",
         mostRecentPaneIndex: 0,

--- a/Tests/DashboardViewControllerClickTests.swift
+++ b/Tests/DashboardViewControllerClickTests.swift
@@ -180,6 +180,7 @@ private func makeSailor(id: String, worktreePath: String) -> SailorDisplayInfo {
         project: "proj",
         thread: "main",
         paneStatuses: [.idle],
+        rolledUpStatus: .idle,
         mostRecentMessage: "No active task.",
         lastUserPrompt: "",
         mostRecentPaneIndex: 1,

--- a/Tests/PaneStatusTests.swift
+++ b/Tests/PaneStatusTests.swift
@@ -3,106 +3,101 @@ import XCTest
 
 final class PaneStatusTests: XCTestCase {
 
-    func testWorktreeStatusStatuses() {
-        let ws = CabinStatus(
-            worktreePath: "/repo/main",
-            panes: [
-                PaneStatus(paneIndex: 1, terminalID: "t1", status: .running, lastMessage: "building", lastUserPrompt: "", lastUpdated: Date()),
-                PaneStatus(paneIndex: 2, terminalID: "t2", status: .idle, lastMessage: "done", lastUserPrompt: "", lastUpdated: Date()),
-            ],
-            mostRecentPaneIndex: 1,
-            mostRecentMessage: "building",
-            mostRecentUserPrompt: ""
-        )
+    private let t0 = Date(timeIntervalSince1970: 1_000_000)
+
+    private func pane(_ index: Int, _ id: String, _ status: SailorStatus,
+                      message: String = "", changedAt: Date,
+                      agentType: SailorType = .unknown) -> PaneStatus {
+        PaneStatus(paneIndex: index, terminalID: id, status: status, lastMessage: message,
+                   lastUserPrompt: "", lastUpdated: changedAt, statusChangedAt: changedAt,
+                   agentType: agentType)
+    }
+
+    private func worktree(_ panes: [PaneStatus]) -> CabinStatus {
+        CabinStatus(worktreePath: "/repo/main", panes: panes, mostRecentPaneIndex: 1,
+                    mostRecentMessage: "", mostRecentUserPrompt: "")
+    }
+
+    func testStatusesFollowLeafOrder() {
+        let ws = worktree([
+            pane(1, "t1", .running, changedAt: t0),
+            pane(2, "t2", .idle, changedAt: t0),
+        ])
         XCTAssertEqual(ws.statuses, [.running, .idle])
     }
 
-    func testRepresentativeIsAgentOverBusyShell() {
-        // Shell pane (npm) running forever must not mask a blocked AI agent.
-        let ws = CabinStatus(
-            worktreePath: "/repo/main",
-            panes: [
-                PaneStatus(paneIndex: 1, terminalID: "shell", status: .running, lastMessage: "webpack…",
-                           lastUserPrompt: "", lastUpdated: Date(), agentType: .npm),
-                PaneStatus(paneIndex: 2, terminalID: "agent", status: .waiting, lastMessage: "approve?",
-                           lastUserPrompt: "", lastUpdated: Date(), agentType: .claudeCode),
-            ],
-            mostRecentPaneIndex: 1, mostRecentMessage: "webpack…", mostRecentUserPrompt: ""
-        )
-        XCTAssertEqual(ws.highestPriority, .waiting)
+    // MARK: - Rollup: most recently changed pane
+
+    func testRepresentativeIsTheMostRecentlyChangedPane() {
+        let ws = worktree([
+            pane(1, "old", .waiting, changedAt: t0),
+            pane(2, "new", .running, changedAt: t0.addingTimeInterval(60)),
+        ])
         XCTAssertEqual(ws.representative?.paneIndex, 2)
+        XCTAssertEqual(ws.rolledUpStatus, .running)
     }
 
-    func testRepresentativeStatusAndMessageSamePane() {
-        // Higher-priority pane owns both the badge status and the message.
-        let ws = CabinStatus(
-            worktreePath: "/repo/main",
-            panes: [
-                PaneStatus(paneIndex: 1, terminalID: "a", status: .idle, lastMessage: "idle msg",
-                           lastUserPrompt: "", lastUpdated: Date(), agentType: .claudeCode),
-                PaneStatus(paneIndex: 2, terminalID: "b", status: .error, lastMessage: "boom",
-                           lastUserPrompt: "", lastUpdated: Date(), agentType: .claudeCode),
-            ],
-            mostRecentPaneIndex: 1, mostRecentMessage: "idle msg", mostRecentUserPrompt: ""
-        )
+    /// Deliberate change of behaviour: the rollup used to rank an AI agent's
+    /// state above a shell task's, so a blocked agent held the badge against a
+    /// long-running `npm run dev`. Recency replaced that — the shell pane wins
+    /// here purely because it changed later.
+    func testABusyShellCanNowOutrankAWaitingAgent() {
+        let ws = worktree([
+            pane(1, "agent", .waiting, changedAt: t0, agentType: .claudeCode),
+            pane(2, "shell", .running, changedAt: t0.addingTimeInterval(1), agentType: .npm),
+        ])
+        XCTAssertEqual(ws.rolledUpStatus, .running)
+    }
+
+    /// The badge and the text must describe the same pane, or the row reads as
+    /// one pane's status next to another pane's output.
+    func testStatusAndMessageComeFromTheSamePane() {
+        let ws = worktree([
+            pane(1, "a", .idle, message: "idle msg", changedAt: t0),
+            pane(2, "b", .error, message: "boom", changedAt: t0.addingTimeInterval(5)),
+        ])
         XCTAssertEqual(ws.representative?.status, .error)
         XCTAssertEqual(ws.representative?.lastMessage, "boom")
     }
 
-    func testWorktreeStatusHasUrgent() {
-        let ws = CabinStatus(
-            worktreePath: "/repo/main",
-            panes: [
-                PaneStatus(paneIndex: 1, terminalID: "t1", status: .running, lastMessage: "", lastUserPrompt: "", lastUpdated: Date()),
-                PaneStatus(paneIndex: 2, terminalID: "t2", status: .error, lastMessage: "failed", lastUserPrompt: "", lastUpdated: Date()),
-            ],
-            mostRecentPaneIndex: 2,
-            mostRecentMessage: "failed",
-            mostRecentUserPrompt: ""
-        )
+    /// `statusChangedAt` exists so output churn cannot steal the badge: pane 1
+    /// is printing constantly (`lastUpdated` is newest) but its status has not
+    /// moved since t0, so pane 2's later status change still speaks.
+    func testMessageOnlyUpdatesDoNotStealTheBadge() {
+        let chatty = PaneStatus(paneIndex: 1, terminalID: "chatty", status: .running,
+                                lastMessage: "line 900", lastUserPrompt: "",
+                                lastUpdated: t0.addingTimeInterval(300),
+                                statusChangedAt: t0)
+        let ws = worktree([chatty, pane(2, "b", .waiting, changedAt: t0.addingTimeInterval(10))])
+        XCTAssertEqual(ws.rolledUpStatus, .waiting)
+        XCTAssertEqual(ws.representative?.paneIndex, 2)
+    }
+
+    func testEmptyWorktreeHasUnknownStatus() {
+        XCTAssertEqual(worktree([]).rolledUpStatus, .unknown)
+    }
+
+    // MARK: - Urgency is independent of the rollup
+
+    /// `hasUrgent` still scans every pane, so an error stays visible even when a
+    /// later-changed pane owns the badge.
+    func testHasUrgentSeesAPaneTheRollupDidNotPick() {
+        let ws = worktree([
+            pane(1, "t1", .error, message: "failed", changedAt: t0),
+            pane(2, "t2", .running, changedAt: t0.addingTimeInterval(60)),
+        ])
+        XCTAssertEqual(ws.rolledUpStatus, .running)
         XCTAssertTrue(ws.hasUrgent)
     }
 
-    func testWorktreeStatusNotUrgent() {
-        let ws = CabinStatus(
-            worktreePath: "/repo/main",
-            panes: [
-                PaneStatus(paneIndex: 1, terminalID: "t1", status: .running, lastMessage: "", lastUserPrompt: "", lastUpdated: Date()),
-            ],
-            mostRecentPaneIndex: 1,
-            mostRecentMessage: "",
-            mostRecentUserPrompt: ""
-        )
-        XCTAssertFalse(ws.hasUrgent)
+    func testNotUrgentWhenNoPaneIs() {
+        XCTAssertFalse(worktree([pane(1, "t1", .running, changedAt: t0)]).hasUrgent)
     }
 
-    func testWorktreeStatusHighestPriority() {
-        let ws = CabinStatus(
-            worktreePath: "/repo/main",
-            panes: [
-                PaneStatus(paneIndex: 1, terminalID: "t1", status: .idle, lastMessage: "", lastUserPrompt: "", lastUpdated: Date()),
-                PaneStatus(paneIndex: 2, terminalID: "t2", status: .waiting, lastMessage: "?", lastUserPrompt: "", lastUpdated: Date()),
-                PaneStatus(paneIndex: 3, terminalID: "t3", status: .running, lastMessage: "", lastUserPrompt: "", lastUpdated: Date()),
-            ],
-            mostRecentPaneIndex: 2,
-            mostRecentMessage: "?",
-            mostRecentUserPrompt: ""
-        )
-        XCTAssertEqual(ws.highestPriority, .waiting)
-    }
-
-    func testSinglePaneWorktreeStatus() {
-        let ws = CabinStatus(
-            worktreePath: "/repo/main",
-            panes: [
-                PaneStatus(paneIndex: 1, terminalID: "t1", status: .running, lastMessage: "working", lastUserPrompt: "", lastUpdated: Date()),
-            ],
-            mostRecentPaneIndex: 1,
-            mostRecentMessage: "working",
-            mostRecentUserPrompt: ""
-        )
+    func testSinglePaneWorktree() {
+        let ws = worktree([pane(1, "t1", .running, message: "working", changedAt: t0)])
         XCTAssertEqual(ws.statuses.count, 1)
-        XCTAssertEqual(ws.highestPriority, .running)
+        XCTAssertEqual(ws.rolledUpStatus, .running)
         XCTAssertFalse(ws.hasUrgent)
     }
 }


### PR DESCRIPTION
The rollup ranked panes by a tuple of `(is an AI agent, status priority)`, so a blocked agent held the badge over a shell task and `waiting` outranked `running` no matter how long ago it happened. Recency replaces that: **whichever pane changed status last speaks for the worktree.**

## This loses behaviour on purpose

A `npm run dev` that starts *after* an agent goes waiting now takes the badge, where before the agent kept it. `testABusyShellCanNowOutrankAWaitingAgent` pins that down so it reads as a decision rather than a regression for someone to "fix" later.

`hasUrgent` is untouched and still scans every pane, so an error stays visible when a later-changed pane owns the badge.

## Recency needs its own timestamp

`lastUpdated` already existed, but it advances on message changes too — a pane printing output continuously would have held the badge forever without its status ever moving. `statusChangedAt` advances only on a real status change:

```swift
let statusChangedAt = statusChanged ? now : (oldPaneState?.statusChangedAt ?? now)
```

Covered by `testMessageOnlyUpdatesDoNotStealTheBadge`.

## Collapses a second derivation

`SailorDisplayInfo.status` computed `highestPriority(paneStatuses)` independently of the aggregator, so the dashboard row and the tab badge could describe the same worktree differently depending on which path updated last. The aggregator's result is now carried through as `rolledUpStatus` and the dashboard consumes it. `paneStatuses` stays in leaf order for the per-pane dots.

1543 unit tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)