### PR TITLE
Web client: same-origin hosting + mirrored pane layout

### DIFF
--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -771,6 +771,12 @@ class TabCoordinator {
                     controlDataSource.wakeHandler = { [weak self] stationId in
                         self?.terminalCoordinator.wakePane(targetStationId: stationId) ?? []
                     }
+                    controlDataSource.liveLayoutsHandler = { [weak self] in
+                        self?.terminalCoordinator.liveLayouts() ?? [:]
+                    }
+                    controlDataSource.worktreeGroupsHandler = { [weak self] mode in
+                        self?.worktreeGroups(mode: mode) ?? []
+                    }
                     controlDataSource.exportLayoutHandler = { [weak self] in
                         self?.terminalCoordinator.exportLayout()
                     }
@@ -1681,4 +1687,21 @@ extension TabCoordinator {
 
 private extension String {
     var shellQuoted: String { "'\(self.replacingOccurrences(of: "'", with: "'\\''"))'" }
+}
+
+// MARK: - Remote grouping
+
+extension TabCoordinator {
+    /// The dashboard's own grouping, computed here and shipped as data.
+    ///
+    /// Remote clients render these groups verbatim; re-implementing the rules on
+    /// the far side is what would let the browser and the desktop disagree.
+    func worktreeGroups(mode: String) -> [[String: Any]] {
+        let items = buildWorktreeRowInfos().map {
+            $0.groupingItem(creationDate: DashboardOverviewView.creationDate($0.worktreePath))
+        }
+        return WorktreeGrouping
+            .groups(items, mode: WorktreeGroupingMode(wire: mode), now: Date())
+            .map(\.dict)
+    }
 }

--- a/Sources/App/TerminalCoordinator.swift
+++ b/Sources/App/TerminalCoordinator.swift
@@ -679,3 +679,24 @@ class TerminalCoordinator {
         stationManager.removeAll()
     }
 }
+
+// MARK: - Remote layout mirroring
+
+extension TerminalCoordinator {
+    /// Every live split tree, keyed by worktree path.
+    ///
+    /// A remote client needs this to mirror the window rather than invent its own
+    /// arrangement: the tree is the layout, and its leaves are already keyed by
+    /// the `paneSessionKey` that `pane.vt_open` attaches to.
+    func liveLayouts() -> [String: [String: Any]] {
+        var out: [String: [String: Any]] = [:]
+        for tree in stationManager.allTrees {
+            var entry: [String: Any] = ["root": tree.toCodable().dict]
+            if let focused = tree.allLeaves.first(where: { $0.id == tree.focusedId }) {
+                entry["focused_pane_session_key"] = focused.paneSessionKey
+            }
+            out[tree.worktreePath] = entry
+        }
+        return out
+    }
+}

--- a/Sources/Core/ControlProtocol.swift
+++ b/Sources/Core/ControlProtocol.swift
@@ -59,6 +59,12 @@ protocol ControlDataSource: AnyObject {
     /// means one `zmx list` plus a full process-table walk (argv included) —
     /// far too costly to put on every `pane.list`, which agents poll.
     func snapshotPanes(includingMemory: Bool) -> [PaneSnapshot]
+    /// Live split trees keyed by worktree path, so a remote client can mirror
+    /// this window's arrangement instead of inventing one. nil = nothing to mirror.
+    func liveLayouts() -> [String: [String: Any]]?
+    /// The dashboard's own worktree groups for `mode`, already computed Mac-side
+    /// so a remote client cannot drift from the desktop.
+    func worktreeGroups(mode: String) -> [[String: Any]]?
     /// Read a pane's terminal text. `source`: visible | recent | detection.
     func readPane(paneId: String, source: String, lines: Int) -> String?
     /// Feed an inbound hook/suggest payload (same shape as the HTTP webhook body)
@@ -304,6 +310,25 @@ final class ControlRouter {
             guard ok else { return .error(code: ControlError.notFound, message: "pane not found: \(paneId)") }
             return .ok([method == "pane.close" ? "closed" : "focused": true])
 
+        case "layout.live":
+            guard let layouts = dataSource?.liveLayouts() else {
+                return .error(code: ControlError.notFound, message: "no live layout")
+            }
+            if let path = params["worktree_path"] as? String {
+                guard let one = layouts[path] else {
+                    return .error(code: ControlError.notFound, message: "unknown worktree")
+                }
+                return .ok(one)
+            }
+            return .ok(["layouts": layouts])
+
+        case "fleet.groups":
+            let groupingMode = (params["mode"] as? String) ?? "repository"
+            guard let groups = dataSource?.worktreeGroups(mode: groupingMode) else {
+                return .error(code: ControlError.notFound, message: "no grouping available")
+            }
+            return .ok(["mode": groupingMode, "groups": groups])
+
         case "layout.export":
             guard let layout = dataSource?.exportLayout() else {
                 return .error(code: ControlError.notFound, message: "no active layout")
@@ -501,4 +526,13 @@ final class ControlRouter {
     static func encodeParseError() -> String {
         "{\"id\":\"\",\"error\":{\"code\":\(ControlError.parse),\"message\":\"invalid JSON\"}}\n"
     }
+}
+
+// MARK: - Optional remote-mirroring surface
+
+/// Defaults keep existing conformers — including test fakes — compiling: a data
+/// source with no window to mirror simply reports nothing to mirror.
+extension ControlDataSource {
+    func liveLayouts() -> [String: [String: Any]]? { nil }
+    func worktreeGroups(mode: String) -> [[String: Any]]? { nil }
 }

--- a/Sources/Core/HostGatewayConfig.swift
+++ b/Sources/Core/HostGatewayConfig.swift
@@ -5,11 +5,18 @@ struct HostGatewayConfig: Codable, Equatable {
     var port: UInt16?
     /// Public WSS URL embedded in pair `b=`. Empty → localhost derived URL.
     var publicURL: String?
+    /// Directory served at `/`. Empty → the bundled `seahelm-web`; set it to a
+    /// working copy to iterate on the web client without rebuilding the app.
+    var webRoot: String?
 
-    init(enabled: Bool? = nil, port: UInt16? = nil, publicURL: String? = nil) {
+    init(enabled: Bool? = nil,
+         port: UInt16? = nil,
+         publicURL: String? = nil,
+         webRoot: String? = nil) {
         self.enabled = enabled
         self.port = port
         self.publicURL = publicURL
+        self.webRoot = webRoot
     }
 
     var resolvedEnabled: Bool { enabled ?? false }
@@ -19,8 +26,19 @@ struct HostGatewayConfig: Codable, Equatable {
         return "ws://127.0.0.1:\(resolvedPort)/ws"
     }
 
+    /// Page URL matching `resolvedPublicURL`, since both leave the same origin.
+    var resolvedPageURL: String {
+        guard var components = URLComponents(string: resolvedPublicURL) else {
+            return "http://127.0.0.1:\(resolvedPort)/"
+        }
+        components.scheme = components.scheme == "wss" ? "https" : "http"
+        components.path = "/"
+        return components.string ?? "http://127.0.0.1:\(resolvedPort)/"
+    }
+
     enum CodingKeys: String, CodingKey {
         case enabled, port
         case publicURL = "public_url"
+        case webRoot = "web_root"
     }
 }

--- a/Sources/Core/HostGatewayServer.swift
+++ b/Sources/Core/HostGatewayServer.swift
@@ -1,20 +1,37 @@
 import Foundation
 import Network
 
-/// Localhost WebSocket server for browser / web clients (`ws://127.0.0.1:PORT/ws`).
+/// WebSocket + static-page server for browser clients (`http://HOST:PORT/`, `ws://HOST:PORT/ws`).
+///
+/// One port serves both, which `NWProtocolWebSocket` cannot do on its own — with the
+/// WebSocket protocol in the stack a plain `GET /` is never answered at all. So the
+/// public port runs a bare TCP listener that reads the request head and demultiplexes:
+/// a WebSocket upgrade is proxied byte-for-byte to an internal loopback listener that
+/// keeps the real WebSocket stack, anything else is answered as a static file. The
+/// framework still owns every frame; the front door only decides which door it is.
 final class HostGatewayServer {
     private let config: HostGatewayConfig
     private let router: ControlRouter
     private let expectedMacId: String
     private let rootSecretBase64url: String
     private let vt: HostGatewayVTAttaching
+    private let staticFiles: HostGatewayStaticFiles
     private let queue = DispatchQueue(label: "seahelm.hostgateway", qos: .userInitiated)
 
-    private var listener: NWListener?
+    /// Public port: static files plus the upgrade demux.
+    private var frontListener: NWListener?
+    /// Loopback-only port carrying the WebSocket protocol stack.
+    private var wsListener: NWListener?
+    private var wsPort: UInt16 = 0
+
     private var connections: [ObjectIdentifier: ConnectionState] = [:]
+    private var proxied: [ObjectIdentifier: NWConnection] = [:]
     private var readyHandlers: [() -> Void] = []
     private let stateLock = NSLock()
     private var _isListening = false
+
+    /// Request head cap: real browser heads are ~1KB, so this only bounds abuse.
+    private static let maxRequestHeadBytes = 16 * 1024
 
     private(set) var isListening: Bool {
         get {
@@ -44,6 +61,8 @@ final class HostGatewayServer {
         self.expectedMacId = expectedMacId
         self.rootSecretBase64url = rootSecretBase64url
         self.vt = vt
+        self.staticFiles = HostGatewayStaticFiles(
+            root: HostGatewayStaticFiles.resolveRoot(override: config.webRoot))
     }
 
     func start(onReady: (() -> Void)? = nil) {
@@ -51,60 +70,11 @@ final class HostGatewayServer {
             if let onReady {
                 self.readyHandlers.append(onReady)
             }
-            guard self.listener == nil else {
+            guard self.frontListener == nil, self.wsListener == nil else {
                 if self.isListening { self.fireReadyHandlers() }
                 return
             }
-
-            let parameters = NWParameters(tls: nil)
-            parameters.allowLocalEndpointReuse = true
-            parameters.acceptLocalOnly = true
-            parameters.includePeerToPeer = false
-
-            let wsOptions = NWProtocolWebSocket.Options()
-            wsOptions.autoReplyPing = true
-            wsOptions.setClientRequestHandler(self.queue) { _, headers in
-                let path = headers.first { $0.name.lowercased() == ":path" }?.value
-                    ?? headers.first { $0.name.lowercased() == "path" }?.value
-                if let path, path != "/ws" {
-                    return NWProtocolWebSocket.Response(status: .reject, subprotocol: nil, additionalHeaders: [])
-                }
-                return NWProtocolWebSocket.Response(status: .accept, subprotocol: nil, additionalHeaders: [])
-            }
-            parameters.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
-
-            guard let port = NWEndpoint.Port(rawValue: self.config.resolvedPort) else {
-                self.isListening = false
-                self.fireReadyHandlers()
-                return
-            }
-
-            do {
-                let listener = try NWListener(using: parameters, on: port)
-                self.listener = listener
-                listener.stateUpdateHandler = { [weak self] state in
-                    guard let self else { return }
-                    switch state {
-                    case .ready:
-                        self.isListening = true
-                        self.fireReadyHandlers()
-                    case .failed, .cancelled:
-                        self.isListening = false
-                        self.listener = nil
-                    default:
-                        break
-                    }
-                }
-                listener.newConnectionHandler = { [weak self] connection in
-                    self?.accept(connection)
-                }
-                listener.start(queue: self.queue)
-            } catch {
-                NSLog("[HostGateway] listener failed: \(error.localizedDescription)")
-                self.isListening = false
-                self.listener = nil
-                self.fireReadyHandlers()
-            }
+            self.startWebSocketListener()
         }
     }
 
@@ -114,20 +84,267 @@ final class HostGatewayServer {
                 state.connection.cancel()
             }
             connections.removeAll()
-            listener?.cancel()
-            listener = nil
+            for connection in proxied.values {
+                connection.cancel()
+            }
+            proxied.removeAll()
+            frontListener?.cancel()
+            frontListener = nil
+            wsListener?.cancel()
+            wsListener = nil
+            wsPort = 0
             isListening = false
             readyHandlers.removeAll()
         }
     }
 
-    // MARK: - Connection handling
+    // MARK: - Listeners
+
+    /// Internal listener: the real WebSocket stack, reachable only over loopback.
+    private func startWebSocketListener() {
+        let parameters = NWParameters(tls: nil)
+        parameters.allowLocalEndpointReuse = true
+        parameters.includePeerToPeer = false
+        // Bind loopback on an ephemeral port: only the front door can reach it.
+        parameters.requiredLocalEndpoint = NWEndpoint.hostPort(host: .ipv4(.loopback), port: .any)
+
+        let wsOptions = NWProtocolWebSocket.Options()
+        wsOptions.autoReplyPing = true
+        wsOptions.setClientRequestHandler(queue) { _, headers in
+            let path = headers.first { $0.name.lowercased() == ":path" }?.value
+                ?? headers.first { $0.name.lowercased() == "path" }?.value
+            if let path, Self.requestPath(path) != "/ws" {
+                return NWProtocolWebSocket.Response(status: .reject, subprotocol: nil, additionalHeaders: [])
+            }
+            return NWProtocolWebSocket.Response(status: .accept, subprotocol: nil, additionalHeaders: [])
+        }
+        parameters.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
+
+        do {
+            let listener = try NWListener(using: parameters)
+            wsListener = listener
+            listener.stateUpdateHandler = { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .ready:
+                    self.wsPort = listener.port?.rawValue ?? 0
+                    self.startFrontListener()
+                case .failed, .cancelled:
+                    self.failStart("websocket listener \(state)")
+                default:
+                    break
+                }
+            }
+            listener.newConnectionHandler = { [weak self] connection in
+                self?.accept(connection)
+            }
+            listener.start(queue: queue)
+        } catch {
+            NSLog("[HostGateway] websocket listener failed: \(error.localizedDescription)")
+            failStart("websocket listener error")
+        }
+    }
+
+    /// Public listener: bare TCP, so a plain `GET` reaches us instead of stalling.
+    private func startFrontListener() {
+        guard frontListener == nil else { return }
+        guard let port = NWEndpoint.Port(rawValue: config.resolvedPort) else {
+            failStart("invalid port \(config.resolvedPort)")
+            return
+        }
+
+        let parameters = NWParameters.tcp
+        parameters.allowLocalEndpointReuse = true
+        parameters.acceptLocalOnly = true
+        parameters.includePeerToPeer = false
+
+        do {
+            let listener = try NWListener(using: parameters, on: port)
+            frontListener = listener
+            listener.stateUpdateHandler = { [weak self] state in
+                guard let self else { return }
+                switch state {
+                case .ready:
+                    self.isListening = true
+                    self.fireReadyHandlers()
+                case .failed, .cancelled:
+                    self.failStart("front listener \(state)")
+                default:
+                    break
+                }
+            }
+            listener.newConnectionHandler = { [weak self] connection in
+                self?.acceptFront(connection)
+            }
+            listener.start(queue: queue)
+        } catch {
+            NSLog("[HostGateway] front listener failed: \(error.localizedDescription)")
+            failStart("front listener error")
+        }
+    }
+
+    private func failStart(_ reason: String) {
+        NSLog("[HostGateway] not listening: \(reason)")
+        isListening = false
+        frontListener?.cancel()
+        frontListener = nil
+        wsListener?.cancel()
+        wsListener = nil
+        wsPort = 0
+        fireReadyHandlers()
+    }
 
     private func fireReadyHandlers() {
         let handlers = readyHandlers
         readyHandlers.removeAll()
         handlers.forEach { $0() }
     }
+
+    // MARK: - Front door: read the head, then pick a door
+
+    private func acceptFront(_ connection: NWConnection) {
+        connection.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            if case .ready = state {
+                self.readRequestHead(on: connection, buffered: Data())
+            } else if case .failed = state {
+                connection.cancel()
+            }
+        }
+        connection.start(queue: queue)
+    }
+
+    private func readRequestHead(on connection: NWConnection, buffered: Data) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            var buffer = buffered
+            if let data { buffer.append(data) }
+
+            if error != nil {
+                connection.cancel()
+                return
+            }
+            if let terminator = buffer.range(of: Data("\r\n\r\n".utf8)) {
+                let head = String(decoding: buffer[buffer.startIndex..<terminator.lowerBound], as: UTF8.self)
+                self.route(connection, head: head, rawRequest: buffer)
+                return
+            }
+            if isComplete || buffer.count > Self.maxRequestHeadBytes {
+                connection.cancel()
+                return
+            }
+            self.readRequestHead(on: connection, buffered: buffer)
+        }
+    }
+
+    private func route(_ connection: NWConnection, head: String, rawRequest: Data) {
+        if Self.isWebSocketUpgrade(head: head) {
+            proxyToWebSocket(connection, initial: rawRequest)
+            return
+        }
+        let (method, target) = Self.requestLine(head: head)
+        let response = staticFiles.response(method: method, target: target)
+        let payload = HostGatewayStaticFiles.serialize(response, includeBody: method != "HEAD")
+        connection.send(content: payload, isComplete: true, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+
+    // MARK: - Upgrade proxy
+
+    /// Replay the client's handshake to the internal listener, then pump bytes both
+    /// ways. Nothing here understands WebSocket framing — that stays the framework's.
+    private func proxyToWebSocket(_ client: NWConnection, initial: Data) {
+        guard wsPort != 0, let port = NWEndpoint.Port(rawValue: wsPort) else {
+            client.cancel()
+            return
+        }
+        let upstream = NWConnection(host: .ipv4(.loopback), port: port, using: .tcp)
+        proxied[ObjectIdentifier(client)] = upstream
+
+        upstream.stateUpdateHandler = { [weak self] state in
+            guard let self else { return }
+            switch state {
+            case .ready:
+                upstream.send(content: initial, isComplete: true, completion: .contentProcessed { [weak self] error in
+                    guard let self else { return }
+                    if error != nil {
+                        self.teardown(client, upstream)
+                        return
+                    }
+                    self.pump(from: client, to: upstream)
+                    self.pump(from: upstream, to: client)
+                })
+            case .failed, .cancelled:
+                self.teardown(client, upstream)
+            default:
+                break
+            }
+        }
+        upstream.start(queue: queue)
+    }
+
+    private func pump(from source: NWConnection, to destination: NWConnection) {
+        source.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            if let data, !data.isEmpty {
+                destination.send(content: data, isComplete: true, completion: .contentProcessed { [weak self] sendError in
+                    guard let self else { return }
+                    if sendError != nil {
+                        self.teardown(source, destination)
+                        return
+                    }
+                    self.pump(from: source, to: destination)
+                })
+                return
+            }
+            if error != nil || isComplete {
+                self.teardown(source, destination)
+                return
+            }
+            self.pump(from: source, to: destination)
+        }
+    }
+
+    private func teardown(_ first: NWConnection, _ second: NWConnection) {
+        first.cancel()
+        second.cancel()
+        proxied.removeValue(forKey: ObjectIdentifier(first))
+        proxied.removeValue(forKey: ObjectIdentifier(second))
+    }
+
+    // MARK: - Request parsing
+
+    static func isWebSocketUpgrade(head: String) -> Bool {
+        for line in head.split(separator: "\r\n", omittingEmptySubsequences: true).dropFirst() {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = line[line.startIndex..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+            guard name == "upgrade" else { continue }
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces).lowercased()
+            if value.contains("websocket") { return true }
+        }
+        return false
+    }
+
+    static func requestLine(head: String) -> (method: String, target: String) {
+        guard let first = head.split(separator: "\r\n", omittingEmptySubsequences: true).first else {
+            return ("GET", "/")
+        }
+        let parts = first.split(separator: " ", omittingEmptySubsequences: true)
+        let method = parts.first.map { String($0).uppercased() } ?? "GET"
+        let target = parts.count > 1 ? String(parts[1]) : "/"
+        return (method, target)
+    }
+
+    /// Path portion of a request target, so `/ws?token=x` still routes as `/ws`.
+    static func requestPath(_ target: String) -> String {
+        if let cut = target.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+            return String(target[target.startIndex..<cut])
+        }
+        return target
+    }
+
+    // MARK: - WebSocket sessions (internal listener)
 
     private func accept(_ connection: NWConnection) {
         let session = HostGatewaySession(

--- a/Sources/Core/HostGatewayStaticFiles.swift
+++ b/Sources/Core/HostGatewayStaticFiles.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Static hosting for the browser client, served from the Host Gateway's own port.
+///
+/// Same-origin is not a convenience here, it is what makes the client work at all:
+/// an `https://` page may not open a `ws://` socket, and `SubtleCrypto` — which the
+/// pairing HKDF needs — exists only in a secure context. Page and socket therefore
+/// have to arrive over one origin, so whatever secures the socket secures the page.
+struct HostGatewayStaticFiles {
+    /// Directory holding `index.html` and its assets; nil disables static hosting.
+    let root: URL?
+
+    init(root: URL?) {
+        self.root = root
+    }
+
+    /// Bundled `seahelm-web`, or a `web_root` override pointing at a working copy.
+    static func resolveRoot(override: String?) -> URL? {
+        if let override, !override.isEmpty {
+            let expanded = (override as NSString).expandingTildeInPath
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: expanded, isDirectory: &isDirectory),
+                  isDirectory.boolValue else { return nil }
+            return URL(fileURLWithPath: expanded)
+        }
+        return Bundle.main.resourceURL?.appendingPathComponent("seahelm-web")
+    }
+
+    struct Response: Equatable {
+        let status: Int
+        let reason: String
+        let contentType: String
+        let body: Data
+    }
+
+    /// Resolve an HTTP request target (`/`, `/e2ee.js`, `/x?v=1`) to a response.
+    func response(method: String, target: String) -> Response {
+        guard method == "GET" || method == "HEAD" else {
+            return Self.plain(405, "Method Not Allowed", "method not allowed\n")
+        }
+        guard let root else {
+            return Self.plain(404, "Not Found", "web client not bundled\n")
+        }
+        guard let file = Self.resolve(target: target, in: root) else {
+            return Self.plain(404, "Not Found", "not found\n")
+        }
+        guard let data = try? Data(contentsOf: file) else {
+            return Self.plain(404, "Not Found", "not found\n")
+        }
+        return Response(status: 200,
+                        reason: "OK",
+                        contentType: Self.contentType(for: file.pathExtension.lowercased()),
+                        body: data)
+    }
+
+    /// Map a request target onto a file inside `root`, refusing to escape it.
+    static func resolve(target: String, in root: URL) -> URL? {
+        var path = target
+        if let cut = path.firstIndex(where: { $0 == "?" || $0 == "#" }) {
+            path = String(path[path.startIndex..<cut])
+        }
+        path = path.removingPercentEncoding ?? path
+        guard path.hasPrefix("/") else { return nil }
+        if path.hasSuffix("/") { path += "index.html" }
+
+        let base = root.standardizedFileURL
+        let candidate = base.appendingPathComponent(String(path.dropFirst())).standardizedFileURL
+        // `..` segments are resolved above, so a prefix check is what confines them.
+        guard candidate.path == base.path || candidate.path.hasPrefix(base.path + "/") else { return nil }
+
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: candidate.path, isDirectory: &isDirectory) else { return nil }
+        if isDirectory.boolValue {
+            let index = candidate.appendingPathComponent("index.html")
+            return FileManager.default.fileExists(atPath: index.path) ? index : nil
+        }
+        return candidate
+    }
+
+    static func contentType(for pathExtension: String) -> String {
+        switch pathExtension {
+        case "html", "htm": return "text/html; charset=utf-8"
+        case "js", "mjs": return "text/javascript; charset=utf-8"
+        case "css": return "text/css; charset=utf-8"
+        case "json", "map": return "application/json; charset=utf-8"
+        case "svg": return "image/svg+xml"
+        case "png": return "image/png"
+        case "jpg", "jpeg": return "image/jpeg"
+        case "ico": return "image/x-icon"
+        case "woff2": return "font/woff2"
+        case "woff": return "font/woff"
+        case "txt", "md": return "text/plain; charset=utf-8"
+        default: return "application/octet-stream"
+        }
+    }
+
+    private static func plain(_ status: Int, _ reason: String, _ body: String) -> Response {
+        Response(status: status,
+                 reason: reason,
+                 contentType: "text/plain; charset=utf-8",
+                 body: Data(body.utf8))
+    }
+
+    /// Serialize to the wire. HEAD keeps the headers and drops the body.
+    static func serialize(_ response: Response, includeBody: Bool) -> Data {
+        var head = "HTTP/1.1 \(response.status) \(response.reason)\r\n"
+        head += "Content-Type: \(response.contentType)\r\n"
+        head += "Content-Length: \(response.body.count)\r\n"
+        // The gateway is a live view of the machine; a stale cached shell is worse
+        // than a re-fetch of a few hundred KB over the loopback or a tunnel.
+        head += "Cache-Control: no-cache\r\n"
+        head += "Connection: close\r\n\r\n"
+        var data = Data(head.utf8)
+        if includeBody { data.append(response.body) }
+        return data
+    }
+}

--- a/Sources/Core/SeahelmControlDataSource.swift
+++ b/Sources/Core/SeahelmControlDataSource.swift
@@ -24,6 +24,10 @@ final class SeahelmControlDataSource: ControlDataSource {
     /// main thread. Each returns the ids actually affected.
     var sleepHandler: ((String?) -> [String])?
     var wakeHandler: ((String?) -> [String])?
+    /// Owner-set window mirroring, run on the main thread: the live split trees
+    /// and the dashboard's grouping for a given mode.
+    var liveLayoutsHandler: (() -> [String: [String: Any]])?
+    var worktreeGroupsHandler: ((String) -> [[String: Any]])?
 
     init(hookSink: @escaping (WebhookEvent) -> String? = { _ in nil }) {
         self.hookSink = hookSink
@@ -318,5 +322,23 @@ final class SeahelmControlDataSource: ControlDataSource {
     /// request on its own background thread.
     private func runOnMain(_ block: @escaping () -> Void) {
         if Thread.isMainThread { block() } else { DispatchQueue.main.sync(execute: block) }
+    }
+}
+
+// MARK: - Window mirroring
+
+extension SeahelmControlDataSource {
+    func liveLayouts() -> [String: [String: Any]]? {
+        guard let h = liveLayoutsHandler else { return nil }
+        var out: [String: [String: Any]] = [:]
+        runOnMain { out = h() }
+        return out
+    }
+
+    func worktreeGroups(mode: String) -> [[String: Any]]? {
+        guard let h = worktreeGroupsHandler else { return nil }
+        var out: [[String: Any]] = []
+        runOnMain { out = h(mode) }
+        return out
     }
 }

--- a/Sources/Terminal/SplitNode.swift
+++ b/Sources/Terminal/SplitNode.swift
@@ -203,3 +203,21 @@ indirect enum CodableSplitNode: Codable {
         }
     }
 }
+
+extension CodableSplitNode {
+    /// Wire shape for remote clients mirroring this window's layout.
+    ///
+    /// Leaves carry `pane_session_key` — the same key `pane.vt_open` takes — so a
+    /// client can lay the tree out and attach each pane without a second lookup.
+    var dict: [String: Any] {
+        switch self {
+        case let .leaf(paneSessionKey, title):
+            var d: [String: Any] = ["type": "leaf", "pane_session_key": paneSessionKey]
+            if let title, !title.isEmpty { d["title"] = title }
+            return d
+        case let .split(axis, ratio, first, second):
+            return ["type": "split", "axis": axis, "ratio": ratio,
+                    "first": first.dict, "second": second.dict]
+        }
+    }
+}

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -2425,7 +2425,8 @@ final class DashboardOverviewView: NSView {
     /// Worktree directory creation date, cached — the sort key inside a repo
     /// group. Missing/unreadable paths sort first (distantPast).
     private static var creationDateCache: [String: Date] = [:]
-    private static func creationDate(_ path: String) -> Date {
+    /// Also used to build grouping items for remote clients (TabCoordinator).
+    static func creationDate(_ path: String) -> Date {
         if let cached = creationDateCache[path] { return cached }
         let attrs = try? FileManager.default.attributesOfItem(atPath: path)
         let date = attrs?[.creationDate] as? Date ?? .distantPast

--- a/Sources/UI/Dashboard/WorktreeGrouping.swift
+++ b/Sources/UI/Dashboard/WorktreeGrouping.swift
@@ -210,3 +210,66 @@ struct WorktreeGroupingPreference {
         defaults.set(mode.rawValue, forKey: Self.key)
     }
 }
+
+// MARK: - Wire format
+
+/// Remote clients render the same groups the dashboard does. Grouping stays a
+/// Mac-side computation and travels as data, so the browser cannot drift from
+/// the desktop the way a re-implementation would.
+extension WorktreeGroupingMode {
+    init(wire: String) {
+        switch wire.lowercased() {
+        case "status": self = .status
+        case "activity", "activitytime", "time": self = .activityTime
+        case "pane": self = .pane
+        default: self = .repository
+        }
+    }
+
+    var wire: String {
+        switch self {
+        case .repository: return "repository"
+        case .status: return "status"
+        case .activityTime: return "activity"
+        case .pane: return "pane"
+        }
+    }
+}
+
+extension WorktreeGroupID {
+    var wire: String {
+        switch self {
+        case let .repository(name): return "repository:\(name)"
+        case let .status(status): return "status:\(status.rawValue)"
+        case let .activity(bucket): return "activity:\(bucket.rawValue)"
+        }
+    }
+}
+
+extension WorktreeGroupingItem {
+    var dict: [String: Any] {
+        var d: [String: Any] = [
+            "id": id,
+            "worktree_path": path,
+            "repository": repository,
+            "status": status.rawValue,
+            "is_main_worktree": isMainWorktree,
+        ]
+        if let lastActivityAt {
+            d["last_activity_at"] = lastActivityAt.timeIntervalSince1970
+        }
+        return d
+    }
+}
+
+extension WorktreeGroup {
+    var dict: [String: Any] {
+        var d: [String: Any] = [
+            "id": id.wire,
+            "title": title,
+            "items": items.map(\.dict),
+        ]
+        if let status { d["status"] = status.rawValue }
+        return d
+    }
+}

--- a/Tests/HostGatewayServerTests.swift
+++ b/Tests/HostGatewayServerTests.swift
@@ -134,4 +134,72 @@ final class HostGatewayServerTests: XCTestCase {
 
         task.cancel(with: .goingAway, reason: nil)
     }
+
+    /// The page has to come off the same port as `/ws`, or the browser client is
+    /// left on a foreign origin where `crypto.subtle` does not exist.
+    func testStaticPageServedFromSamePort() throws {
+        let webRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("gateway-web-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: webRoot, withIntermediateDirectories: true)
+        try Data("<html>cockpit</html>".utf8).write(to: webRoot.appendingPathComponent("index.html"))
+        defer { try? FileManager.default.removeItem(at: webRoot) }
+
+        let server = HostGatewayServer(
+            config: HostGatewayConfig(enabled: true, port: testPort, webRoot: webRoot.path),
+            router: ControlRouter(dataSource: ServerFakeDataSource()),
+            expectedMacId: macId,
+            rootSecretBase64url: MqttCrypto.base64url(root),
+            vt: ServerFakeVT())
+        defer { server.stop() }
+
+        waitUntilListening(server)
+
+        let exp = expectation(description: "http get")
+        var status = -1
+        var body = ""
+        var contentType = ""
+        let task = URLSession.shared.dataTask(
+            with: URL(string: "http://127.0.0.1:\(testPort)/")!
+        ) { data, response, error in
+            if let error { XCTFail("GET failed: \(error)") }
+            if let http = response as? HTTPURLResponse {
+                status = http.statusCode
+                contentType = http.value(forHTTPHeaderField: "Content-Type") ?? ""
+            }
+            body = String(decoding: data ?? Data(), as: UTF8.self)
+            exp.fulfill()
+        }
+        task.resume()
+        wait(for: [exp], timeout: 10)
+
+        XCTAssertEqual(status, 200)
+        XCTAssertEqual(body, "<html>cockpit</html>")
+        XCTAssertTrue(contentType.hasPrefix("text/html"), "got \(contentType)")
+    }
+
+    /// Static hosting must not become a file server for the rest of the disk.
+    func testUnknownPathIs404() throws {
+        let server = HostGatewayServer(
+            config: HostGatewayConfig(enabled: true, port: testPort, webRoot: NSTemporaryDirectory()),
+            router: ControlRouter(dataSource: ServerFakeDataSource()),
+            expectedMacId: macId,
+            rootSecretBase64url: MqttCrypto.base64url(root),
+            vt: ServerFakeVT())
+        defer { server.stop() }
+
+        waitUntilListening(server)
+
+        let exp = expectation(description: "http 404")
+        var status = -1
+        let task = URLSession.shared.dataTask(
+            with: URL(string: "http://127.0.0.1:\(testPort)/definitely-not-here.js")!
+        ) { _, response, _ in
+            status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            exp.fulfill()
+        }
+        task.resume()
+        wait(for: [exp], timeout: 10)
+
+        XCTAssertEqual(status, 404)
+    }
 }

--- a/Tests/HostGatewayStaticFilesTests.swift
+++ b/Tests/HostGatewayStaticFilesTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import seahelm
+
+final class HostGatewayStaticFilesTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("hostgateway-static-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("<html>index</html>".utf8).write(to: root.appendingPathComponent("index.html"))
+        try Data("var E2EE;".utf8).write(to: root.appendingPathComponent("e2ee.js"))
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private var files: HostGatewayStaticFiles { HostGatewayStaticFiles(root: root) }
+
+    func testRootServesIndex() {
+        let response = files.response(method: "GET", target: "/")
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(String(decoding: response.body, as: UTF8.self), "<html>index</html>")
+        XCTAssertEqual(response.contentType, "text/html; charset=utf-8")
+    }
+
+    func testAssetContentType() {
+        let response = files.response(method: "GET", target: "/e2ee.js")
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(response.contentType, "text/javascript; charset=utf-8")
+    }
+
+    func testQueryStringIsStripped() {
+        let response = files.response(method: "GET", target: "/e2ee.js?v=20260724")
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(String(decoding: response.body, as: UTF8.self), "var E2EE;")
+    }
+
+    func testMissingFileIs404() {
+        XCTAssertEqual(files.response(method: "GET", target: "/nope.js").status, 404)
+    }
+
+    func testTraversalIsRefused() throws {
+        // A real secret one level up: resolution must not reach it.
+        let outside = root.deletingLastPathComponent().appendingPathComponent("outside-\(UUID().uuidString).txt")
+        try Data("secret".utf8).write(to: outside)
+        defer { try? FileManager.default.removeItem(at: outside) }
+
+        let target = "/../" + outside.lastPathComponent
+        XCTAssertNil(HostGatewayStaticFiles.resolve(target: target, in: root))
+        XCTAssertEqual(files.response(method: "GET", target: target).status, 404)
+        XCTAssertEqual(files.response(method: "GET", target: "/%2e%2e/" + outside.lastPathComponent).status, 404)
+    }
+
+    func testNonGetIsRefused() {
+        XCTAssertEqual(files.response(method: "POST", target: "/").status, 405)
+    }
+
+    func testMissingRootIs404() {
+        XCTAssertEqual(HostGatewayStaticFiles(root: nil).response(method: "GET", target: "/").status, 404)
+    }
+
+    func testResolveRootRejectsMissingOverride() {
+        XCTAssertNil(HostGatewayStaticFiles.resolveRoot(override: "/no/such/dir/anywhere"))
+        XCTAssertEqual(HostGatewayStaticFiles.resolveRoot(override: root.path)?.path, root.path)
+    }
+
+    func testSerializeHeadOmitsBodyButKeepsLength() {
+        let response = files.response(method: "HEAD", target: "/")
+        let wire = String(decoding: HostGatewayStaticFiles.serialize(response, includeBody: false), as: UTF8.self)
+        XCTAssertTrue(wire.hasPrefix("HTTP/1.1 200 OK\r\n"))
+        XCTAssertTrue(wire.contains("Content-Length: 18\r\n"))
+        XCTAssertTrue(wire.hasSuffix("\r\n\r\n"))
+        XCTAssertFalse(wire.contains("<html>"))
+    }
+
+    func testRequestParsing() {
+        XCTAssertTrue(HostGatewayServer.isWebSocketUpgrade(
+            head: "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: WebSocket\r\nConnection: Upgrade"))
+        XCTAssertFalse(HostGatewayServer.isWebSocketUpgrade(
+            head: "GET / HTTP/1.1\r\nHost: x\r\nUser-Agent: upgrade-websocket-lookalike"))
+
+        let line = HostGatewayServer.requestLine(head: "get /a/b?c=1 HTTP/1.1\r\nHost: x")
+        XCTAssertEqual(line.method, "GET")
+        XCTAssertEqual(line.target, "/a/b?c=1")
+        XCTAssertEqual(HostGatewayServer.requestPath("/ws?token=x"), "/ws")
+    }
+}

--- a/Tests/RemoteMirroringTests.swift
+++ b/Tests/RemoteMirroringTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import seahelm
+
+/// A data source that only knows how to mirror a window — everything else falls
+/// through to the protocol-extension defaults, which is the point: adding the
+/// mirroring surface must not force existing conformers to implement it.
+private final class MirrorDataSource: ControlDataSource {
+    var layouts: [String: [String: Any]]?
+    var groupsByMode: [String: [[String: Any]]] = [:]
+    private(set) var requestedModes: [String] = []
+
+    func snapshotPanes() -> [PaneSnapshot] { [] }
+    func snapshotPanes(includingMemory: Bool) -> [PaneSnapshot] { [] }
+    func readPane(paneId: String, source: String, lines: Int) -> String? { nil }
+    func ingestHook(json: [String: Any]) -> String? { nil }
+    func sendKeys(paneId: String, keys: [String]) -> Bool { false }
+
+    func liveLayouts() -> [String: [String: Any]]? { layouts }
+    func worktreeGroups(mode: String) -> [[String: Any]]? {
+        requestedModes.append(mode)
+        return groupsByMode[mode]
+    }
+}
+
+final class RemoteMirroringTests: XCTestCase {
+
+    // MARK: - Wire shape
+
+    func testLeafCarriesTheKeyVTOpenTakes() {
+        let node = CodableSplitNode.leaf(paneSessionKey: "seahelm-repo-main", title: "claude")
+        let d = node.dict
+        XCTAssertEqual(d["type"] as? String, "leaf")
+        XCTAssertEqual(d["pane_session_key"] as? String, "seahelm-repo-main")
+        XCTAssertEqual(d["title"] as? String, "claude")
+    }
+
+    func testEmptyTitleIsOmittedRatherThanShippedBlank() {
+        let d = CodableSplitNode.leaf(paneSessionKey: "k", title: "").dict
+        XCTAssertNil(d["title"])
+    }
+
+    func testNestedSplitSerializesBothAxes() {
+        let tree = CodableSplitNode.split(
+            axis: "horizontal", ratio: 0.6,
+            first: .leaf(paneSessionKey: "a", title: nil),
+            second: .split(axis: "vertical", ratio: 0.25,
+                           first: .leaf(paneSessionKey: "b", title: nil),
+                           second: .leaf(paneSessionKey: "c", title: nil)))
+        let d = tree.dict
+        XCTAssertEqual(d["axis"] as? String, "horizontal")
+        XCTAssertEqual(d["ratio"] as? Double, 0.6)
+        let second = d["second"] as? [String: Any]
+        XCTAssertEqual(second?["axis"] as? String, "vertical")
+        let inner = second?["first"] as? [String: Any]
+        XCTAssertEqual(inner?["pane_session_key"] as? String, "b")
+    }
+
+    // MARK: - layout.live
+
+    func testLayoutLiveReturnsEveryWorktree() {
+        let ds = MirrorDataSource()
+        ds.layouts = ["/wt/a": ["root": ["type": "leaf", "pane_session_key": "a"]]]
+        guard case .ok(let d) = ControlRouter(dataSource: ds)
+            .handle(method: "layout.live", params: [:]) else { return XCTFail() }
+        XCTAssertEqual((d["layouts"] as? [String: Any])?.count, 1)
+    }
+
+    func testLayoutLiveNarrowsToOneWorktree() {
+        let ds = MirrorDataSource()
+        ds.layouts = [
+            "/wt/a": ["root": ["type": "leaf", "pane_session_key": "a"]],
+            "/wt/b": ["root": ["type": "leaf", "pane_session_key": "b"]],
+        ]
+        let router = ControlRouter(dataSource: ds)
+        guard case .ok(let d) = router
+            .handle(method: "layout.live", params: ["worktree_path": "/wt/b"]) else { return XCTFail() }
+        XCTAssertEqual((d["root"] as? [String: Any])?["pane_session_key"] as? String, "b")
+
+        guard case .error(let code, _) = router
+            .handle(method: "layout.live", params: ["worktree_path": "/wt/zzz"]) else { return XCTFail() }
+        XCTAssertEqual(code, ControlError.notFound)
+    }
+
+    func testLayoutLiveWithoutAWindowIsNotFound() {
+        guard case .error(let code, _) = ControlRouter(dataSource: MirrorDataSource())
+            .handle(method: "layout.live", params: [:]) else { return XCTFail() }
+        XCTAssertEqual(code, ControlError.notFound)
+    }
+
+    // MARK: - fleet.groups
+
+    func testFleetGroupsDefaultsToRepository() {
+        let ds = MirrorDataSource()
+        ds.groupsByMode["repository"] = [["id": "repository:seahelm", "title": "seahelm", "items": []]]
+        guard case .ok(let d) = ControlRouter(dataSource: ds)
+            .handle(method: "fleet.groups", params: [:]) else { return XCTFail() }
+        XCTAssertEqual(d["mode"] as? String, "repository")
+        XCTAssertEqual((d["groups"] as? [[String: Any]])?.first?["title"] as? String, "seahelm")
+        XCTAssertEqual(ds.requestedModes, ["repository"])
+    }
+
+    func testFleetGroupsPassesTheRequestedMode() {
+        let ds = MirrorDataSource()
+        ds.groupsByMode["status"] = [["id": "status:Waiting", "title": "Needs input", "items": []]]
+        guard case .ok(let d) = ControlRouter(dataSource: ds)
+            .handle(method: "fleet.groups", params: ["mode": "status"]) else { return XCTFail() }
+        XCTAssertEqual(d["mode"] as? String, "status")
+        XCTAssertEqual(ds.requestedModes, ["status"])
+    }
+
+    // MARK: - Mode vocabulary
+
+    func testWireModesMapOntoTheDashboardsOwnModes() {
+        XCTAssertEqual(WorktreeGroupingMode(wire: "repository"), .repository)
+        XCTAssertEqual(WorktreeGroupingMode(wire: "status"), .status)
+        XCTAssertEqual(WorktreeGroupingMode(wire: "activity"), .activityTime)
+        XCTAssertEqual(WorktreeGroupingMode(wire: "time"), .activityTime)
+        // Anything unrecognised lands on the mode the desktop also starts in.
+        XCTAssertEqual(WorktreeGroupingMode(wire: "nonsense"), .repository)
+        for mode in WorktreeGroupingMode.allCases {
+            XCTAssertEqual(WorktreeGroupingMode(wire: mode.wire), mode, "round trip for \(mode)")
+        }
+    }
+
+    func testGroupSerializationCarriesStatusAndItems() {
+        let item = WorktreeGroupingItem(
+            id: "w1", path: "/wt/a", repository: "seahelm", status: .waiting,
+            lastActivityAt: Date(timeIntervalSince1970: 1000), isMainWorktree: true,
+            creationDate: Date(timeIntervalSince1970: 0))
+        let group = WorktreeGroup(id: .status(.waiting), title: "Needs input", status: .waiting, items: [item])
+        let d = group.dict
+        XCTAssertEqual(d["id"] as? String, "status:Waiting")
+        XCTAssertEqual(d["status"] as? String, "Waiting")
+        let items = d["items"] as? [[String: Any]]
+        XCTAssertEqual(items?.first?["worktree_path"] as? String, "/wt/a")
+        XCTAssertEqual(items?.first?["status"] as? String, "Waiting")
+        XCTAssertEqual(items?.first?["last_activity_at"] as? Double, 1000)
+        XCTAssertEqual(items?.first?["is_main_worktree"] as? Bool, true)
+    }
+}

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -126,6 +126,20 @@
   #termWrap{flex:1 1 auto;min-height:0;background:#05090c;
     border:1px solid var(--line-12);border-radius:var(--r);padding:6px;overflow:auto}
   #term{width:100%;height:100%}
+  /* Mirrored split tree. Slots are flex shares of the Mac's ratios; there are
+     deliberately no drag handles — this is a mirror, and the panes belong to
+     the machine that owns them. */
+  .vt-split{display:flex;width:100%;height:100%;gap:5px;min-width:0;min-height:0}
+  .vt-slot{display:flex;min-width:0;min-height:0}
+  .vt-slot>*{flex:1 1 auto;min-width:0;min-height:0}
+  .vt-leaf{display:flex;flex-direction:column;min-width:0;min-height:0;overflow:hidden;
+    border:1px solid var(--line-12);border-radius:var(--r);background:#05090c}
+  .vt-leaf.on{border-color:var(--accent-20)}
+  .vt-leaf-title{flex:none;font-size:10px;letter-spacing:.06em;color:var(--muted);
+    padding:3px 7px;background:var(--panel);border-bottom:1px solid var(--line-12);
+    white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .vt-leaf.on .vt-leaf-title{color:var(--accent)}
+  .vt-host{flex:1 1 auto;min-height:0;min-width:0;overflow:hidden}
   #termWrap.empty{display:flex;align-items:center;justify-content:center}
   /* Scrolled back in a live terminal, there is otherwise no way home but to
      swipe all the way down — and new output keeps arriving below you. */
@@ -167,6 +181,11 @@
   .fm-add{flex:none;background:none;border:0;color:var(--muted);cursor:pointer;
     font-family:var(--mono);font-size:13px;line-height:1;padding:0 2px;border-radius:3px}
   .fm-add:hover{color:var(--accent)}
+  .fm-modes{display:flex;gap:4px;margin:0 0 10px}
+  .fm-modes button{flex:1;background:var(--panel);color:var(--muted);
+    border:1px solid var(--line-12);border-radius:var(--r);padding:4px 0;
+    font-family:var(--mono);font-size:11px;cursor:pointer}
+  .fm-modes button.on{background:var(--accent-12);border-color:var(--line-38);color:var(--accent)}
   .fm-rows{display:flex;flex-direction:column;gap:4px}
   .fm-row{display:flex;gap:7px;padding:8px 10px;border-radius:8px;cursor:pointer;
     transition:background .12s}
@@ -272,6 +291,11 @@
         <span class="fm-title">First mate</span>
         <span class="fm-sub" id="fmSub">0 projects · 0 running</span>
       </div>
+      <div class="fm-modes" id="fmModes">
+        <button data-mode="repository">项目</button>
+        <button data-mode="status">状态</button>
+        <button data-mode="activity">时间</button>
+      </div>
       <div class="fm-scroll">
         <div id="tree"></div>
       </div>
@@ -310,18 +334,25 @@ const S = {
   sel:null, selPane:null,
   encKey:null, authPass:null,   // set once a seahelm:// pair link is applied (E2EE on)
   // VT terminal: `open` is the pane key currently streaming
-  vt:{ term:null, open:null, pending:'', flushT:null },
+  // One entry per mirrored pane, keyed by paneSessionKey; `focus` is the pane
+  // keystrokes reach, `worktree` is the layout currently mounted.
+  vt:{ panes:new Map(), focus:null, worktree:null },
+  // Groups are computed Mac-side (fleet.groups) so the browser cannot drift
+  // from the dashboard; `groups` is null until the first reply lands.
+  grouping:{ mode: localStorage.getItem('seahelm_grouping') || 'repository', groups:null },
 };
 // Opening size only. zmx reports no geometry and has no resize verb, so the
 // bridge reads the session's real grid from outside (pid → tty → `stty size`)
 // and ships it with the snapshot; we resize to that before replaying. These
 // numbers just give the terminal a sane box for the moment before it lands.
-// Sizing stays one-way — the remote adapts by scaling the font (fitTermFont),
-// it cannot make the Mac-side pane a different shape.
+// Sizing stays one-way — we mirror the Mac's split tree and scale each pane's
+// font to its slot (fitPaneFont); we cannot reshape a Mac-side pane.
 const VT_COLS = 120, VT_ROWS = 32;
-// The size the terminal renders at when the grid fits; fitTermFont scales down
-// from here and never past it. VT_FONT_MIN is where shrinking stops being worth
-// it — below this you cannot read the pane anyway, so we pan instead.
+// The size a pane renders at when its grid fits. fitPaneFont only ever scales
+// DOWN from here: mirroring the Mac's layout already gives each slot roughly the
+// shape of the grid inside it, so the base size is the intended size rather than
+// a floor to grow off. VT_FONT_MIN is where shrinking stops being worth it —
+// below this you cannot read the pane anyway, so we pan instead.
 const VT_FONT_BASE = 12, VT_FONT_MIN = 9;
 // SailorStatus.color, 1:1 with Sources/Core/SailorStatus.swift (dark values).
 // `waiting` is the amber attention accent, NOT the blue one — the Mac routes
@@ -489,13 +520,37 @@ function onGatewayNotify(method, params){
   }
 }
 
+/** Ask the Mac to group the fleet the way its dashboard would. */
+function refreshGroups(){
+  if (S.transport !== 'gateway' || !isLinked()) { renderTree(); return; }
+  const mode = S.grouping.mode;
+  sendCommand('fleet.groups', { mode }, (r) => {
+    if (S.grouping.mode !== mode) return;            // mode changed while in flight
+    S.grouping.groups = (r && r.ok !== false && r.result && r.result.groups) || null;
+    renderTree();
+  });
+}
+function setGroupingMode(mode){
+  S.grouping.mode = mode;
+  localStorage.setItem('seahelm_grouping', mode);
+  syncModeButtons();
+  refreshGroups();
+}
+function syncModeButtons(){
+  for (const b of document.querySelectorAll('#fmModes button'))
+    b.classList.toggle('on', b.dataset.mode === S.grouping.mode);
+}
+for (const b of document.querySelectorAll('#fmModes button'))
+  b.onclick = () => setGroupingMode(b.dataset.mode);
+syncModeButtons();
+
 function applySessionSnapshot(result){
   S.panes.clear();
   for (const p of (result.panes || [])) {
     const key = p.pane_session_key || p.pane_id;
     if (key) S.panes.set(key, p);
   }
-  renderTree();
+  refreshGroups();
 }
 
 function connectMqtt(url){
@@ -747,37 +802,56 @@ function buildFleet(){
   return rows;
 }
 
+/**
+ * Groups to draw. The Mac's own grouping (fleet.groups) wins, so the list shows
+ * exactly what the dashboard shows — including "Needs input" or "Recent hour"
+ * headers this side never computes. The local fallback is repository order, the
+ * mode the desktop also starts in, for MQTT/offline sessions.
+ */
+function groupsToRender(rows){
+  const byPath = new Map(rows.map(r => [r.path, r]));
+  const server = S.grouping.groups;
+  if (server && server.length){
+    return server.map(g => ({
+      title: g.title,
+      status: g.status || null,
+      isRepo: String(g.id || '').startsWith('repository:'),
+      rows: (g.items || []).map(i => byPath.get(i.worktree_path)).filter(Boolean),
+    })).filter(g => g.rows.length);
+  }
+  const local = new Map();
+  for (const r of rows){
+    if (!local.has(r.project)) local.set(r.project, []);
+    local.get(r.project).push(r);
+  }
+  for (const list of local.values()) list.sort((a,b) => (b.startedAt||0) - (a.startedAt||0));
+  return [...local.entries()].sort((a,b) => a[0].localeCompare(b[0]))
+    .map(([title, list]) => ({ title, status:null, isRepo:true, rows:list }));
+}
+
 function renderTree(){
   const t = $('tree'); t.innerHTML='';
   const rows = buildFleet();
   updateFirstMateHeader(rows);
   if (!rows.length){ t.innerHTML='<div class="muted">无 pane</div>'; renderSuggestions(); return; }
 
-  // Repository groups, most recently started worktree first inside each.
-  const groups = new Map();
-  for (const r of rows){
-    if (!groups.has(r.project)) groups.set(r.project, []);
-    groups.get(r.project).push(r);
-  }
-  for (const list of groups.values()){
-    list.sort((a,b) => (b.startedAt||0) - (a.startedAt||0));
-  }
-
-  for (const [project, list] of [...groups.entries()].sort((a,b)=>a[0].localeCompare(b[0]))){
+  for (const group of groupsToRender(rows)){
     const g = document.createElement('div'); g.className='fm-group';
     const head = document.createElement('div'); head.className='fm-group-head';
-    head.innerHTML = `<span class="fm-deck">${esc(project)}</span>`
-      + `<button class="fm-add" title="新建 worktree">+</button>`;
+    head.innerHTML = (group.status ? statusDotHTML(group.status, 'fm-dot') : '')
+      + `<span class="fm-deck">${esc(group.title)}</span>`
+      + (group.isRepo ? `<button class="fm-add" title="新建 worktree">+</button>` : '');
     // The Mac opens the helm prefilled with `/worktree @<project>`; the web has
     // no helm, so this is deliberately inert rather than pretending to work.
-    head.querySelector('.fm-add').onclick = (e) => {
+    const add = head.querySelector('.fm-add');
+    if (add) add.onclick = (e) => {
       e.stopPropagation();
-      log('sys','(not wired)', `新建 worktree @${project} —— web 端暂未接`);
+      log('sys','(not wired)', `新建 worktree @${group.title} —— web 端暂未接`);
     };
     g.appendChild(head);
 
     const box = document.createElement('div'); box.className='fm-rows';
-    for (const r of list){
+    for (const r of group.rows){
       const sel = S.sel === r.path;
       const row = document.createElement('div');
       row.className = 'fm-row' + (sel ? ' sel' : '');
@@ -840,9 +914,9 @@ function selectPaneByKey(key){
   if (row) selectWorktree(row, key);
 }
 
-// The grid is fixed by the remote, so the only thing a window resize can change
-// is how big we draw it.
-window.addEventListener('resize', () => { if (S.vt.term) fitTermFont(); });
+// Every pane is drawn at whatever size its slot in the mirrored layout gives it,
+// so a window resize means refitting all of them, not one.
+window.addEventListener('resize', fitAllPanes);
 
 /** Retick the elapsed labels in place — no re-render, no scroll jump. */
 function tickTimes(){
@@ -854,163 +928,246 @@ function tickTimes(){
   }
 }
 setInterval(tickTimes, 1000);
-/** The mid column is the terminal. Selecting a pane is the only thing that fills it. */
+
+// ── Mirrored pane layout ────────────────────────────────────────────────────
+// The mid column shows the whole worktree, not one pane: the Mac ships its live
+// split tree (`layout.live`) and we rebuild it here as nested flex boxes. Two
+// reasons this beats picking a pane and scaling it up. It is the same window the
+// user already knows, and — less obviously — a slot in the mirrored tree has
+// roughly the aspect ratio of the pane that lives in it, so fitting a grid into
+// it stops being a fight. Dividers are deliberately inert: this is a mirror, and
+// resizing belongs to the machine that owns the panes.
+
+/** The mid column is the worktree. Selecting one mounts its whole layout. */
 function renderDetail(){
-  const key = S.selPane; const head = $('detailHead'); const wrap = $('termWrap');
-  // A terminal belongs to one pane; switching panes tears the old stream down.
-  if (S.vt.open && S.vt.open !== key) closeTerm();
-  if (!key){
+  const head = $('detailHead'), wrap = $('termWrap');
+  if (!S.sel){
+    unmountPanes();
     head.textContent = '终端';
     wrap.classList.add('empty');
-    if (!S.vt.term) wrap.innerHTML = '<div id="term"></div>';
+    wrap.innerHTML = '<div class="muted">选择一个 worktree</div>';
     return;
   }
-  const p = S.panes.get(key) || {};
   const row = buildFleet().find(r => r.path === S.sel);
-  head.textContent = [row && row.project, row && row.branch, (p.title||key)]
-    .filter(Boolean).join(' · ');
+  head.textContent = [row && row.project, row && row.branch].filter(Boolean).join(' · ') || S.sel;
   wrap.classList.remove('empty');
-  if (S.vt.open !== key) openTerm(key);
+  // Already mirroring this worktree — a click inside it only moves focus.
+  if (S.vt.worktree === S.sel){
+    if (S.selPane && S.vt.panes.has(S.selPane)) focusPane(S.selPane);
+    return;
+  }
+  requestLayout(S.sel);
 }
 
-// ── VT terminal ─────────────────────────────────────────────────────────────
-// Renders the raw PTY byte stream a `zmx tail` produces. Nothing here knows
-// about Ghostty — in a browser xterm.js *is* the renderer, which is the whole
-// reason this PoC can validate the transport without touching libghostty.
+/** Fetch the worktree's live tree; fall back to a stack if the Mac has none. */
+function requestLayout(path){
+  sendCommand('layout.live', { worktree_path: path }, (r) => {
+    if (S.sel !== path) return;                    // selection moved while in flight
+    const root = r && r.ok !== false && r.result && r.result.root;
+    if (!root){
+      // No live tree (worktree closed on the Mac) — stack what we know of it.
+      mountPanes(stackedTreeFor(path), null, path);
+      return;
+    }
+    mountPanes(root, r.result.focused_pane_session_key || null, path);
+  });
+}
+
+/** Fallback shape: every known pane of the worktree, stacked top to bottom. */
+function stackedTreeFor(path){
+  const row = buildFleet().find(r => r.path === path);
+  const keys = (row ? row.panes : []).map(([k]) => k).filter(Boolean);
+  if (!keys.length) return null;
+  return keys.map(k => ({ type:'leaf', pane_session_key:k }))
+             .reduce((a, b) => ({ type:'split', axis:'vertical', ratio:0.5, first:a, second:b }));
+}
+
+function mountPanes(tree, focusKey, path){
+  unmountPanes();
+  const wrap = $('termWrap');
+  wrap.innerHTML = '';
+  if (!tree){
+    wrap.classList.add('empty');
+    wrap.innerHTML = '<div class="muted">无 pane</div>';
+    return;
+  }
+  S.vt.worktree = path;
+  wrap.appendChild(buildLayoutNode(tree));
+  for (const key of S.vt.panes.keys()){
+    sendCommand('pane.vt_open', { pane_session_key: key, cols: VT_COLS, rows: VT_ROWS }, (r) => {
+      if (r && r.ok === false) log('sys','(vt open failed)', JSON.stringify(r.error||r));
+    });
+  }
+  focusPane(focusKey || S.selPane || S.vt.panes.keys().next().value || null);
+  fitAllPanes();
+}
+
+function unmountPanes(){
+  for (const [key, entry] of S.vt.panes){
+    if (isLinked()) sendCommand('pane.vt_close', { pane_session_key: key });
+    if (entry.flushT) clearTimeout(entry.flushT);
+    try { entry.term.dispose(); } catch (e) {}
+  }
+  S.vt.panes.clear();
+  S.vt.focus = null;
+  S.vt.worktree = null;
+}
+
+function buildLayoutNode(node){
+  if (!node) return document.createElement('div');
+  if (node.type === 'leaf') return buildLayoutLeaf(node);
+  const el = document.createElement('div');
+  el.className = 'vt-split';
+  // horizontal = left | right, vertical = top / bottom (SplitAxis in SplitNode.swift).
+  el.style.flexDirection = node.axis === 'horizontal' ? 'row' : 'column';
+  const ratio = Math.min(0.9, Math.max(0.1, Number(node.ratio) || 0.5));
+  for (const [child, share] of [[node.first, ratio], [node.second, 1 - ratio]]){
+    const slot = document.createElement('div');
+    slot.className = 'vt-slot';
+    slot.style.flex = share + ' 1 0';
+    slot.appendChild(buildLayoutNode(child));
+    el.appendChild(slot);
+  }
+  return el;
+}
+
+function buildLayoutLeaf(node){
+  const key = node.pane_session_key;
+  const el = document.createElement('div');
+  el.className = 'vt-leaf';
+  el.dataset.key = key;
+
+  const bar = document.createElement('div');
+  bar.className = 'vt-leaf-title';
+  const known = S.panes.get(key) || {};
+  bar.textContent = node.title || known.title || key;
+
+  const host = document.createElement('div');
+  host.className = 'vt-host';
+  el.appendChild(bar); el.appendChild(host);
+
+  const t = new Terminal({
+    cols:VT_COLS, rows:VT_ROWS, convertEol:false, scrollback:5000,
+    fontFamily:'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize:VT_FONT_BASE,
+    theme:{ background:'#05090c', foreground:'#c8d6d5' },
+  });
+  t.open(host);
+  const entry = { term:t, el, host, pending:'', flushT:null };
+  S.vt.panes.set(key, entry);
+
+  // xterm only fires onData for the terminal that actually holds focus, so each
+  // pane can own its own outbound path — no routing table, no focus bookkeeping.
+  t.onData((data) => {
+    entry.pending += data;
+    if (entry.flushT) return;
+    entry.flushT = setTimeout(() => {
+      entry.flushT = null;
+      const buf = entry.pending; entry.pending = '';
+      if (!buf || !isLinked()) return;
+      sendCommand('pane.send_keys',
+        { pane_session_key: key, b64: bytesToB64(new TextEncoder().encode(buf)) });
+    }, 10);
+  });
+  t.onScroll(() => { if (S.vt.focus === key) updateToBottom(); });
+  el.addEventListener('mousedown', () => focusPane(key));
+  return el;
+}
+
+function focusPane(key){
+  S.vt.focus = key;
+  for (const [k, entry] of S.vt.panes) entry.el.classList.toggle('on', k === key);
+  const entry = key && S.vt.panes.get(key);
+  if (entry) { try { entry.term.focus(); } catch (e) {} }
+  updateToBottom();
+}
+
+function fitAllPanes(){
+  for (const entry of S.vt.panes.values()) fitPaneFont(entry);
+}
+
+/**
+ * Scale one pane's font so its grid fills its slot.
+ * The grid is dictated by the Mac side and cannot be renegotiated, so the only
+ * free variable is how big we draw it — down from VT_FONT_BASE, never past it.
+ * Constrains on BOTH axes and takes the tighter one: width alone lets a tall
+ * session run off the bottom, height alone lets a wide one spill out the side.
+ */
+function fitPaneFont(entry){
+  const t = entry.term;
+  const screen = entry.host.querySelector('.xterm-screen');
+  if (!screen) return;
+  const box = screen.getBoundingClientRect();
+  const availW = entry.host.clientWidth - 4, availH = entry.host.clientHeight - 4;
+  if (!box.width || !box.height || availW <= 0 || availH <= 0) return;
+
+  const scale = Math.min(availW / box.width, availH / box.height);
+  let size = Math.max(VT_FONT_MIN, Math.min(VT_FONT_BASE, Math.floor(t.options.fontSize * scale)));
+  if (size !== t.options.fontSize) t.options.fontSize = size;
+
+  // xterm rounds cell metrics to whole pixels, so cell size is a step function of
+  // font size and the linear guess can still overflow. Step down until it really
+  // fits — but never past the readable floor, below which panning is the honest
+  // answer rather than smaller type.
+  for (let i = 0; i < 8 && size > VT_FONT_MIN; i++){
+    const el = entry.host.querySelector('.xterm-screen');
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    if (rect.width <= availW && rect.height <= availH) break;
+    size -= 1;
+    t.options.fontSize = size;
+  }
+}
+
 function b64ToBytes(b64){
   const s = atob(b64); const a = new Uint8Array(s.length);
   for (let i=0;i<s.length;i++) a[i]=s.charCodeAt(i);
   return a;
 }
+function bytesToB64(bytes){
+  let s=''; for (let i=0;i<bytes.length;i++) s+=String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+
 /** Shared VT path for MQTT topic payloads and Gateway notify frames. */
 function handleVT(paneKey, v){
   if (!v) return;
+  const entry = S.vt.panes.get(paneKey);
+  if (!entry) return;                       // a pane we are not mirroring right now
   const bytes = v.b64 ? b64ToBytes(v.b64) : new Uint8Array(0);
   if (v.type !== 'vt.snapshot' && !bytes.length) return;
-  if (S.vt.open !== paneKey) return;
-  const t = ensureTerm();
+  const t = entry.term;
   if (v.type === 'vt.snapshot'){
     if (v.cols && v.rows && (t.cols !== v.cols || t.rows !== v.rows)){
       t.resize(v.cols, v.rows);
       log('sys','(vt resize)', `${v.cols}x${v.rows} — matched session geometry`);
     }
     t.reset();
-    if (bytes.length) t.write(bytes, () => fitTermFont());
-    else fitTermFont();
-    updateToBottom();
+    if (bytes.length) t.write(bytes, () => fitPaneFont(entry));
+    else fitPaneFont(entry);
+    if (S.vt.focus === paneKey) updateToBottom();
     return;
   }
   t.write(bytes);
 }
-function bytesToB64(bytes){
-  let s=''; for (let i=0;i<bytes.length;i++) s+=String.fromCharCode(bytes[i]);
-  return btoa(s);
-}
-function ensureTerm(){
-  if (S.vt.term) return S.vt.term;
-  const t = new Terminal({
-    cols:VT_COLS, rows:VT_ROWS, convertEol:false, scrollback:5000,
-    fontFamily:'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize:VT_FONT_BASE,
-    theme:{ background:'#05090c', foreground:'#c8d6d5' },
-  });
-  t.open($('term'));
-  // Keystrokes go out as base64 of the UTF-8 bytes: the bridge feeds them
-  // straight to `zmx send`, so control bytes and escapes survive intact.
-  // Coalesced over a frame — one message per burst of typing rather than per
-  // character. The bridge also serializes sends, which is what actually
-  // guarantees order; this just keeps the message count sane.
-  t.onData((data) => {
-    if (!S.vt.open) return;
-    S.vt.pending += data;
-    if (S.vt.flushT) return;
-    S.vt.flushT = setTimeout(() => {
-      S.vt.flushT = null;
-      const buf = S.vt.pending; S.vt.pending = '';
-      if (!buf || !S.vt.open) return;
-      sendCommand('pane.send_keys',
-        { pane_session_key:S.vt.open, b64: bytesToB64(new TextEncoder().encode(buf)) });
-    }, 10);
-  });
-  // Scrolled away from the live edge, offer the way back — new output keeps
-  // landing below you and xterm deliberately holds your position.
-  t.onScroll(() => updateToBottom());
-  S.vt.term = t;
-  return t;
-}
+
+/** The "back to live" affordance tracks whichever pane has focus. */
 function updateToBottom(){
-  const t = S.vt.term, btn = $('toBottom');
+  const btn = $('toBottom');
   if (!btn) return;
-  if (!t || !S.vt.open) { btn.classList.remove('on'); return; }
-  const b = t.buffer.active;
+  const entry = S.vt.focus ? S.vt.panes.get(S.vt.focus) : null;
+  if (!entry){ btn.classList.remove('on'); return; }
+  const b = entry.term.buffer.active;
   btn.classList.toggle('on', b.viewportY < b.baseY);
 }
-/**
- * Scale the font so the session's rows fit the column.
- * The grid size is dictated by the Mac side and cannot be renegotiated, so the
- * only free variable is how big we draw it. Measures a real rendered row rather
- * than assuming a line-height ratio, then clamps to something still readable.
- */
-function fitTermFont(){
-  const t = S.vt.term, wrap = $('termWrap');
-  if (!t || !wrap) return;
-  const screen = document.querySelector('#term .xterm-screen');
-  if (!screen) return;
-  const box = screen.getBoundingClientRect();
-  if (!box.width || !box.height) return;
 
-  // Constrain on BOTH axes and take the tighter one. Fitting height alone let a
-  // wide session (128 cols) spill ~118px past the column, so the right-hand edge
-  // of the terminal was only reachable by scrolling sideways.
-  const availW = wrap.clientWidth - 14;                  // padding + border
-  if (availW <= 0) return;
-
-  // Fit on WIDTH, not on both axes. Two reasons: broken/clipped columns ruin a
-  // TUI far more than a bit of vertical scrolling does, and leaving the vertical
-  // axis alone keeps it free for xterm's own scrollback scroller, so the two
-  // never fight over the same gesture. Clamp up to the base size but never past
-  // it — this also runs after the debug panel is hidden, and the terminal should
-  // grow back into the space it gained.
-  const desired = availW * t.options.fontSize / box.width;
-  let size = Math.max(VT_FONT_MIN, Math.min(VT_FONT_BASE, Math.floor(desired)));
-  if (size !== t.options.fontSize) t.options.fontSize = size;
-
-  // xterm rounds cell metrics to whole pixels, so cell size is a step function of
-  // font size and the linear guess can still overflow (measured: 128 cols still
-  // spilled 60px). Step down until it genuinely fits — but never past the
-  // readable floor. 128 columns cannot be legible on a 390px phone at any size,
-  // so below the floor panning is the honest answer, not smaller type.
-  for (let i = 0; i < 8 && size > VT_FONT_MIN; i++){
-    const el = document.querySelector('#term .xterm-screen');
-    if (!el) return;
-    if (el.getBoundingClientRect().width <= availW) break;
-    size -= 1;
-    t.options.fontSize = size;
-  }
-}
-function openTerm(pid){
-  if (!isLinked()) return alert('未连接');
-  if (S.vt.open === pid) return;
-  closeTerm();
-  const t = ensureTerm();
-  t.reset();
-  S.vt.open = pid;
-  // Geometry is applied from the snapshot message (it lands first); the reply is
-  // only useful for surfacing a failure.
-  sendCommand('pane.vt_open', { pane_session_key: pid, cols: VT_COLS, rows: VT_ROWS }, (r) => {
-    if (r && r.ok === false) log('sys','(vt open failed)', JSON.stringify(r.error||r));
-  });
-}
-function closeTerm(){
-  if (!S.vt.open) return;
-  if (isLinked()) sendCommand('pane.vt_close', { pane_session_key: S.vt.open });
-  S.vt.open = null;
-}
 // An attach client is a real client of the zmx session, so leaving one behind is
-// not harmless. vt_close covers the tidy exits; this covers closing the tab, and
-// the bridge's lease sweep covers a crash, where neither of these ever runs.
-window.addEventListener('pagehide', closeTerm);
+// not harmless — and mirroring a layout opens one per pane, which multiplies the
+// cost of getting this wrong. vt_close covers the tidy exits; pagehide covers
+// closing the tab; the bridge's lease sweep covers a crash, where neither runs.
+window.addEventListener('pagehide', unmountPanes);
 setInterval(() => {
-  if (S.vt.open && isLinked()) sendCommand('pane.vt_keepalive', { pane_session_key: S.vt.open });
+  if (!isLinked()) return;
+  for (const key of S.vt.panes.keys()) sendCommand('pane.vt_keepalive', { pane_session_key: key });
 }, 20000);
 // ── outbound (commands) ─────────────────────────────────────────────────────
 let corrN=0;
@@ -1067,7 +1224,11 @@ $('connectBtn').onclick=connect;
 $('dndBtn').onclick=toggleDnd;
 $('drawerBtn').onclick=()=>setDrawer(!$('leftcol').classList.contains('open'));
 $('scrim').onclick=()=>setDrawer(false);
-$('toBottom').onclick=()=>{ if (S.vt.term) S.vt.term.scrollToBottom(); updateToBottom(); };
+$('toBottom').onclick=()=>{
+  const e = S.vt.focus && S.vt.panes.get(S.vt.focus);
+  if (e) e.term.scrollToBottom();
+  updateToBottom();
+};
 // Debug panel is a developer surface — remembered per browser so it stays out
 // of the way once you've dismissed it.
 function applyLogVisibility(){
@@ -1076,7 +1237,7 @@ function applyLogVisibility(){
   const btn = $('logBtn');
   btn.classList.toggle('on', !off);
   btn.title = off ? '显示报文日志' : '隐藏报文日志';
-  if (S.vt.term) setTimeout(fitTermFont, 200);   // the terminal just got wider
+  setTimeout(fitAllPanes, 200);   // the panes just got wider
 }
 $('logBtn').onclick = () => {
   const off = localStorage.getItem('seahelm_log_off') === '1';

--- a/project.yml
+++ b/project.yml
@@ -142,6 +142,20 @@ targets:
           RES="${CODESIGNING_FOLDER_PATH}/Contents/Resources"
           rm -rf "${RES}/terminfo"
           cp -R "${RES}/ghostty/terminfo" "${RES}/terminfo"
+      # HostGatewayServer serves this directory at `/`, same origin as `/ws`.
+      # Copied by script rather than as a folder reference because devbroker/ is
+      # a 17MB dev-only MQTT harness that has no business in the shipped bundle.
+      - name: "Bundle seahelm-web client"
+        basedOnDependencyAnalysis: false
+        script: |
+          set -euo pipefail
+          SRC="${SRCROOT}/clients/seahelm-web"
+          DEST="${CODESIGNING_FOLDER_PATH}/Contents/Resources/seahelm-web"
+          rm -rf "${DEST}"
+          mkdir -p "${DEST}"
+          rsync -a \
+            --exclude 'devbroker' --exclude '.gitignore' --exclude 'README.md' \
+            "${SRC}/" "${DEST}/"
     sources:
       - path: Sources
         type: group

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		1063EE7F5505310F9DEE6E07 /* SuggestGuidanceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159B10196D13B333CFC76E1D /* SuggestGuidanceWriter.swift */; };
 		10D70ABC6FF1371989A62258 /* ClaudeUsageSummaryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258A1C3E5F11466A79C1CAF3 /* ClaudeUsageSummaryProvider.swift */; };
 		11D083414156821D443B9356 /* IMessageChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB2DB0B6757C922D065765 /* IMessageChannel.swift */; };
+		12348F72590729F9B44FC244 /* HostGatewayStaticFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADAB7F280D7925E9A0CD660C /* HostGatewayStaticFiles.swift */; };
 		12702A1B7B7DD78FD49D65D5 /* AppFont.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E9418C39C2F95AA6193F67 /* AppFont.swift */; };
 		12B626905E1B75F6419CD452 /* ChromeLayoutMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4890F1362CCDACF15E685662 /* ChromeLayoutMetricsTests.swift */; };
 		13005279CEAF281DCBE08040 /* NotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D0B8A444B60E3445EC7977 /* NotificationManagerTests.swift */; };
@@ -182,6 +183,7 @@
 		71610612223CEDEA13DC6166 /* IMessageBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D16F46555938EC971913798 /* IMessageBridgeTests.swift */; };
 		71937D0C72752C62DFBB63C1 /* WorktreeAgentTypeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 999DBD13511B3A8C4F4D4B8E /* WorktreeAgentTypeStore.swift */; };
 		7264850316B48C75C53EA138 /* InlineWorktreeCreateViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6626CE19664527CAF45610 /* InlineWorktreeCreateViewTests.swift */; };
+		72897701FB2E01A0DA5305D1 /* HostGatewayStaticFilesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB735C1E5E1238DE2F51758B /* HostGatewayStaticFilesTests.swift */; };
 		72EA963BA7948ECBF5DABF5C /* ChoiceOptionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC7E1231F33AA739B410611 /* ChoiceOptionParser.swift */; };
 		731E2F002EF8752F8E5F5241 /* WebhookEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9C4CC61EFF38937C86A54 /* WebhookEventTests.swift */; };
 		73225618467620F782EF0465 /* KeyboardSubstateControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77AAEF167452AD3BAB184D84 /* KeyboardSubstateControllerTests.swift */; };
@@ -416,6 +418,7 @@
 		EFF4E2636CB1CE5070B69163 /* BridgeCommandParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7622ADBA243E87D1CA94C7BD /* BridgeCommandParserTests.swift */; };
 		F0A5FE9C41E1E500E1B441E5 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 105CE82C3D2CBF90259D60A2 /* Sparkle */; };
 		F0C9DBC1959D88845016A1F4 /* SeahelmSuggestInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97FC10F15109A2EF528DD87 /* SeahelmSuggestInstaller.swift */; };
