### PR TITLE
fix: resolve a zmx session's daemon by walking its process tree

### DIFF
--- a/Sources/Core/SessionManager.swift
+++ b/Sources/Core/SessionManager.swift
@@ -169,11 +169,17 @@ enum SessionManager {
 
     // MARK: - Orphan zmx client processes
 
-    /// One `zmx` process as the client sweep sees it.
+    /// One process row as the client sweep sees it.
     struct ZmxProcess: Equatable {
         let pid: Int32
         let ppid: Int32
         let command: String
+
+        /// The vendored binary's path, not a bare "zmx": an agent's own command
+        /// line can mention zmx without being one.
+        var isZmxBinary: Bool {
+            command.contains("/bin/zmx ") || command.hasSuffix("/bin/zmx")
+        }
     }
 
     /// `zmx attach`/`run` clients that no longer have anyone to serve.
@@ -185,29 +191,62 @@ enum SessionManager {
     /// sessions that were perfectly alive, and `zmx list` showed `clients=1`,
     /// i.e. they had never attached at all. What identifies them is having no
     /// live parent while not being a session daemon themselves.
-    static func orphanZmxClientPids(processes: [ZmxProcess], daemonPids: Set<Int32>) -> [Int32] {
-        // Without a daemon list every session daemon looks like an orphan, and
-        // killing those ends the agents inside them. Refuse rather than guess.
-        guard !daemonPids.isEmpty else { return [] }
+    ///
+    /// Which makes telling a daemon from a client the whole job, and it cannot be
+    /// done from `zmx list` pids alone: `pid=` names the *process inside* the
+    /// session (the shell, or the agent), never the zmx process hosting it. A
+    /// set of those pids therefore never intersects the zmx processes being
+    /// swept, so excluding it protected nothing and this sweep reaped every
+    /// surviving daemon of the previous instance — killing all 8 live sessions
+    /// about five minutes after each restart. The daemon is found by walking up
+    /// from the reported pid to the nearest zmx-binary ancestor instead; the walk
+    /// starts at the pid itself so a future zmx that does report the daemon pid
+    /// stays correct. Any session whose daemon cannot be resolved that way
+    /// abandons the whole sweep — reaping nothing costs CPU, guessing costs
+    /// agents.
+    static func orphanZmxClientPids(processes: [ZmxProcess], sessionPids: Set<Int32>) -> [Int32] {
+        // Without session pids every daemon looks like an orphan. Refuse to guess.
+        guard !sessionPids.isEmpty else { return [] }
+        let byPid = Dictionary(processes.map { ($0.pid, $0) }, uniquingKeysWith: { first, _ in first })
+        var daemonPids: Set<Int32> = []
+        for sessionPid in sessionPids {
+            guard let daemon = zmxDaemonPid(hosting: sessionPid, byPid: byPid) else { return [] }
+            daemonPids.insert(daemon)
+        }
         return processes.compactMap { proc in
+            guard proc.isZmxBinary else { return nil }
             guard !daemonPids.contains(proc.pid) else { return nil }   // session daemon
             guard proc.ppid == 1 else { return nil }                   // has a live parent
             return proc.pid
         }
     }
 
-    /// Parse `ps -axo pid=,ppid=,command=` down to the zmx processes.
+    /// The zmx process hosting `sessionPid`: itself if it is one, else its
+    /// nearest zmx-binary ancestor. Note the client that *created* a session is
+    /// also an ancestor of it (`login` → client → daemon → shell), so only the
+    /// nearest one may be treated as the daemon — stopping at the first hit is
+    /// what keeps the outer client reapable.
+    private static func zmxDaemonPid(hosting sessionPid: Int32, byPid: [Int32: ZmxProcess]) -> Int32? {
+        var current: Int32? = sessionPid
+        // Bounded: a ps snapshot can disagree with itself about parentage.
+        for _ in 0..<16 {
+            guard let pid = current, pid > 1, let proc = byPid[pid] else { return nil }
+            if proc.isZmxBinary { return proc.pid }
+            current = proc.ppid
+        }
+        return nil
+    }
+
+    /// Parse `ps -axo pid=,ppid=,command=`. Every row is kept, not just the zmx
+    /// ones: resolving a session's daemon means walking parents through the
+    /// non-zmx processes (`login`, the session's own shell) in between.
     static func parseZmxProcesses(psOutput: String) -> [ZmxProcess] {
         psOutput.components(separatedBy: .newlines).compactMap { line in
             let parts = line.split(maxSplits: 2, whereSeparator: \.isWhitespace)
             guard parts.count == 3,
                   let pid = Int32(parts[0]),
                   let ppid = Int32(parts[1]) else { return nil }
-            let command = String(parts[2])
-            // Match the vendored binary's path, not a bare "zmx": an agent's own
-            // command line can mention zmx without being one.
-            guard command.contains("/bin/zmx ") || command.hasSuffix("/bin/zmx") else { return nil }
-            return ZmxProcess(pid: pid, ppid: ppid, command: command)
+            return ZmxProcess(pid: pid, ppid: ppid, command: String(parts[2]))
         }
     }
 
@@ -216,13 +255,18 @@ enum SessionManager {
     @discardableResult
     static func cleanupOrphanZmxClients(listOutput: String? = nil, psOutput: String? = nil) -> [Int32] {
         let list = listOutput ?? ProcessRunner.output([ZmxLocator.executable(), "list"]) ?? ""
-        let daemonPids = Set(list.components(separatedBy: .newlines).compactMap { line -> Int32? in
+        let sessionPids = Set(list.components(separatedBy: .newlines).compactMap { line -> Int32? in
             guard let value = zmxListField(line, "pid=") else { return nil }
             return Int32(value)
         })
         let ps = psOutput ?? ProcessRunner.output(["ps", "-axo", "pid=,ppid=,command="]) ?? ""
-        let orphans = orphanZmxClientPids(processes: parseZmxProcesses(psOutput: ps), daemonPids: daemonPids)
+        let processes = parseZmxProcesses(psOutput: ps)
+        let orphans = orphanZmxClientPids(processes: processes, sessionPids: sessionPids)
+        let byPid = Dictionary(processes.map { ($0.pid, $0) }, uniquingKeysWith: { first, _ in first })
         for pid in orphans {
+            // Log the command line before killing: the one bug this sweep has had
+            // was invisible in a bare pid count.
+            NSLog("[SessionManager] Reaping orphan zmx client %d: %@", pid, byPid[pid]?.command ?? "?")
             // SIGKILL, not SIGTERM: the spin loop never reaches a signal handler,
             // so a terminate is simply ignored.
             kill(pid, SIGKILL)

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -195,50 +195,108 @@ class SessionManagerTests: XCTestCase {
 
     // MARK: - Orphan zmx client processes
 
-    private let daemons: Set<Int32> = [100, 200]
+    private static let zmxPath = "/App/Contents/Resources/bin/zmx"
 
-    private func proc(_ pid: Int32, _ ppid: Int32, _ cmd: String = "/App/Contents/Resources/bin/zmx attach s") -> SessionManager.ZmxProcess {
+    private func proc(_ pid: Int32, _ ppid: Int32, _ cmd: String) -> SessionManager.ZmxProcess {
         SessionManager.ZmxProcess(pid: pid, ppid: ppid, command: cmd)
     }
 
-    func testOrphanClientIsReaped() {
-        let pids = SessionManager.orphanZmxClientPids(processes: [proc(300, 1)], daemonPids: daemons)
-        XCTAssertEqual(pids, [300])
+    private func zmx(_ pid: Int32, _ ppid: Int32, _ session: String = "seahelm-a") -> SessionManager.ZmxProcess {
+        proc(pid, ppid, "\(Self.zmxPath) attach \(session)")
     }
 
-    /// Session daemons are ppid 1 by design; reaping one ends the agent inside.
-    func testSessionDaemonIsNeverReaped() {
-        let pids = SessionManager.orphanZmxClientPids(processes: [proc(100, 1), proc(200, 1)], daemonPids: daemons)
-        XCTAssertEqual(pids, [])
+    /// The login wrapper Station spawns each pane through. Its command line names
+    /// the zmx binary but quotes it, so it must not read as a zmx process itself.
+    private static let loginWrapper =
+        "/usr/bin/login -flp me /bin/bash -c exec -l /usr/bin/env -u ZMX_SESSION '\(zmxPath)' attach seahelm-a"
+
+    /// The shape a pane actually has: app → login → client → daemon → shell,
+    /// with `zmx list` reporting the *shell's* pid for the session.
+    private func livePaneTree() -> [SessionManager.ZmxProcess] {
+        [
+            proc(79811, 1, "/App/Contents/MacOS/Seahelm"),
+            proc(95359, 79811, Self.loginWrapper),
+            zmx(95362, 95359),
+            zmx(95363, 95362),
+            proc(95364, 95363, "-zsh"),
+        ]
+    }
+
+    func testLivePaneReapsNothing() {
+        let pids = SessionManager.orphanZmxClientPids(processes: livePaneTree(), sessionPids: [95364])
+        XCTAssertEqual(pids, [], "nothing is orphaned while the app is alive")
+    }
+
+    /// The regression: `zmx list` reports the pid of the process *inside* the
+    /// session, so a set of those pids never intersects the zmx processes being
+    /// swept — the sweep reaped every surviving daemon and killed all 8 live
+    /// sessions ~5 minutes after each restart.
+    func testOrphanedDaemonIsNeverReaped() {
+        // The previous app (and its login) are gone; the client was adopted by
+        // launchd and still parents the daemon that holds the agent.
+        let processes = [zmx(95362, 1), zmx(95363, 95362), proc(95364, 95363, "-zsh")]
+        let pids = SessionManager.orphanZmxClientPids(processes: processes, sessionPids: [95364])
+        XCTAssertEqual(pids, [95362], "the client is reaped, the daemon hosting the session is not")
+    }
+
+    /// Once its client is gone the daemon is the ppid-1 zmx process itself.
+    func testLoneOrphanedDaemonIsKept() {
+        let processes = [zmx(95363, 1), proc(95364, 95363, "-zsh")]
+        XCTAssertEqual(SessionManager.orphanZmxClientPids(processes: processes, sessionPids: [95364]), [])
+    }
+
+    func testOrphanClientIsReaped() {
+        let processes = livePaneTree() + [zmx(300, 1)]
+        XCTAssertEqual(SessionManager.orphanZmxClientPids(processes: processes, sessionPids: [95364]), [300])
     }
 
     func testClientWithLiveParentIsKept() {
-        let pids = SessionManager.orphanZmxClientPids(processes: [proc(300, 9478)], daemonPids: daemons)
-        XCTAssertEqual(pids, [])
+        let processes = livePaneTree() + [zmx(300, 9478)]
+        XCTAssertEqual(SessionManager.orphanZmxClientPids(processes: processes, sessionPids: [95364]), [])
     }
 
-    /// Without a daemon list every daemon looks orphaned, so the sweep must
+    /// Without session pids every daemon looks orphaned, so the sweep must
     /// refuse rather than guess.
-    func testEmptyDaemonListReapsNothing() {
-        let pids = SessionManager.orphanZmxClientPids(processes: [proc(300, 1)], daemonPids: [])
-        XCTAssertEqual(pids, [])
+    func testEmptySessionListReapsNothing() {
+        XCTAssertEqual(SessionManager.orphanZmxClientPids(processes: [zmx(300, 1)], sessionPids: []), [])
+    }
+
+    /// A session whose daemon can't be resolved (ps and `zmx list` disagreeing,
+    /// e.g. the shell exited between the two calls) abandons the whole sweep:
+    /// reaping nothing costs CPU, guessing costs agents.
+    func testUnresolvableSessionAbandonsSweep() {
+        let processes = livePaneTree() + [zmx(300, 1)]
+        XCTAssertEqual(SessionManager.orphanZmxClientPids(processes: processes, sessionPids: [95364, 777]), [])
+    }
+
+    /// Future-proofing: if zmx ever reports the daemon's own pid, the walk starts
+    /// at that pid and still protects it.
+    func testDaemonReportedDirectlyIsKept() {
+        let processes = [zmx(95363, 1), proc(95364, 95363, "-zsh")]
+        XCTAssertEqual(SessionManager.orphanZmxClientPids(processes: processes, sessionPids: [95363]), [])
     }
 
     /// The two worst offenders found were spinning against live sessions, so a
     /// "target session is gone" test would have missed them entirely.
     func testOrphanAgainstLiveSessionIsStillReaped() {
-        let live = proc(300, 1, "/App/Contents/Resources/bin/zmx attach seahelm-workspace-saas-mono")
-        XCTAssertEqual(SessionManager.orphanZmxClientPids(processes: [live], daemonPids: daemons), [300])
+        let processes = livePaneTree() + [zmx(300, 1, "seahelm-a")]
+        XCTAssertEqual(SessionManager.orphanZmxClientPids(processes: processes, sessionPids: [95364]), [300])
     }
 
-    func testParsePsOutputPicksOnlyZmxBinaries() {
+    /// Every row is parsed now — resolving a daemon means walking parents through
+    /// the non-zmx processes in between — so the binary test moved to `isZmxBinary`.
+    func testParsePsOutputKeepsEveryRowAndFlagsZmxBinaries() {
         let ps = """
           300     1 /Volumes/x/Seahelm.app/Contents/Resources/bin/zmx attach seahelm-a
           301  9478 /Volumes/x/Seahelm.app/Contents/Resources/bin/zmx run seahelm-b /bin/zsh
           302     1 /usr/bin/node --flag zmx-ish-name
           303     1 claude --resume zmx
+          304     1 /usr/bin/login -flp me /bin/bash -c exec -l /usr/bin/env '/App/bin/zmx' attach seahelm-a
         """
         let parsed = SessionManager.parseZmxProcesses(psOutput: ps)
-        XCTAssertEqual(parsed.map(\.pid), [300, 301], "only the vendored zmx binary counts")
+        XCTAssertEqual(parsed.map(\.pid), [300, 301, 302, 303, 304])
+        XCTAssertEqual(
+            parsed.filter(\.isZmxBinary).map(\.pid), [300, 301],
+            "only the vendored zmx binary counts — not a login wrapper naming it")
     }
 }


### PR DESCRIPTION
#46 shipped a sweep that **kills every live zmx session about five minutes after each app restart**. This fixes it.

## The bug

#46 excluded session daemons from the sweep using the pids from `zmx list`:

```swift
guard !daemonPids.contains(proc.pid) else { return nil }   // "session daemon"
guard proc.ppid == 1 else { return nil }
return proc.pid
```

But `zmx list`'s `pid=` names the process **inside** the session, not the zmx process hosting it:

```
$ zmx list
name=seahelm-task-betly-app-bugfix-3   pid=85508 ...
$ ps -o command= -p 85508
-zsh
```

A set of shell pids never intersects the zmx processes being swept, so that guard excluded nothing. Every `ppid == 1` zmx process was reaped — daemons included — on the 300s `orphanCleanupTimer`.

## The fix

Walk up from the reported pid to the **nearest** zmx-binary ancestor. Two details matter:

- The walk starts at the pid itself, so a future zmx that *does* report the daemon's own pid stays correct.
- Only the nearest ancestor counts. The client that created a session is also an ancestor of it (`login` → client → daemon → shell); treating that one as a daemon would make it unreapable.

Any session whose daemon cannot be resolved abandons the whole sweep rather than proceeding with a partial exclusion set — reaping nothing costs CPU, guessing costs agents.

## Verification against the live system

This is the check #46 lacked. Its unit tests passed too; they encoded the same wrong assumption the code did. Run against a real snapshot — 16 sessions, 47 zmx processes:

```
resolved 16 daemons (16 sessions)
would reap: 0
daemons ∩ reap-list: 0
```

The same snapshot under the old logic selects every one of those 16 daemons.

## Other changes

`parseZmxProcesses` keeps every ps row rather than pre-filtering to zmx ones — resolving a daemon means walking parents through the `login` and shell processes in between. The zmx filter moved into the sweep itself.

Reaped pids are now logged with their command line. The one bug this sweep has had was invisible in a bare pid count.

Refs #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)