### PR TITLE
Fix web terminal copy; advertise split focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ The project uses XcodeGen (`project.yml`) to generate the Xcode project file. Af
 
 **Thread safety:** `ghosttyLock` (NSLock) serializes all Ghostty C API calls between the background status poll and main-thread input. Key input deliberately does NOT hold the lock (Ghostty is internally thread-safe for keys, and holding it would deadlock on synchronous callbacks).
 
-**Window key handling:** `SeahelmWindow.performKeyEquivalent` handles split pane shortcuts (Cmd+D split, Cmd+Shift+Arrow move focus, Cmd+Ctrl+Arrow resize) before menu key equivalents. `sendEvent` intercepts Escape.
+**Window key handling:** `SeahelmWindow.performKeyEquivalent` handles split pane shortcuts (Cmd+D / Cmd+Shift+D split, Cmd+Option+Arrow move split focus, Cmd+Ctrl+Arrow resize) before menu key equivalents. `sendEvent` intercepts Escape.
 
 ## Agent Orchestration ("the fleet")
 

--- a/Sources/UI/Helm/ShortcutHintBar.swift
+++ b/Sources/UI/Helm/ShortcutHintBar.swift
@@ -24,8 +24,13 @@ final class ShortcutHintBar: NSView {
     /// the strip says.
     ///
     /// Six is the ceiling — the strip is budgeted at two lines of three (see
-    /// `ShortcutHintBarTests`), so making room for the cycle cost `⇧⌘D`, the one
-    /// chord a reader can guess from the `⌘D` sitting next to it.
+    /// `ShortcutHintBarTests`), so every addition is a trade. Making room for the
+    /// cycle cost `⇧⌘D`, the one chord a reader can guess from the `⌘D` beside it;
+    /// making room for split focus cost `?`.
+    ///
+    /// Dropping `?` costs more than the slot: it was the advertisement for the
+    /// help overlay, which is where every chord that does not fit here lives. The
+    /// key still works — nothing on screen says so any more.
     private static let items: [(key: String, label: String)] = [
         // "Next"/"Prev" rather than "Worktree+/-": the strip is budgeted at two
         // rows of three (ShortcutHintBarTests) and the longer word drops it to
@@ -34,9 +39,11 @@ final class ShortcutHintBar: NSView {
         ("\u{2303}\u{21E5}", "Next"),
         ("\u{2303}\u{21E7}\u{21E5}", "Prev"),
         ("\u{2318}P", "Command"),
-        ("\u{2318}W", "Close"),
+        // Arrows shown as ←→ only, for width; the `?` overlay carries the full
+        // "⌘⌥ ← → ↑ ↓" along with every chord that did not fit here.
+        ("\u{2318}\u{2325}\u{2190}\u{2192}", "Focus"),
         ("\u{2318}D", "Split"),
-        ("?", "Keys"),
+        ("\u{2318}W", "Close"),
     ]
 
     private static let chipBg = NSColor(name: nil) { appearance in

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -1048,6 +1048,13 @@ function renderTermKeys(){
     bar.appendChild(b);
   }
 
+  const copy = document.createElement('button');
+  copy.textContent = '⧉';
+  copy.title = '复制选区(手机上没有 ⌘C)';
+  copy.disabled = !live;
+  copy.onclick = () => copySelection();
+  bar.appendChild(copy);
+
   const sep = document.createElement('span');
   sep.className = 'sep';
   bar.appendChild(sep);
@@ -1072,6 +1079,19 @@ function renderTermKeys(){
     paneAction('pane.close', {});
   };
   bar.appendChild(close);
+}
+
+/** Button path: no `copy` event to hijack, so write the clipboard directly. */
+function copySelection(){
+  const entry = S.vt.focus ? S.vt.panes.get(S.vt.focus) : null;
+  if (!entry) return;
+  const text = entry.term.getSelection();
+  if (!text){ log('sys', '(copy)', '没有选中内容'); return; }
+  // Requires a secure context, which the page already needs for pairing anyway.
+  navigator.clipboard.writeText(text)
+    .then(() => log('sys', '(copy)', `已复制 ${text.length} 字符`))
+    .catch((e) => log('sys', '(copy failed)', String(e && e.message)));
+  try { entry.term.focus(); } catch (e) {}
 }
 
 function sendRawKey(bytes){
@@ -1246,6 +1266,19 @@ function buildLayoutLeaf(node){
   });
   t.onScroll(() => { if (S.vt.focus === key) updateToBottom(); });
   el.addEventListener('mousedown', () => focusPane(key));
+
+  // xterm paints its selection onto the canvas, so the browser has no DOM range
+  // covering it. A native copy therefore falls back to whatever the browser does
+  // consider selected — xterm's hidden helper textarea, which holds one row — and
+  // the result is a multi-line selection that copies a single line. Feed the
+  // clipboard the terminal's own selection instead. Covers ⌘C and the context
+  // menu alike, since both raise `copy`.
+  el.addEventListener('copy', (e) => {
+    const text = t.getSelection();
+    if (!text) return;
+    e.clipboardData.setData('text/plain', text);
+    e.preventDefault();
+  });
   return el;
 }
 


### PR DESCRIPTION
Two unrelated fixes that arrived from the same session of actually using the thing.

## Copying from the web terminal only ever returned one line

Selecting several lines and pressing ⌘C copied a single line.

xterm paints its selection onto the canvas, so **the browser has no DOM range covering it**. A native copy falls back to whatever the browser *does* consider selected — xterm's hidden helper textarea, which exists for IME and accessibility and holds one row. The selection was never wrong; the copy simply was not reading the terminal.

The fix intercepts `copy` and hands the clipboard `term.getSelection()`. The listener sits on the pane container, so ⌘C and the context menu are both covered, and in a mirrored multi-pane layout it routes to whichever pane has focus.

Also adds a `⧉` button beside the other keys, for the case with no ⌘C at all — a phone. That path cannot hijack a `copy` event, so it writes the clipboard directly via `navigator.clipboard`; the API needs a secure context, which this page already requires in order to pair.

## The documented shortcut for moving split focus was wrong

`CLAUDE.md` said **Cmd+Shift+Arrow**. It is **Cmd+Option+Arrow** — Cmd+Shift+Arrow is bound to nothing at all. `GlobalKeymap` and `KeyboardHelpOverlay` have agreed with each other the whole time; only the doc was wrong, which is the worst place for it to be wrong, since it is what someone reads *before* touching keybindings. The same sentence also omitted Cmd+Shift+D for a vertical split; both are corrected.

The hint strip now carries `⌘⌥←→ Focus`. Nothing about ⌘⌥ suggests "move between panes", which is precisely what the strip exists for — it was the one chord in this window that a user had to ask about.

It displaces `?`. The strip is budgeted at six slots (`ShortcutHintBarTests`: three per row, two rows, ≤62pt), so every addition is a trade, and the trade is recorded in the source rather than left for someone to rediscover:

| slot | cost |
|---|---|
| worktree cycle | `⇧⌘D` — guessable from the `⌘D` beside it |
| split focus | `?` |

**`?` still opens the help overlay** — the key is untouched. But nothing on screen advertises it any more, and that overlay is where the full `⌘⌥ ← → ↑ ↓` and every chord that does not fit in six slots still live. Worth knowing before the strip is edited again.

## Verified

- Layout budget holds with the longer `⌘⌥←→` key string: `ShortcutHintBarTests` 5/5 pass, still three per row across two rows.
- App builds; restarted on it, panes and all 16 zmx sessions intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)