+		F0F527252C6EC20636C126EA /* RemoteMirroringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE4CA714BD0B18293FBD6216 /* RemoteMirroringTests.swift */; };
 		F11D0C88B5897BAFBB1BC8F0 /* AgentRegistryTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF44014C31BB9F7833218FB4 /* AgentRegistryTransitionTests.swift */; };
 		F18B943680E61083D1FD04D8 /* OSCProgressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF833BDB434AB8F30EE6D6AF /* OSCProgressTests.swift */; };
 		F18F39D20F1D77592272356C /* AgentSessionRefTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C827E67B268966037EEDC48 /* AgentSessionRefTests.swift */; };
@@ -736,7 +739,9 @@
 		AA151402CD4A6E95C947C0AB /* ExternalChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalChannel.swift; sourceTree = "<group>"; };
 		AA3A8892B1DC42E27FCD2A98 /* CodexUsageSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageSummaryProvider.swift; sourceTree = "<group>"; };
 		AB8C0AA934FBBE1D3F9E6831 /* AgentManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentManifest.swift; sourceTree = "<group>"; };
+		ADAB7F280D7925E9A0CD660C /* HostGatewayStaticFiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayStaticFiles.swift; sourceTree = "<group>"; };
 		ADC1F3A1FF1F0CC45B8BD0A8 /* NormalizedEventDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventDecoderTests.swift; sourceTree = "<group>"; };
+		AE4CA714BD0B18293FBD6216 /* RemoteMirroringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteMirroringTests.swift; sourceTree = "<group>"; };
 		AE7778575158B23A9C90C792 /* HostGatewayServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayServer.swift; sourceTree = "<group>"; };
 		AEC631B07301756615C755E6 /* AgentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentType.swift; sourceTree = "<group>"; };
 		AEF6A7F6ECFDABB135EC6D4C /* WorktreeRowHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeRowHelpers.swift; sourceTree = "<group>"; };
@@ -766,6 +771,7 @@
 		BAB9C63D8B4C22ACE7671274 /* NormalizedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEvent.swift; sourceTree = "<group>"; };
 		BB13F37078B010D666F6E81E /* SeahelmCliInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmCliInstallerTests.swift; sourceTree = "<group>"; };
 		BB4AD78048C5DC1D7D1D5E3F /* ChromeDividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeDividerView.swift; sourceTree = "<group>"; };
+		BB735C1E5E1238DE2F51758B /* HostGatewayStaticFilesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayStaticFilesTests.swift; sourceTree = "<group>"; };
 		BB9854E3679A7AF9524F5077 /* LayoutNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutNode.swift; sourceTree = "<group>"; };
 		BBA707703AD383C078C3DFC3 /* SeahelmSkillInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmSkillInstallerTests.swift; sourceTree = "<group>"; };
 		BBBA75436246C615D345870B /* SessionMonitorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionMonitorView.swift; sourceTree = "<group>"; };
@@ -983,6 +989,7 @@
 				1EA61698D1160080DD9E900B /* HostGatewayPairing.swift */,
 				AE7778575158B23A9C90C792 /* HostGatewayServer.swift */,
 				7842E00A1A18C4FAD50AF0ED /* HostGatewaySession.swift */,
