### PR TITLE
perf: watch the file tree by directory, and skip build output

### DIFF
--- a/Sources/UI/SidePanel/FileTreeOutlineController.swift
+++ b/Sources/UI/SidePanel/FileTreeOutlineController.swift
@@ -11,6 +11,22 @@ final class DirectoryWatcher {
     private let onChange: ([String]) -> Void
     private let queue = DispatchQueue(label: "seahelm.filetree.watcher")
 
+    /// Directories whose churn can never change what the tree should show, and
+    /// which produce most of the events in a worktree being built in. A single
+    /// `npm install` or `xcodebuild` writes tens of thousands of files into
+    /// these; the tree only needs to know that something outside them changed.
+    static let ignoredDirectories = [".git", "node_modules", ".build", "DerivedData"]
+
+    /// Whether a batch of changed paths contains anything the tree should redraw
+    /// for. Pure so the filter can be tested without a live stream.
+    static func hasRelevantChange(in paths: [String]) -> Bool {
+        paths.contains { path in
+            !ignoredDirectories.contains { dir in
+                path.contains("/\(dir)/") || path.hasSuffix("/\(dir)")
+            }
+        }
+    }
+
     /// Returns nil if the FSEvents stream could not be created.
     init?(path: String, onChange: @escaping ([String]) -> Void) {
         self.onChange = onChange
@@ -20,16 +36,20 @@ final class DirectoryWatcher {
             info: Unmanaged.passUnretained(self).toOpaque(),
             retain: nil, release: nil, copyDescription: nil
         )
+        // Directory granularity, not `kFSEventStreamCreateFlagFileEvents`. The
+        // tree reloads a directory as a unit, so per-file events bought nothing
+        // and cost one event per file written — with a build running in the
+        // worktree that is the difference between a handful of events and tens
+        // of thousands, all of which fseventsd has to record and deliver.
         let flags = UInt32(
-            kFSEventStreamCreateFlagFileEvents
-            | kFSEventStreamCreateFlagNoDefer
+            kFSEventStreamCreateFlagNoDefer
             | kFSEventStreamCreateFlagUseCFTypes
         )
         let callback: FSEventStreamCallback = { _, info, numEvents, eventPaths, _, _ in
             guard let info else { return }
             let watcher = Unmanaged<DirectoryWatcher>.fromOpaque(info).takeUnretainedValue()
             let paths = (unsafeBitCast(eventPaths, to: NSArray.self) as? [String]) ?? []
-            guard numEvents > 0 else { return }
+            guard numEvents > 0, DirectoryWatcher.hasRelevantChange(in: paths) else { return }
             watcher.onChange(paths)
         }
         guard let stream = FSEventStreamCreate(
@@ -237,11 +257,9 @@ final class FileTreeOutlineController: NSObject, NSOutlineViewDataSource, NSOutl
         watcher?.stop()
         watcher = nil
         guard let path else { return }
-        watcher = DirectoryWatcher(path: path) { [weak self] paths in
-            // Ignore pure-.git churn (index/commit writes) — it would otherwise
-            // reload the tree constantly with no user-visible change.
-            let relevant = paths.contains { !$0.contains("/.git/") && !$0.hasSuffix("/.git") }
-            guard relevant else { return }
+        watcher = DirectoryWatcher(path: path) { [weak self] _ in
+            // The watcher already dropped batches that were only build or .git
+            // churn, so anything arriving here is worth a redraw.
             self?.scheduleExternalRefresh()
         }
     }

--- a/Tests/FileTreeOutlineControllerTests.swift
+++ b/Tests/FileTreeOutlineControllerTests.swift
@@ -72,4 +72,42 @@ final class FileTreeOutlineControllerTests: XCTestCase {
         controller.restoreExpansion(["/definitely/not/in/this/tree"])
         XCTAssertEqual(controller.currentExpandedPaths(), [])
     }
+
+    // MARK: - Watcher filtering
+
+    /// The tree reloads a directory as a unit, so the stream asks for directory
+    /// granularity and drops batches that only touch build output. A worktree
+    /// being built in produces tens of thousands of such events, all of which
+    /// fseventsd has to record and deliver.
+    func testWatcherIgnoresBuildAndGitChurn() {
+        XCTAssertFalse(DirectoryWatcher.hasRelevantChange(in: [
+            "/wt/.git/index",
+            "/wt/node_modules/foo/package.json",
+            "/wt/.build/Debug/thing.o",
+            "/wt/DerivedData/Build/x",
+        ]))
+    }
+
+    func testWatcherReportsRealChanges() {
+        XCTAssertTrue(DirectoryWatcher.hasRelevantChange(in: ["/wt/Sources/App.swift"]))
+    }
+
+    /// One real edit inside a noisy batch must still redraw — the filter drops
+    /// batches, not paths.
+    func testWatcherReportsMixedBatch() {
+        XCTAssertTrue(DirectoryWatcher.hasRelevantChange(in: [
+            "/wt/node_modules/a", "/wt/README.md", "/wt/.git/HEAD",
+        ]))
+    }
+
+    /// The directory itself, not just paths beneath it.
+    func testWatcherIgnoresTheDirectoryEntryItself() {
+        XCTAssertFalse(DirectoryWatcher.hasRelevantChange(in: ["/wt/node_modules"]))
+    }
+
+    /// A name that merely contains an ignored word is a normal file.
+    func testWatcherDoesNotIgnoreLookalikeNames() {
+        XCTAssertTrue(DirectoryWatcher.hasRelevantChange(in: ["/wt/Sources/node_modules_helper.swift"]))
+        XCTAssertTrue(DirectoryWatcher.hasRelevantChange(in: ["/wt/my.build.log"]))
+    }
 }


### PR DESCRIPTION
The tree's FSEvents stream asked for `kFSEventStreamCreateFlagFileEvents` — per-file granularity — over the whole worktree root, with no exclusions. The tree reloads a directory as a unit, so per-file events bought nothing and cost **one event per file written**. A build running in the watched worktree turns that into tens of thousands of events, every one of which fseventsd records and delivers.

## Changes

Dropping the flag leaves directory granularity, which is what the tree actually consumes. `.git`, `node_modules`, `.build` and `DerivedData` are then dropped in the stream callback.

The `.git` filter already existed but sat in the controller's closure — *after* the events had been recorded, delivered and unpacked. It only skipped the redraw. Moving it into the watcher keeps that saving and adds the build directories.

The filter is a pure function so the cases that matter are pinned down:

- a real edit inside a noisy batch still redraws (it filters batches, not paths)
- a file merely *named* like an ignored directory (`node_modules_helper.swift`, `my.build.log`) is not swallowed

## Scope worth being honest about

This is the amplifier, not the source. fseventsd records volume-wide file events whether or not anything subscribes — it was at **2.75 GB** during a 10-minute system-wide swap stall today, driven by build output this app does not control. Subscribing to that firehose at the heaviest granularity made Seahelm part of the cost; it was never the whole of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)