### PR TITLE
fix: scrub the launching agent's session env before spawning panes

### DIFF
--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -6,8 +6,23 @@ import AppKit
 // Ghostty surface inherits it. `zmx attach <name>` silently prefers
 // $ZMX_SESSION over its argument, so a leaked value makes every pane attach
 // to the wrong (often dead) session: layout restores, content doesn't.
+//
+// The same shell is usually an agent's, which leaks that agent's session
+// identity the same way — and an agent inheriting it disables its own
+// transcript saving ("Transcript saving is off — inherited
+// CLAUDE_CODE_CHILD_SESSION"), so the pane's conversation is silently lost on
+// exit and cannot be resumed. The messaging socket/token are worse than stale:
+// they point a fresh agent at the relaunching agent's channel. CLAUDE_CODE_EXECPATH
+// is left alone — it names a binary, not a session, and a pane may legitimately
+// want the same one.
+//
 // Scrub before anything can spawn a child.
-for leaked in ["ZMX_SESSION", "SEAHELM_ENV", "SEAHELM_SOCKET_PATH", "SEAHELM_PANE_ID"] {
+let leakedSessionEnv = [
+    "ZMX_SESSION", "SEAHELM_ENV", "SEAHELM_SOCKET_PATH", "SEAHELM_PANE_ID",
+    "CLAUDE_CODE_CHILD_SESSION", "CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_MESSAGING_SOCKET", "CLAUDE_CODE_MESSAGING_TOKEN",
+]
+for leaked in leakedSessionEnv {
     unsetenv(leaked)
 }
 


### PR DESCRIPTION
Relaunching the app from inside a pane — a dev rebuild, or an agent running `run.sh` — hands the app that agent's `CLAUDE_CODE_*` variables, and every Ghostty surface it then spawns inherits them.

Verified on a live app before the fix — the claude inside a pane held exactly the same set as the app process:

```
pane's claude (26714)          Seahelm app (14602)
  CLAUDE_CODE_CHILD_SESSION      CLAUDE_CODE_CHILD_SESSION
  CLAUDE_CODE_ENTRYPOINT         CLAUDE_CODE_ENTRYPOINT
  CLAUDE_CODE_EXECPATH           CLAUDE_CODE_EXECPATH
  CLAUDE_CODE_MESSAGING_SOCKET   CLAUDE_CODE_MESSAGING_SOCKET
  CLAUDE_CODE_MESSAGING_TOKEN    CLAUDE_CODE_MESSAGING_TOKEN
  CLAUDE_CODE_SESSION_ID         CLAUDE_CODE_SESSION_ID
```

## Why it matters

`CLAUDE_CODE_CHILD_SESSION` is the damaging one. An agent that sees it believes it is a child session and **turns its own transcript saving off**:

```
⚠ Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION
```

The conversation is then lost on exit and cannot be resumed. The report that started this was a user losing five minutes of work to it — silently, with the only warning a truncated line at the bottom of the pane.

`CLAUDE_CODE_MESSAGING_SOCKET`/`_TOKEN` are worse than stale: they point a fresh agent at the *relaunching* agent's channel. `SESSION_ID` and `ENTRYPOINT` name the parent's session and how it started, neither of which is true of the pane.

`CLAUDE_CODE_EXECPATH` is deliberately kept — it names a binary, not a session, and a pane may legitimately want the same one.

## Same leak, second instance

`main.swift` already guarded against `ZMX_SESSION` escaping this exact way, where it made panes attach to the wrong (often dead) session — layout restored, content did not. Same mechanism, same file, so the two share one list now.

## Verification

Relaunched from an environment stripped of the variables (the launching shell carries them, so `env -u` is needed to test at all):

```
app process        → only CLAUDE_CODE_EXECPATH
19 pane children   → only CLAUDE_CODE_EXECPATH
```

Note the fix cannot clean an app process that already inherited them — `unsetenv` changes what children get, not the process's own exec-time environment. That is the intended scope: the panes are what matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)