+				ADAB7F280D7925E9A0CD660C /* HostGatewayStaticFiles.swift */,
 				B5512F73C560C4BEA3AA8424 /* IdeaStore.swift */,
 				47BB2DB0B6757C922D065765 /* IMessageChannel.swift */,
 				65B33DFB88A7C2AFDA0FAA8D /* IMessageChatDB.swift */,
@@ -1358,6 +1365,7 @@
 				148C3573E73EB0680BE0D550 /* HostGatewayPairingURLTests.swift */,
 				A7F8EA0DFCBD7F74049EA635 /* HostGatewayServerTests.swift */,
 				1D9E5FDD907FFB3D57373A8A /* HostGatewaySessionTests.swift */,
+				BB735C1E5E1238DE2F51758B /* HostGatewayStaticFilesTests.swift */,
 				EF22C41D6F582FFD30D8BD2D /* HTMLPreviewResourceTests.swift */,
 				7CFF2129E5D3A2E51C49F22C /* IdeaStoreTests.swift */,
 				5D16F46555938EC971913798 /* IMessageBridgeTests.swift */,
@@ -1394,6 +1402,7 @@
 				9626FD6C7EE99EAEC76D6443 /* PRURLParsingTests.swift */,
 				97C4FA6FDE7FEC53DDB662BD /* PtyGridAbsorbTests.swift */,
 				82C1E60B8144F4FB489FADD2 /* RegionFocusControllerTests.swift */,
+				AE4CA714BD0B18293FBD6216 /* RemoteMirroringTests.swift */,
 				5B4CB5436AAB9C042D5AF800 /* ReturnToPortTests.swift */,
 				46776FFD2F37DD5907B7D108 /* ScanDecoderTests.swift */,
 				BB13F37078B010D666F6E81E /* SeahelmCliInstallerTests.swift */,
@@ -1628,6 +1637,7 @@
 				21283461340CBF88A3E68FC9 /* Resources */,
 				B903EB00832368C62C8A20D8 /* Frameworks */,
 				05920B5863E0906DAF2B66D4 /* Mirror terminfo beside ghostty resources */,
+				A1B7C31390E40E55B8E529C7 /* Bundle seahelm-web client */,
 			);
 			buildRules = (
 			);
@@ -1786,6 +1796,25 @@
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\nRES=\"${CODESIGNING_FOLDER_PATH}/Contents/Resources/bin\"\n\"${SRCROOT}/scripts/fetch-zmx.sh\" \"${RES}/zmx\"\nif [ \"${CODE_SIGNING_ALLOWED:-YES}\" = \"YES\" ] && [ -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]; then\n  # Release builds need a secure timestamp for notarization; skip it in\n  # Debug so local builds don't pay a network round-trip per sign.\n  TS=\"--timestamp\"\n  [ \"${CONFIGURATION:-Debug}\" = \"Debug\" ] && TS=\"--timestamp=none\"\n  codesign --force --options runtime $TS \\\n    --sign \"${EXPANDED_CODE_SIGN_IDENTITY}\" \"${RES}/zmx\"\nfi\n";
 		};
+		A1B7C31390E40E55B8E529C7 /* Bundle seahelm-web client */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle seahelm-web client";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\nSRC=\"${SRCROOT}/clients/seahelm-web\"\nDEST=\"${CODESIGNING_FOLDER_PATH}/Contents/Resources/seahelm-web\"\nrm -rf \"${DEST}\"\nmkdir -p \"${DEST}\"\nrsync -a \\\n  --exclude 'devbroker' --exclude '.gitignore' --exclude 'README.md' \\\n  \"${SRC}/\" \"${DEST}/\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1853,6 +1882,7 @@
 				4783FC9B272C628F79A218AF /* HostGatewayPairingURLTests.swift in Sources */,
 				9684C23FB2CD701D95E47EDA /* HostGatewayServerTests.swift in Sources */,
 				71206C48591B67FF56E51E8E /* HostGatewaySessionTests.swift in Sources */,
+				72897701FB2E01A0DA5305D1 /* HostGatewayStaticFilesTests.swift in Sources */,
 				71610612223CEDEA13DC6166 /* IMessageBridgeTests.swift in Sources */,
 				3D08E49AA0DFCF40D705CD5C /* IMessageRuleCoalescerTests.swift in Sources */,
 				DA8BCC5B96E62682BEBA2925 /* IMessageRuleTargetTests.swift in Sources */,
@@ -1888,6 +1918,7 @@
 				8BB5F6D554A6F5BE68613FBA /* ProcessRunnerTests.swift in Sources */,
 				844747226335348450B94EEA /* PtyGridAbsorbTests.swift in Sources */,
 				8AB6456ED364F85D037EBE00 /* RegionFocusControllerTests.swift in Sources */,
+				F0F527252C6EC20636C126EA /* RemoteMirroringTests.swift in Sources */,
 				C309311CA5316E705F68CA77 /* ReturnToPortTests.swift in Sources */,
 				65856EB705254F9707D884C5 /* ScanDecoderTests.swift in Sources */,
 				D63952B04D839AFBF04F5FC1 /* SeahelmCliInstallerTests.swift in Sources */,
@@ -2071,6 +2102,7 @@
 				88CCF79393F2D978227B95E9 /* HostGatewayPairing.swift in Sources */,
 				C2733167BB2AB84E425AC1D1 /* HostGatewayServer.swift in Sources */,
 				0302EB911AF4960365D33FB1 /* HostGatewaySession.swift in Sources */,
+				12348F72590729F9B44FC244 /* HostGatewayStaticFiles.swift in Sources */,
 				11D083414156821D443B9356 /* IMessageChannel.swift in Sources */,
 				81703C0A816662FB4E12B9CF /* IMessageChatDB.swift in Sources */,
 				F9270DA52D3D8E5F8C70F8A4 /* IMessageConfig.swift in Sources */,


### PR DESCRIPTION
The browser client worked, but only barely: the page had to be hosted somewhere else, it showed one pane at a time, and its fleet list grouped by repository only. This makes the gateway serve its own client and makes that client a mirror of the desktop.

## Same-origin hosting

`HostGatewayServer` spoke only WebSocket, so a browser pointed at it hung forever — with `NWProtocolWebSocket` in the stack a plain `GET /` is never answered at all. That forced the page onto a different origin from its socket, and `SubtleCrypto` (which the pairing HKDF needs) exists only in a secure context, so a page served over plain HTTP from a LAN address could not even derive its auth token.

The public port now runs bare TCP and demultiplexes on the request head:

```
*:2783  front door (TCP)  ──┬── plain GET       → static file
                            └── Upgrade request → byte-proxied to ↓
127.0.0.1:<ephemeral>  internal listener (full WebSocket stack, loopback only)
```

The proxy understands no WebSocket framing — the framework still owns every frame. That kept the verified socket path untouched: **the two pre-existing end-to-end WebSocket tests now run through the proxy unchanged.**

Bundling copies `clients/seahelm-web` by build script rather than as a folder reference, because `devbroker/` is a 17MB dev-only MQTT harness. 680K ships.

## Live layout and grouping over the control API

| method | returns |
|---|---|
| `layout.live` | live split trees, keyed by worktree path |
| `fleet.groups` | `WorktreeGrouping`'s output for a requested mode |

Grouping stays Mac-side deliberately. `WorktreeGrouping` is a pure, tested function; a second implementation in JS is exactly how the browser and the desktop would come to disagree about what "Needs input" or "Recent hour" means.

The layout needed no new vocabulary: `CodableSplitNode`'s leaves are already keyed by `paneSessionKey`, which is the key `pane.vt_open` takes — so a client lays the tree out and attaches each pane with no id mapping in between.

Both requirements sit in the protocol body with extension defaults. An extension-only default is statically dispatched and would never reach a conformer's implementation through an existential; the defaults keep existing conformers and test fakes compiling untouched.

## The web client mirrors the window

The mid column rebuilds the split tree as nested flex boxes and attaches every leaf. First Mate renders whatever `fleet.groups` returns, behind a 项目 / 状态 / 时间 selector. Dividers are inert on purpose — this is a mirror, and resizing belongs to the machine that owns the panes.

Mirroring also dissolves the sizing problem rather than fighting it. A single pane stretched to fill a full-height column can only end in dead space or clipped output, because the box shape never matches the grid shape. A slot in the mirrored tree already has roughly the aspect ratio of the pane inside it, so the font simply scales down from its base size to its slot and never past it. Fitting now constrains both axes; width alone let a tall session run off the bottom.

Input needs no routing table: xterm only fires `onData` for the terminal holding focus, so each pane owns its own outbound path.

## Verified

End-to-end against the live app over the gateway:

```
layouts   : 9 worktrees
  teamclaw => (horizontal 0.50 A | (vertical 0.50 B | C))
groups[repository]: teamclaw(3), saas-mono(4), seahelm(1), ban-website(1)
groups[status    ]: Needs input(1), Running(2), Idle(6)
groups[activity  ]: Recent hour(4), Today(3), Recent 7 days(2)
```

Static hosting: `/` and assets 200 with correct MIME, unknown paths 404, `/../ghostty.conf` 404. Sockets: 101 with a verified `Sec-WebSocket-Accept`, auth ok, unauthenticated `-32001`. Also confirmed working through a Cloudflare Tunnel over `wss://`, where the https origin is what finally makes `crypto.subtle` available.

**123 tests pass**, including 10 new for layout/grouping serialization and 10 for static-file resolution (path traversal, MIME, HEAD, missing root).

## Caveat

Mirroring opens one `zmx attach` per visible pane, which multiplies the cost of leaving one behind (#44). Switching worktrees closes them all, `pagehide` covers the tab, and the bridge's lease sweep covers a crash, where neither runs. Worth watching under real use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)