### PR TITLE
Agent decisions over the gateway; phone layout, one-step connect

### DIFF
--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -771,6 +771,13 @@ class TabCoordinator {
                     controlDataSource.wakeHandler = { [weak self] stationId in
                         self?.terminalCoordinator.wakePane(targetStationId: stationId) ?? []
                     }
+                    controlDataSource.dismissDecisionHandler = { [weak self] paneId in
+                        // Station id or the stable session key — the queue keys off the
+                        // former, remote callers usually hold the latter.
+                        guard let self else { return false }
+                        let stationId = StationRegistry.shared.station(forSessionName: paneId)?.id ?? paneId
+                        return self.pendingOrders.dismissSuggestion(terminalID: stationId)
+                    }
                     controlDataSource.liveLayoutsHandler = { [weak self] in
                         self?.terminalCoordinator.liveLayouts() ?? [:]
                     }

--- a/Sources/Core/AgentRegistry.swift
+++ b/Sources/Core/AgentRegistry.swift
@@ -427,7 +427,15 @@ class AgentRegistry {
         case .question(let prompt, let options, _):
             dict["question"] = ["prompt": prompt, "options": options]
         case .suggest(let options):
-            dict["suggest"] = ["options": options]
+            var payload: [String: Any] = ["options": options]
+            // The completion gate above exists to stop unrelated events resending
+            // stale prose. A suggestion is the exception it does not cover: the
+            // options were authored *inside* this very message, so shipping it
+            // here is shipping the thing the options are about. Without it a
+            // remote client gets three buttons and no idea what they answer.
+            let prose = o.info.lastAssistantMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !prose.isEmpty { payload["message"] = prose }
+            dict["suggest"] = payload
         default: break
         }
         return dict

--- a/Sources/Core/ControlProtocol.swift
+++ b/Sources/Core/ControlProtocol.swift
@@ -65,6 +65,8 @@ protocol ControlDataSource: AnyObject {
     /// The dashboard's own worktree groups for `mode`, already computed Mac-side
     /// so a remote client cannot drift from the desktop.
     func worktreeGroups(mode: String) -> [[String: Any]]?
+    /// Decline a pane's open suggestion. False if there was nothing to decline.
+    func dismissDecision(paneId: String) -> Bool
     /// Read a pane's terminal text. `source`: visible | recent | detection.
     func readPane(paneId: String, source: String, lines: Int) -> String?
     /// Feed an inbound hook/suggest payload (same shape as the HTTP webhook body)
@@ -310,6 +312,14 @@ final class ControlRouter {
             guard ok else { return .error(code: ControlError.notFound, message: "pane not found: \(paneId)") }
             return .ok([method == "pane.close" ? "closed" : "focused": true])
 
+        case "decision.dismiss":
+            let paneRef = (params["pane_id"] as? String)
+                ?? (params["pane_session_key"] as? String) ?? ""
+            guard !paneRef.isEmpty else {
+                return .error(code: ControlError.invalidParams, message: "pane required")
+            }
+            return .ok(["dismissed": dataSource?.dismissDecision(paneId: paneRef) ?? false])
+
         case "layout.live":
             guard let layouts = dataSource?.liveLayouts() else {
                 return .error(code: ControlError.notFound, message: "no live layout")
@@ -533,6 +543,7 @@ final class ControlRouter {
 /// Defaults keep existing conformers — including test fakes — compiling: a data
 /// source with no window to mirror simply reports nothing to mirror.
 extension ControlDataSource {
+    func dismissDecision(paneId: String) -> Bool { false }
     func liveLayouts() -> [String: [String: Any]]? { nil }
     func worktreeGroups(mode: String) -> [[String: Any]]? { nil }
 }

--- a/Sources/Core/HostGatewayDecisions.swift
+++ b/Sources/Core/HostGatewayDecisions.swift
@@ -57,8 +57,11 @@ final class HostGatewayDecisions {
             return .opened(d)
         }
         if let s = event["suggest"] as? [String: Any] {
+            // Carried in `prompt`: it is the text the options answer, which is the
+            // same role a question's prompt plays. The wire keeps them distinct.
             let d = Decision(paneSessionKey: key, paneId: paneId, kind: "suggest",
-                             prompt: "", options: s["options"] as? [String] ?? [], seq: seq)
+                             prompt: s["message"] as? String ?? "",
+                             options: s["options"] as? [String] ?? [], seq: seq)
             lock.lock(); open[key] = d; lock.unlock()
             return .opened(d)
         }
@@ -115,6 +118,10 @@ final class HostGatewayDecisions {
         if d.kind == "question" {
             p["prompt"] = d.prompt
             p["danger"] = isDanger(d.prompt)
+        } else if !d.prompt.isEmpty {
+            // `message` rather than `prompt`: a suggestion is not asking, it is
+            // reporting — and the client renders the two the same way anyway.
+            p["message"] = d.prompt
         }
         return p
     }

--- a/Sources/Core/HostGatewayDecisions.swift
+++ b/Sources/Core/HostGatewayDecisions.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Open questions and suggestions, tracked so the Host Gateway can both push them
+/// and answer them.
+///
+/// MQTT got this for free: decisions went out as *retained* topics, so a client
+/// connecting at any time received whatever was still open. A WebSocket has no
+/// such memory, so the state has to live here and be replayed on authentication —
+/// otherwise a browser that connects one second after a question is raised waits
+/// forever for an event it already missed.
+///
+/// Pure logic, no transport: the server feeds it EventHub events and sends
+/// whatever it returns.
+final class HostGatewayDecisions {
+    struct Decision: Equatable {
+        let paneSessionKey: String
+        let paneId: String
+        let kind: String            // "question" | "suggest"
+        let prompt: String
+        let options: [String]
+        let seq: Int
+    }
+
+    private var open: [String: Decision] = [:]
+    private let lock = NSLock()
+
+    /// What a single EventHub event does to the set.
+    enum Change: Equatable {
+        case opened(Decision)
+        case cleared(paneSessionKey: String)
+        case none
+    }
+
+    /// Danger wording is advisory — it only styles the card. Kept deliberately
+    /// small; the authority on what a prompt means is the prompt itself.
+    private static let dangerRE = try? NSRegularExpression(
+        pattern: "(delete|remove|rm -rf|drop|force|reset --hard|overwrite|revoke)",
+        options: .caseInsensitive)
+
+    static func isDanger(_ s: String) -> Bool {
+        guard let re = dangerRE else { return false }
+        return re.firstMatch(in: s, range: NSRange(s.startIndex..., in: s)) != nil
+    }
+
+    @discardableResult
+    func apply(event: [String: Any]) -> Change {
+        let key = event["pane_session_key"] as? String ?? ""
+        guard !key.isEmpty else { return .none }
+        let paneId = event["pane_id"] as? String ?? ""
+        let seq = event["seq"] as? Int ?? 0
+
+        if let q = event["question"] as? [String: Any] {
+            let d = Decision(paneSessionKey: key, paneId: paneId, kind: "question",
+                             prompt: q["prompt"] as? String ?? "",
+                             options: q["options"] as? [String] ?? [], seq: seq)
+            lock.lock(); open[key] = d; lock.unlock()
+            return .opened(d)
+        }
+        if let s = event["suggest"] as? [String: Any] {
+            let d = Decision(paneSessionKey: key, paneId: paneId, kind: "suggest",
+                             prompt: "", options: s["options"] as? [String] ?? [], seq: seq)
+            lock.lock(); open[key] = d; lock.unlock()
+            return .opened(d)
+        }
+        // A pane that has left `waiting` is no longer asking anything. Anything
+        // else (running → running, message updates) must not clear a live prompt.
+        if let status = event["status"] as? String, status != AgentStatus.waiting.rawValue {
+            lock.lock(); let had = open.removeValue(forKey: key) != nil; lock.unlock()
+            return had ? .cleared(paneSessionKey: key) : .none
+        }
+        return .none
+    }
+
+    func options(forPaneSessionKey key: String) -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return open[key]?.options ?? []
+    }
+
+    func clear(paneSessionKey key: String) {
+        lock.lock(); open.removeValue(forKey: key); lock.unlock()
+    }
+
+    /// Everything still open, for replay to a client that just authenticated.
+    func pending() -> [Decision] {
+        lock.lock(); defer { lock.unlock() }
+        return open.values.sorted { $0.seq < $1.seq }
+    }
+
+    /// Wire shape. Matches what the web client already renders for MQTT
+    /// `pane/<key>/event`, so the browser needed no new card format.
+    static func notifyParams(for d: Decision) -> [String: Any] {
+        var p: [String: Any] = [
+            "type": d.kind,
+            "pane_id": d.paneId,
+            "pane_session_key": d.paneSessionKey,
+            "options": d.options,
+            "seq": d.seq,
+        ]
+        if d.kind == "question" {
+            p["prompt"] = d.prompt
+            p["danger"] = isDanger(d.prompt)
+        }
+        return p
+    }
+
+    static func clearedParams(paneSessionKey key: String) -> [String: Any] {
+        ["pane_session_key": key, "cleared": true]
+    }
+}

--- a/Sources/Core/HostGatewayDecisions.swift
+++ b/Sources/Core/HostGatewayDecisions.swift
@@ -62,11 +62,27 @@ final class HostGatewayDecisions {
             lock.lock(); open[key] = d; lock.unlock()
             return .opened(d)
         }
-        // A pane that has left `waiting` is no longer asking anything. Anything
-        // else (running → running, message updates) must not clear a live prompt.
-        if let status = event["status"] as? String, status != AgentStatus.waiting.rawValue {
-            lock.lock(); let had = open.removeValue(forKey: key) != nil; lock.unlock()
-            return had ? .cleared(paneSessionKey: key) : .none
+        // Only a *question* dies when its pane stops waiting: the prompt it
+        // belongs to is gone from the screen, so answering it would key nothing.
+        //
+        // A suggestion is the opposite. It is raised as the agent *finishes* — the
+        // Stop hook is what emits `::seahelm-suggest::` — so the pane is already
+        // idle when the options arrive. Clearing on "not waiting" therefore killed
+        // every suggestion one status poll after it appeared, which is why the
+        // desktop island could hold a card the browser never saw. A suggestion
+        // ends when it is picked, replaced, or the pane starts working again.
+        if let status = event["status"] as? String {
+            lock.lock()
+            let existing = open[key]
+            let expired: Bool
+            switch existing?.kind {
+            case "question": expired = status != AgentStatus.waiting.rawValue
+            case "suggest":  expired = status == AgentStatus.running.rawValue
+            default:         expired = false
+            }
+            if expired { open.removeValue(forKey: key) }
+            lock.unlock()
+            return expired ? .cleared(paneSessionKey: key) : .none
         }
         return .none
     }

--- a/Sources/Core/HostGatewayServer.swift
+++ b/Sources/Core/HostGatewayServer.swift
@@ -24,6 +24,10 @@ final class HostGatewayServer {
     private var wsListener: NWListener?
     private var wsPort: UInt16 = 0
 
+    /// Open questions/suggestions, shared by every session: one client answering
+    /// resolves it for all of them, and a client arriving late needs the backlog.
+    private let decisions = HostGatewayDecisions()
+    private var eventToken: Int?
     private var connections: [ObjectIdentifier: ConnectionState] = [:]
     private var proxied: [ObjectIdentifier: NWConnection] = [:]
     private var readyHandlers: [() -> Void] = []
@@ -74,7 +78,27 @@ final class HostGatewayServer {
                 if self.isListening { self.fireReadyHandlers() }
                 return
             }
+            self.subscribeToAgentEvents()
             self.startWebSocketListener()
+        }
+    }
+
+    /// AgentRegistry → EventHub → every authenticated session.
+    ///
+    /// EventHub is already the fan-out seam the control socket and MQTT use, so
+    /// the gateway subscribes rather than growing a second path out of the
+    /// registry. Events arrive on main; everything here belongs to `queue`.
+    private func subscribeToAgentEvents() {
+        guard eventToken == nil else { return }
+        eventToken = EventHub.shared.subscribe { [weak self] _, event in
+            guard let self else { return }
+            self.queue.async {
+                let change = self.decisions.apply(event: event)
+                if case .none = change { return }
+                for state in self.connections.values {
+                    state.session.pushDecision(change)
+                }
+            }
         }
     }
 
@@ -84,6 +108,8 @@ final class HostGatewayServer {
                 state.connection.cancel()
             }
             connections.removeAll()
+            if let eventToken { EventHub.shared.unsubscribe(eventToken) }
+            eventToken = nil
             for connection in proxied.values {
                 connection.cancel()
             }
@@ -351,7 +377,8 @@ final class HostGatewayServer {
             router: router,
             expectedMacId: expectedMacId,
             rootSecretBase64url: rootSecretBase64url,
-            vt: vt)
+            vt: vt,
+            decisions: decisions)
         let key = ObjectIdentifier(connection)
         let state = ConnectionState(connection: connection, session: session)
         connections[key] = state

--- a/Sources/Core/HostGatewaySession.swift
+++ b/Sources/Core/HostGatewaySession.swift
@@ -13,6 +13,8 @@ final class HostGatewaySession {
     private let expectedMacId: String
     private let rootSecretBase64url: String
     private let vt: HostGatewayVTAttaching
+    /// Shared with the server, which feeds it EventHub and fans out the results.
+    private let decisions: HostGatewayDecisions
     private var authenticated = false
     private var openVTKeys: Set<String> = []
     private var pendingNotifications: [HostGatewayOutbound] = []
@@ -22,15 +24,40 @@ final class HostGatewaySession {
     init(router: ControlRouter,
          expectedMacId: String,
          rootSecretBase64url: String,
-         vt: HostGatewayVTAttaching) {
+         vt: HostGatewayVTAttaching,
+         decisions: HostGatewayDecisions = HostGatewayDecisions()) {
         self.router = router
         self.expectedMacId = expectedMacId
         self.rootSecretBase64url = rootSecretBase64url
         self.vt = vt
+        self.decisions = decisions
         vt.onNotify = { [weak self] method, params in
             self?.pendingNotifications.append(.notify(method: method, params: params))
             self?.onPendingOutbound?()
         }
+    }
+
+    /// Server → session: an event that opened or closed a decision.
+    func pushDecision(_ change: HostGatewayDecisions.Change) {
+        guard authenticated else { return }
+        switch change {
+        case .opened(let d):
+            pendingNotifications.append(
+                .notify(method: "pane.event", params: HostGatewayDecisions.notifyParams(for: d)))
+        case .cleared(let key):
+            pendingNotifications.append(
+                .notify(method: "pane.event", params: HostGatewayDecisions.clearedParams(paneSessionKey: key)))
+        case .none:
+            return
+        }
+        onPendingOutbound?()
+    }
+
+    /// Answering locally clears it for everyone; other clients must be told.
+    private func queueDecisionCleared(_ key: String) {
+        pendingNotifications.append(
+            .notify(method: "pane.event", params: HostGatewayDecisions.clearedParams(paneSessionKey: key)))
+        onPendingOutbound?()
     }
 
     func drainNotifications() -> [String] {
@@ -61,7 +88,16 @@ final class HostGatewaySession {
             macId: macId, token: token,
             expectedMacId: expectedMacId, rootSecretBase64url: rootSecretBase64url)
         if ok { authenticated = true }
-        return [HostGatewayFrame.encode(.response(id: id, result: ["ok": ok], error: nil))]
+        var out = [HostGatewayFrame.encode(.response(id: id, result: ["ok": ok], error: nil))]
+        if ok {
+            // Replay what is already open. Without this a client that connects a
+            // second after a question is raised waits for an event it has missed.
+            for d in decisions.pending() {
+                out.append(HostGatewayFrame.encode(
+                    .notify(method: "pane.event", params: HostGatewayDecisions.notifyParams(for: d))))
+            }
+        }
+        return out
     }
 
     private func handleAuthenticated(id: String, method: String, params: [String: Any]) -> String {
@@ -83,6 +119,33 @@ final class HostGatewaySession {
             let key = paneSessionKey(from: params)
             vt.keepalive(paneSessionKey: key)
             return HostGatewayFrame.encode(.response(id: id, result: ["ok": true], error: nil))
+        case "question.answer":
+            // The on-screen prompt is navigated, not addressed: move down `index`
+            // times, then Return. Same shape MqttChannel drives for the Watch.
+            let qKey = paneSessionKey(from: params)
+            let qIndex = max(0, params["index"] as? Int ?? 0)
+            var keys = Array(repeating: "down", count: qIndex)
+            keys.append("enter")
+            let answered = router.handle(method: "pane.send_keys",
+                                         params: ["pane_id": qKey, "keys": keys])
+            decisions.clear(paneSessionKey: qKey)
+            queueDecisionCleared(qKey)
+            return encodeControlResult(id: id, result: answered)
+        case "suggest.pick":
+            // A suggestion is text, so the chosen option is typed verbatim — the
+            // index only means something next to the options we pushed.
+            let sKey = paneSessionKey(from: params)
+            let sIndex = max(0, params["index"] as? Int ?? 0)
+            let opts = decisions.options(forPaneSessionKey: sKey)
+            guard sIndex < opts.count else {
+                return encodeError(id: id, code: ControlError.invalidParams,
+                                   message: "no such suggestion")
+            }
+            let picked = router.handle(method: "pane.send_text",
+                                       params: ["pane_id": sKey, "text": opts[sIndex], "enter": true])
+            decisions.clear(paneSessionKey: sKey)
+            queueDecisionCleared(sKey)
+            return encodeControlResult(id: id, result: picked)
         case "pane.send_keys":
             if let key = vtKey(from: params), openVTKeys.contains(key),
                let utf8 = utf8Payload(from: params) {

--- a/Sources/Core/HostGatewaySession.swift
+++ b/Sources/Core/HostGatewaySession.swift
@@ -146,6 +146,14 @@ final class HostGatewaySession {
             decisions.clear(paneSessionKey: sKey)
             queueDecisionCleared(sKey)
             return encodeControlResult(id: id, result: picked)
+        case "decision.dismiss":
+            // Dismissing has to reach the store, not just the client that asked:
+            // a decision left open is replayed on the next authentication, so a
+            // local-only hide would come straight back on reload.
+            let dKey = paneSessionKey(from: params)
+            decisions.clear(paneSessionKey: dKey)
+            queueDecisionCleared(dKey)
+            return HostGatewayFrame.encode(.response(id: id, result: ["dismissed": true], error: nil))
         case "pane.send_keys":
             if let key = vtKey(from: params), openVTKeys.contains(key),
                let utf8 = utf8Payload(from: params) {

--- a/Sources/Core/HostGatewaySession.swift
+++ b/Sources/Core/HostGatewaySession.swift
@@ -147,12 +147,16 @@ final class HostGatewaySession {
             queueDecisionCleared(sKey)
             return encodeControlResult(id: id, result: picked)
         case "decision.dismiss":
-            // Dismissing has to reach the store, not just the client that asked:
-            // a decision left open is replayed on the next authentication, so a
-            // local-only hide would come straight back on reload.
+            // Two stores hold the same suggestion: this one, which feeds remote
+            // clients, and FirstMate's pending orders, which the desktop island
+            // draws. Declining has to reach both, or the card the user just
+            // dismissed is still standing on the Mac.
             let dKey = paneSessionKey(from: params)
             decisions.clear(paneSessionKey: dKey)
+            // Replayed on the next authentication if left open, so clearing the
+            // local store is what stops a dismissal from coming back on reload.
             queueDecisionCleared(dKey)
+            _ = router.handle(method: "decision.dismiss", params: ["pane_id": dKey])
             return HostGatewayFrame.encode(.response(id: id, result: ["dismissed": true], error: nil))
         case "pane.send_keys":
             if let key = vtKey(from: params), openVTKeys.contains(key),

--- a/Sources/Core/PendingOrdersQueue.swift
+++ b/Sources/Core/PendingOrdersQueue.swift
@@ -85,6 +85,17 @@ final class PendingOrdersQueue {
         if changed { notify() }
     }
 
+    /// Drop a pane's open suggestion without acting on it. Returns whether
+    /// anything went, so a remote caller can tell "declined" from "already gone".
+    @discardableResult
+    func dismissSuggestion(terminalID: String) -> Bool {
+        let before = orders.count
+        orders.removeAll { $0.action.kind == .suggestNextOrder && $0.action.terminalID == terminalID }
+        guard orders.count != before else { return false }
+        notify()
+        return true
+    }
+
     func all() -> [PendingOrder] { orders }
 
     func resolve(id: String) {

--- a/Sources/Core/SeahelmControlDataSource.swift
+++ b/Sources/Core/SeahelmControlDataSource.swift
@@ -28,6 +28,8 @@ final class SeahelmControlDataSource: ControlDataSource {
     /// and the dashboard's grouping for a given mode.
     var liveLayoutsHandler: (() -> [String: [String: Any]])?
     var worktreeGroupsHandler: ((String) -> [[String: Any]])?
+    /// Decline a pane's pending suggestion (main thread — it is UI state).
+    var dismissDecisionHandler: ((String) -> Bool)?
 
     init(hookSink: @escaping (WebhookEvent) -> String? = { _ in nil }) {
         self.hookSink = hookSink
@@ -340,5 +342,14 @@ extension SeahelmControlDataSource {
         var out: [[String: Any]] = []
         runOnMain { out = h(mode) }
         return out
+    }
+}
+
+extension SeahelmControlDataSource {
+    func dismissDecision(paneId: String) -> Bool {
+        guard let h = dismissDecisionHandler else { return false }
+        var ok = false
+        runOnMain { ok = h(paneId) }
+        return ok
     }
 }

--- a/Tests/HostGatewayDecisionsTests.swift
+++ b/Tests/HostGatewayDecisionsTests.swift
@@ -84,3 +84,33 @@ final class HostGatewayDecisionsTests: XCTestCase {
         XCTAssertNil(p["danger"])
     }
 }
+
+extension HostGatewayDecisionsTests {
+    /// The bug this file exists to prevent recurring: `::seahelm-suggest::` fires
+    /// from the Stop hook, so the pane is idle the moment the options arrive.
+    /// Treating "not waiting" as expiry deleted every suggestion one poll later.
+    func testSuggestSurvivesAnIdlePane() {
+        let d = HostGatewayDecisions()
+        _ = d.apply(event: ["pane_session_key": "k1", "pane_id": "p1", "seq": 1,
+                            "suggest": ["options": ["a", "b"]]])
+        XCTAssertEqual(d.apply(event: ["pane_session_key": "k1", "status": AgentStatus.idle.rawValue]), .none)
+        XCTAssertEqual(d.options(forPaneSessionKey: "k1"), ["a", "b"],
+                       "an idle pane is where a suggestion lives, not where it dies")
+    }
+
+    func testSuggestEndsWhenThePaneGoesBackToWork() {
+        let d = HostGatewayDecisions()
+        _ = d.apply(event: ["pane_session_key": "k1", "pane_id": "p1", "seq": 1,
+                            "suggest": ["options": ["a"]]])
+        XCTAssertEqual(d.apply(event: ["pane_session_key": "k1", "status": AgentStatus.running.rawValue]),
+                       .cleared(paneSessionKey: "k1"))
+    }
+
+    func testQuestionStillDiesWithItsPrompt() {
+        let d = HostGatewayDecisions()
+        _ = d.apply(event: ["pane_session_key": "k1", "pane_id": "p1", "seq": 1,
+                            "question": ["prompt": "?", "options": ["y", "n"]]])
+        XCTAssertEqual(d.apply(event: ["pane_session_key": "k1", "status": AgentStatus.idle.rawValue]),
+                       .cleared(paneSessionKey: "k1"))
+    }
+}

--- a/Tests/HostGatewayDecisionsTests.swift
+++ b/Tests/HostGatewayDecisionsTests.swift
@@ -114,3 +114,26 @@ extension HostGatewayDecisionsTests {
                        .cleared(paneSessionKey: "k1"))
     }
 }
+
+extension HostGatewayDecisionsTests {
+    /// Three buttons with no text above them answer a question the user cannot
+    /// see. The prose that authored the options travels with them.
+    func testSuggestCarriesTheMessageThatAuthoredIt() {
+        let d = HostGatewayDecisions()
+        guard case .opened(let open) = d.apply(event: [
+            "pane_session_key": "k1", "pane_id": "p1", "seq": 1,
+            "suggest": ["options": ["a", "b"], "message": "全部收敛了。剩两个问题。"],
+        ]) else { return XCTFail() }
+        let p = HostGatewayDecisions.notifyParams(for: open)
+        XCTAssertEqual(p["message"] as? String, "全部收敛了。剩两个问题。")
+        XCTAssertNil(p["prompt"], "a suggestion reports; it does not prompt")
+    }
+
+    func testSuggestWithoutProseOmitsTheField() {
+        let d = HostGatewayDecisions()
+        guard case .opened(let open) = d.apply(event: [
+            "pane_session_key": "k1", "seq": 1, "suggest": ["options": ["a"]],
+        ]) else { return XCTFail() }
+        XCTAssertNil(HostGatewayDecisions.notifyParams(for: open)["message"])
+    }
+}

--- a/Tests/HostGatewayDecisionsTests.swift
+++ b/Tests/HostGatewayDecisionsTests.swift
@@ -137,3 +137,24 @@ extension HostGatewayDecisionsTests {
         XCTAssertNil(HostGatewayDecisions.notifyParams(for: open)["message"])
     }
 }
+
+final class PendingOrdersDismissTests: XCTestCase {
+    private func suggestion(terminalID: String) -> FirstMateAction {
+        FirstMateAction(kind: .suggestNextOrder, zone: .red, worktreePath: "/wt",
+                        branch: "main", project: "p", terminalID: terminalID,
+                        message: "done", options: ["a", "b"])
+    }
+
+    func testDismissDropsOnlyThatPanesSuggestion() {
+        let q = PendingOrdersQueue()
+        q.enqueue(suggestion(terminalID: "t1"))
+        q.enqueue(suggestion(terminalID: "t2"))
+        XCTAssertTrue(q.dismissSuggestion(terminalID: "t1"))
+        XCTAssertEqual(q.all().map(\.action.terminalID), ["t2"])
+    }
+
+    func testDismissingNothingReportsNothing() {
+        // The caller uses this to tell "declined" from "already gone".
+        XCTAssertFalse(PendingOrdersQueue().dismissSuggestion(terminalID: "t1"))
+    }
+}

--- a/Tests/HostGatewayDecisionsTests.swift
+++ b/Tests/HostGatewayDecisionsTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import seahelm
+
+final class HostGatewayDecisionsTests: XCTestCase {
+    private func questionEvent(key: String = "k1", seq: Int = 1) -> [String: Any] {
+        ["pane_session_key": key, "pane_id": "p1", "seq": seq,
+         "question": ["prompt": "delete the branch?", "options": ["yes", "no"]]]
+    }
+    private func suggestEvent(key: String = "k1", seq: Int = 2) -> [String: Any] {
+        ["pane_session_key": key, "pane_id": "p1", "seq": seq,
+         "suggest": ["options": ["run tests", "commit"]]]
+    }
+
+    func testQuestionOpensAndCarriesItsOptions() {
+        let d = HostGatewayDecisions()
+        guard case .opened(let open) = d.apply(event: questionEvent()) else { return XCTFail() }
+        XCTAssertEqual(open.kind, "question")
+        XCTAssertEqual(open.options, ["yes", "no"])
+        XCTAssertEqual(d.options(forPaneSessionKey: "k1"), ["yes", "no"])
+    }
+
+    func testLeavingWaitingClearsIt() {
+        let d = HostGatewayDecisions()
+        _ = d.apply(event: questionEvent())
+        let change = d.apply(event: ["pane_session_key": "k1", "status": AgentStatus.running.rawValue])
+        XCTAssertEqual(change, .cleared(paneSessionKey: "k1"))
+        XCTAssertTrue(d.options(forPaneSessionKey: "k1").isEmpty)
+    }
+
+    func testStillWaitingDoesNotClearALivePrompt() {
+        // A status event that is *still* waiting must not cancel the question it
+        // belongs to — that would drop the prompt the moment it was raised.
+        let d = HostGatewayDecisions()
+        _ = d.apply(event: questionEvent())
+        XCTAssertEqual(d.apply(event: ["pane_session_key": "k1", "status": AgentStatus.waiting.rawValue]), .none)
+        XCTAssertEqual(d.options(forPaneSessionKey: "k1"), ["yes", "no"])
+    }
+
+    func testClearingSomethingAlreadyClosedIsNotAnEvent() {
+        let d = HostGatewayDecisions()
+        XCTAssertEqual(d.apply(event: ["pane_session_key": "k1", "status": AgentStatus.idle.rawValue]), .none)
+    }
+
+    func testEventsWithoutAPaneAreIgnored() {
+        XCTAssertEqual(HostGatewayDecisions().apply(event: ["status": "Waiting"]), .none)
+    }
+
+    func testPendingReplaysInSequenceOrder() {
+        // Replay is what a socket has instead of retained topics, so its order is
+        // the order the decisions were raised.
+        let d = HostGatewayDecisions()
+        _ = d.apply(event: suggestEvent(key: "b", seq: 9))
+        _ = d.apply(event: questionEvent(key: "a", seq: 3))
+        XCTAssertEqual(d.pending().map(\.paneSessionKey), ["a", "b"])
+    }
+
+    func testLaterDecisionReplacesTheEarlierOneForAPane() {
+        let d = HostGatewayDecisions()
+        _ = d.apply(event: questionEvent(key: "k1"))
+        _ = d.apply(event: suggestEvent(key: "k1"))
+        XCTAssertEqual(d.pending().count, 1)
+        XCTAssertEqual(d.options(forPaneSessionKey: "k1"), ["run tests", "commit"])
+    }
+
+    func testWireShapeMatchesWhatTheWebClientRenders() {
+        let d = HostGatewayDecisions()
+        guard case .opened(let open) = d.apply(event: questionEvent()) else { return XCTFail() }
+        let p = HostGatewayDecisions.notifyParams(for: open)
+        XCTAssertEqual(p["type"] as? String, "question")
+        XCTAssertEqual(p["pane_session_key"] as? String, "k1")
+        XCTAssertEqual(p["prompt"] as? String, "delete the branch?")
+        XCTAssertEqual(p["options"] as? [String], ["yes", "no"])
+        XCTAssertEqual(p["danger"] as? Bool, true, "'delete' should read as dangerous")
+
+        let cleared = HostGatewayDecisions.clearedParams(paneSessionKey: "k1")
+        XCTAssertEqual(cleared["cleared"] as? Bool, true)
+    }
+
+    func testSuggestCarriesNoPromptOrDanger() {
+        let d = HostGatewayDecisions()
+        guard case .opened(let open) = d.apply(event: suggestEvent()) else { return XCTFail() }
+        let p = HostGatewayDecisions.notifyParams(for: open)
+        XCTAssertNil(p["prompt"])
+        XCTAssertNil(p["danger"])
+    }
+}

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -290,11 +290,15 @@
   /* ── event / suggestion cards ───────────────────────────── */
   .ev{background:var(--panel);border:1px solid var(--attention);
     border-radius:var(--r);padding:10px;margin-bottom:8px}
-  .ev .eb{font-family:var(--mono);font-size:10px;color:var(--attention);text-transform:uppercase;letter-spacing:.16em}
+  .ev .eb{font-family:var(--mono);font-size:10px;color:var(--attention);text-transform:uppercase;
+    letter-spacing:.16em;display:flex;align-items:center;justify-content:space-between;gap:8px}
   .ev .ev-meta{font-size:10px;color:var(--muted);margin-top:2px}
   /* The dock floats over the terminal, so an agent that wrote three paragraphs
      before its options must not bury the thing it is asking. Clamped, with the
      full text one tap away in the pane itself. */
+  .ev-x{background:none;border:0;color:var(--muted);cursor:pointer;font-size:13px;
+    line-height:1;padding:2px 4px;border-radius:3px;font-family:var(--mono)}
+  .ev-x:hover{color:var(--danger);background:var(--danger-14)}
   .ev .prompt{margin:6px 0 4px;font-size:12px;line-height:1.45;white-space:pre-wrap;
     display:-webkit-box;-webkit-line-clamp:6;-webkit-box-orient:vertical;overflow:hidden}
   .ev .opt{display:block;width:100%;text-align:left;background:var(--panel2);border:1px solid var(--line-20);
@@ -844,12 +848,21 @@ function renderSuggestCard(pid, e){
   const label = (p.title||'').trim() || shortId(p.pane_id||pid);
   const meta = [p.project, p.branch].filter(Boolean).join(' · ');
   const method = e.type==='question' ? 'question.answer' : 'suggest.pick';
-  box.innerHTML=`<div class="eb">${esc(e.type||'suggest')}</div>`
+  box.innerHTML=`<div class="eb">${esc(e.type||'suggest')}`
+    + `<button class="ev-x" title="放弃这条建议">✕</button></div>`
     + `<div class="ev-meta">${esc(label)}${meta?' · '+esc(meta):''}</div>`
     + `<div class="prompt">${esc(e.prompt||e.message||'')}</div>`;
   // Tapping the card jumps to the pane that asked, so you can see the context
   // before answering.
   box.onclick=(ev)=>{ if (ev.target.closest('button')) return; selectPaneByKey(pid); };
+  // The dock floats over the terminal, so without this the only way out is to
+  // pick an option — which types into the pane. Declining has to be free.
+  box.querySelector('.ev-x').onclick=(ev)=>{
+    ev.stopPropagation();
+    S.events.delete(pid);          // optimistic: the card goes now
+    renderSuggestions();
+    sendCommand('decision.dismiss', { pane_session_key: pid });
+  };
   (e.options||[]).forEach((opt,i)=>{
     const b=document.createElement('button'); b.className='opt'; b.innerHTML=`<b>${i}</b>${esc(opt)}`;
     b.onclick=(ev)=>{ ev.stopPropagation();

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -77,6 +77,29 @@
     border-radius:var(--r);margin-left:auto;text-transform:uppercase}
   .st-off{background:var(--danger-14);color:var(--danger)}
   .st-on{background:var(--running-14);color:var(--running)}
+  /* ── connection gate ────────────────────────────────────── */
+  .gate{position:fixed;top:0;left:0;right:0;bottom:0;z-index:90;
+    display:flex;align-items:center;justify-content:center;padding:24px;
+    background:var(--bg);
+    background-image:radial-gradient(120% 80% at 50% -10%, #0c303a 0%, var(--bg) 55%)}
+  .gate[hidden]{display:none}
+  .gate-card{width:min(440px,100%);display:flex;flex-direction:column;gap:12px;text-align:center}
+  .gate-title{font-size:15px;font-weight:600;letter-spacing:.02em}
+  .gate-hint{font-size:12px;color:var(--muted);line-height:1.5}
+  .gate-input{width:100%;background:var(--panel);border:1px solid var(--line-20);
+    color:var(--text);border-radius:var(--r);padding:10px;font-family:var(--mono);
+    font-size:12px;outline:none;resize:vertical}
+  .gate-input:focus{border-color:var(--accent)}
+  .gate-primary{background:var(--accent);color:#042028;border:0;border-radius:var(--r);
+    padding:11px 16px;font-weight:600;font-size:13px;font-family:var(--mono);cursor:pointer}
+  .gate-primary:hover{filter:brightness(1.08)}
+  .gate-link{background:none;border:0;color:var(--muted);font-family:var(--mono);
+    font-size:11px;cursor:pointer;padding:4px}
+  .gate-link:hover{color:var(--danger)}
+  .gate-mac{display:inline-flex;align-items:center;justify-content:center;gap:8px;
+    font-size:13px;color:var(--text)}
+  .gate-error{color:var(--danger);font-size:12px;line-height:1.5;text-align:left}
+  .gate-error[hidden]{display:none}
   /* ── layout ─────────────────────────────────────────────── */
   main{flex:1;display:grid;grid-template-columns:300px 1fr 360px;overflow:hidden;
     transition:grid-template-columns .16s ease}
@@ -106,7 +129,6 @@
   @media (max-width:760px){
     main, main.nolog{grid-template-columns:1fr}
     #drawerBtn{display:inline-flex}
-    #dndBtn{display:none}
     #leftcol{position:fixed;top:0;bottom:0;left:0;z-index:80;
       width:min(86vw,320px);background:var(--bg);
       border-right:1px solid var(--line-20);box-shadow:0 0 40px rgba(0,0,0,.55);
@@ -141,6 +163,18 @@
     white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
   .vt-leaf.on .vt-leaf-title{color:var(--accent)}
   .vt-host{flex:1 1 auto;min-height:0;min-width:0;overflow:hidden}
+  /* Single-pane fallback: the strip stands in for the panes we stopped drawing,
+     so the layout is still legible even though only one of them is on screen. */
+  .vt-single{flex:1 1 auto;min-height:0;min-width:0;display:flex}
+  .vt-single>*{flex:1 1 auto;min-width:0;min-height:0}
+  #termWrap:has(.vt-single){display:flex;flex-direction:column;gap:6px}
+  .pane-strip{flex:none;display:flex;gap:4px;overflow-x:auto;padding-bottom:2px}
+  .pane-chip{flex:none;display:inline-flex;align-items:center;gap:5px;
+    background:var(--panel);color:var(--muted);border:1px solid var(--line-12);
+    border-radius:var(--r);padding:4px 9px;font-family:var(--mono);font-size:11px;
+    cursor:pointer;white-space:nowrap;max-width:46vw;overflow:hidden}
+  .pane-chip.on{background:var(--accent-12);border-color:var(--line-38);color:var(--accent)}
+  .pane-chip span{overflow:hidden;text-overflow:ellipsis}
   #termWrap.empty{display:flex;align-items:center;justify-content:center}
   /* Scrolled back in a live terminal, there is otherwise no way home but to
      swipe all the way down — and new output keeps arriving below you. */
@@ -295,12 +329,11 @@
       <input class="sm" id="pass" placeholder="pass" type="password" value="" />
       <input class="sm" id="mac" value="live" title="mac_id" />
     </span>
-    <span id="pairZone" class="pairzone"></span>
-    <button id="connectBtn">连接</button>
-    <button class="ghost" id="dndBtn" title="切换专注勿扰(Do Not Disturb)">DND</button>
-    <button class="ghost" id="logBtn" title="隐藏报文日志">日志</button>
     <span id="status" class="st-off">离线</span>
+    <button class="ghost" id="logBtn" title="隐藏报文日志">日志</button>
+    <button class="ghost" id="disconnectBtn" title="断开连接">断开</button>
   </header>
+  <div id="gate" class="gate" hidden></div>
   <main>
     <div class="col" id="leftcol">
       <div class="fm-header">
@@ -331,6 +364,7 @@
       <div class="toolbar">
         <button id="clearLog">清空</button>
         <button id="pubMock">发 mock 快照</button>
+        <button id="logVtBtn">VT 帧</button>
       </div>
       <div id="log"></div>
     </div>
@@ -345,6 +379,16 @@
 <script src="./e2ee.js"></script>
 <script>
 // ── state ─────────────────────────────────────────────────────────────────
+const GEOM_KEY = 'seahelm_pane_geometry';
+function loadGeom(){
+  try { return new Map(Object.entries(JSON.parse(localStorage.getItem(GEOM_KEY) || '{}'))); }
+  catch (e) { return new Map(); }
+}
+function saveGeom(){
+  try { localStorage.setItem(GEOM_KEY, JSON.stringify(Object.fromEntries(S.geom))); }
+  catch (e) {}   // private mode, quota — the cache is an optimisation, not state
+}
+
 const S = {
   client:null, mac:'testmac', transport:null,   // transport: null | 'mqtt' | 'gateway'
   gw:null,   // gateway WebSocket state when transport === 'gateway'
@@ -356,7 +400,13 @@ const S = {
   // VT terminal: `open` is the pane key currently streaming
   // One entry per mirrored pane, keyed by paneSessionKey; `focus` is the pane
   // keystrokes reach, `worktree` is the layout currently mounted.
-  vt:{ panes:new Map(), focus:null, worktree:null },
+  vt:{ panes:new Map(), focus:null, worktree:null, tree:null, mode:'mirror' },
+  // paneSessionKey → {cols, rows}, learned from vt.snapshot and remembered so
+  // the next mount can decide its layout without attaching first. Persisted
+  // because that decision happens *before* anything attaches: on a cold visit
+  // the prior is a guess, and a wrong guess in the conservative direction would
+  // otherwise stick until the window happened to be resized.
+  geom:loadGeom(),
   // Groups are computed Mac-side (fleet.groups) so the browser cannot drift
   // from the dashboard; `groups` is null until the first reply lands.
   grouping:{ mode: localStorage.getItem('seahelm_grouping') || 'repository', groups:null },
@@ -450,7 +500,22 @@ function disconnectAll(){
 }
 
 // ── logging ───────────────────────────────────────────────────────────────
+// VT frames arrive per keystroke and per screen update, so leaving them in
+// drowns everything worth reading — the log was a wall of `RX vt.data`. Filtered
+// by default, with a switch for when the terminal stream is the thing you are
+// debugging.
+const VT_METHODS = new Set(['vt.data', 'vt.snapshot', 'pane.send_keys', 'pane.vt_keepalive']);
+let showVTFrames = localStorage.getItem('seahelm_log_vt') === '1';
+
+function setShowVTFrames(on){
+  showVTFrames = on;
+  localStorage.setItem('seahelm_log_vt', on ? '1' : '0');
+  const btn = $('logVtBtn');
+  if (btn){ btn.classList.toggle('on', on); btn.title = on ? '隐藏 VT 帧' : '显示 VT 帧'; }
+}
+
 function log(dir, topic, payload){
+  if (!showVTFrames && VT_METHODS.has(String(topic))) return;
   const el = document.createElement('div');
   el.className = 'logline ' + dir;
   const body = typeof payload === 'string' ? payload : JSON.stringify(payload);
@@ -464,7 +529,12 @@ function log(dir, topic, payload){
   el.appendChild(head); el.appendChild(bd);
   $('log').prepend(el);   // newest on top (reverse-chronological)
 }
-function setStatus(on, txt){ const s=$('status'); s.textContent=txt; s.className = on?'st-on':'st-off'; }
+function setStatus(on, txt){
+  const s = $('status'); s.textContent = txt; s.className = on ? 'st-on' : 'st-off';
+  // The gate is a function of connection state, so it re-renders wherever that
+  // state is set — including the paths that drop the socket without asking.
+  renderGate();
+}
 
 // ── connect ───────────────────────────────────────────────────────────────
 function connect(){
@@ -531,6 +601,16 @@ function onGatewayFrame(msg){
 }
 
 function onGatewayNotify(method, params){
+  // Open questions / suggestions. MQTT delivered these as retained topics; over
+  // the socket the Mac pushes them and replays whatever is open on auth.
+  if (method === 'pane.event') {
+    const key = params.pane_session_key || params.pane_id;
+    if (!key) return;
+    if (params.cleared) S.events.delete(key);
+    else S.events.set(key, params);
+    renderSuggestions();
+    return;
+  }
   if (method === 'vt.snapshot' || method === 'vt.data') {
     const key = params.pane_session_key || params.pane_id;
     handleVT(key, {
@@ -622,7 +702,7 @@ async function applyPair(link){
   $('user').value = p.mac; $('pass').value = '';
   localStorage.setItem('seahelm_pair', link);
   log('sys', '(paired)', `${p.mac} · E2EE on`);
-  renderPairZone();
+  renderGate();
 }
 function pairPrompt(){
   const link = prompt('粘贴 macOS 配对界面的长链接(seahelm://pair?…):', '');
@@ -633,23 +713,71 @@ function clearPair(){
   S.encKey = null; S.authPass = null;
   localStorage.removeItem('seahelm_pair');
   log('sys', '(unpaired)', '回到明文/手填模式');
-  renderPairZone();
+  renderGate();
 }
 // Reflect pairing state in the header: chip when paired, 配对 button when not.
-function renderPairZone(){
-  const z = $('pairZone');
-  if (S.authPass){
-    z.innerHTML = `<span class="chip"><span class="lock">🔒</span><b>${esc(S.mac)}</b>`
-      + `<span class="e2ee">E2EE</span>`
-      + `<button class="chip-x" id="unpairBtn" title="解除配对">✕</button></span>`;
-    $('unpairBtn').onclick = clearPair;
-  } else {
-    z.innerHTML = `<button id="pairBtn" class="pair-primary" title="粘贴 seahelm:// 配对链接">配对</button>`;
-    $('pairBtn').onclick = pairPrompt;
+/**
+ * Connection gate. Pairing and connecting used to be two buttons in a corner,
+ * which asked the user to know they were two steps — the first one exactly once,
+ * and never again. Now the page has three states and shows only the one you are
+ * in: paste a link, or press connect, or get out of the way entirely.
+ */
+function renderGate(){
+  const gate = $('gate');
+  if (!gate) return;
+
+  if (isLinked()){                       // connected — the fleet is the page
+    gate.hidden = true;
+    gate.innerHTML = '';
+    return;
   }
+  gate.hidden = false;
+
+  if (S.authPass){                       // paired, disconnected
+    gate.innerHTML = `
+      <div class="gate-card">
+        <div class="gate-mac"><span class="lock">🔒</span><b>${esc(S.mac)}</b><span class="e2ee">E2EE</span></div>
+        <button class="gate-primary" id="gateConnect">连接</button>
+        <button class="gate-link" id="gateUnpair">解除配对</button>
+      </div>`;
+    $('gateConnect').onclick = () => { connect(); renderGate(); };
+    $('gateUnpair').onclick = () => { clearPair(); };
+    return;
+  }
+
+  gate.innerHTML = `
+    <div class="gate-card">
+      <div class="gate-title">配对这台 Mac</div>
+      <div class="gate-hint">粘贴 Seahelm 设置里的配对链接(seahelm://pair?…)</div>
+      <textarea class="gate-input" id="gateLink" rows="3" spellcheck="false"
+                placeholder="seahelm://pair?b=…&amp;m=…&amp;k=…"></textarea>
+      <button class="gate-primary" id="gatePair">配对并连接</button>
+      <div class="gate-error" id="gateError" hidden></div>
+    </div>`;
+  const input = $('gateLink'), err = $('gateError');
+  const fail = (m) => { err.textContent = m; err.hidden = false; };
+
+  const go = async () => {
+    const link = (input.value || '').trim();
+    if (!link) return fail('请先粘贴配对链接');
+    err.hidden = true;
+    try {
+      await applyPair(link);
+      connect();                         // one action, not two
+      renderGate();
+    } catch (e) {
+      // The usual cause is a page served without a secure context, where
+      // SubtleCrypto does not exist and e2ee.js never finished loading.
+      fail(typeof E2EE === 'undefined'
+        ? '此页面不在安全上下文中,无法计算配对密钥 —— 请用 https:// 或 http://127.0.0.1 打开'
+        : '配对失败:' + (e && e.message));
+    }
+  };
+  $('gatePair').onclick = go;
+  input.onkeydown = (e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) go(); };
+  setTimeout(() => input.focus(), 0);
 }
 
-// ── inbound routing ────────────────────────────────────────────────────────
 function onMessage(topic, raw){
   const parts = topic.split('/');
   const seg = parts.slice(2);
@@ -711,7 +839,6 @@ function renderSuggestCard(pid, e){
   const p = S.panes.get(pid)||{};
   const label = (p.title||'').trim() || shortId(p.pane_id||pid);
   const meta = [p.project, p.branch].filter(Boolean).join(' · ');
-  const rid = e.question_id || e.suggest_id || '';
   const method = e.type==='question' ? 'question.answer' : 'suggest.pick';
   box.innerHTML=`<div class="eb">${esc(e.type||'suggest')}</div>`
     + `<div class="ev-meta">${esc(label)}${meta?' · '+esc(meta):''}</div>`
@@ -723,7 +850,9 @@ function renderSuggestCard(pid, e){
     const b=document.createElement('button'); b.className='opt'; b.innerHTML=`<b>${i}</b>${esc(opt)}`;
     b.onclick=(ev)=>{ ev.stopPropagation();
       selectPaneByKey(pid);
-      sendCommand(method, e.type==='question'?{question_id:rid,index:i}:{suggest_id:rid,index:i});
+      // Addressed by pane: a question is answered by driving that pane's prompt,
+      // a suggestion by typing the option we were shown.
+      sendCommand(method, { pane_session_key: pid, index: i });
     };
     box.appendChild(b);
   });
@@ -936,7 +1065,22 @@ function selectPaneByKey(key){
 
 // Every pane is drawn at whatever size its slot in the mirrored layout gives it,
 // so a window resize means refitting all of them, not one.
-window.addEventListener('resize', fitAllPanes);
+window.addEventListener('resize', handleViewportResize);
+
+/** Rotating a phone or dragging a window can cross the mirror/single threshold. */
+function handleViewportResize(){
+  const wrap = $('termWrap');
+  if (S.vt.tree && wrap){
+    const want = layoutFitsMirror(S.vt.tree, wrap.clientWidth) ? 'mirror' : 'single';
+    if (want !== S.vt.mode){
+      const keep = S.vt.focus, tree = S.vt.tree, path = S.vt.worktree;
+      unmountPanes();
+      mountPanes(tree, keep, path);
+      return;
+    }
+  }
+  fitAllPanes();
+}
 
 /** Retick the elapsed labels in place — no re-render, no scroll jump. */
 function tickTimes(){
@@ -1176,6 +1320,53 @@ function stackedTreeFor(path){
              .reduce((a, b) => ({ type:'split', axis:'vertical', ratio:0.5, first:a, second:b }));
 }
 
+// A terminal grid cannot reflow — the Mac fixes its column count — so a slot
+// too narrow for that many columns does not wrap, it clips. Mirroring the
+// desktop is right up until the point where every pane is showing half a line,
+// which is what a 2-up split does on a phone: measured here, a pane in a
+// 3-way split is 69 columns, and a 390px phone holds ~72 at the readable floor.
+// One pane fits almost exactly; any split does not.
+//
+// So the trigger is the constraint itself rather than a device width: can every
+// leaf show its columns at VT_FONT_MIN? A narrow window on a laptop degrades for
+// the same reason a phone does, which is the honest generalisation.
+const CELL_RATIO = 0.6;          // monospace advance ÷ font size, near enough
+const ASSUMED_COLS = 80;         // prior before a pane has ever reported geometry
+
+function treeLeaves(node, out){
+  out = out || [];
+  if (!node) return out;
+  if (node.type === 'leaf') { out.push(node); return out; }
+  treeLeaves(node.first, out);
+  treeLeaves(node.second, out);
+  return out;
+}
+
+/** Narrowest fraction of the container any leaf ends up with. */
+function narrowestLeafFraction(node, share){
+  share = share === undefined ? 1 : share;
+  if (!node || node.type === 'leaf') return share;
+  const ratio = Math.min(0.9, Math.max(0.1, Number(node.ratio) || 0.5));
+  // Only a horizontal split divides width; a vertical one costs rows, and rows
+  // are the axis a terminal is allowed to lose — it scrolls in that direction.
+  const [a, b] = node.axis === 'horizontal'
+    ? [share * ratio, share * (1 - ratio)]
+    : [share, share];
+  return Math.min(narrowestLeafFraction(node.first, a),
+                  narrowestLeafFraction(node.second, b));
+}
+
+function layoutFitsMirror(tree, containerWidth){
+  if (!tree || tree.type === 'leaf') return true;
+  const leaves = treeLeaves(tree);
+  const widestCols = leaves.reduce((m, leaf) => {
+    const g = S.geom.get(leaf.pane_session_key);
+    return Math.max(m, (g && g.cols) || ASSUMED_COLS);
+  }, 0);
+  const needed = widestCols * VT_FONT_MIN * CELL_RATIO;
+  return narrowestLeafFraction(tree) * containerWidth >= needed;
+}
+
 function mountPanes(tree, focusKey, path){
   unmountPanes();
   const wrap = $('termWrap');
@@ -1186,14 +1377,82 @@ function mountPanes(tree, focusKey, path){
     return;
   }
   S.vt.worktree = path;
+  S.vt.tree = tree;
+  S.vt.mode = layoutFitsMirror(tree, wrap.clientWidth) ? 'mirror' : 'single';
+
+  if (S.vt.mode === 'single'){
+    const leaves = treeLeaves(tree);
+    const wanted = leaves.find(l => l.pane_session_key === (focusKey || S.selPane)) || leaves[0];
+    mountSinglePane(wanted && wanted.pane_session_key);
+    return;
+  }
+
   wrap.appendChild(buildLayoutNode(tree));
+  openMountedPanes();
+  focusPane(focusKey || S.selPane || S.vt.panes.keys().next().value || null);
+  fitAllPanes();
+}
+
+/** Attach every pane the DOM now holds. */
+function openMountedPanes(){
   for (const key of S.vt.panes.keys()){
     sendCommand('pane.vt_open', { pane_session_key: key, cols: VT_COLS, rows: VT_ROWS }, (r) => {
       if (r && r.ok === false) log('sys','(vt open failed)', JSON.stringify(r.error||r));
     });
   }
-  focusPane(focusKey || S.selPane || S.vt.panes.keys().next().value || null);
+}
+
+/**
+ * One pane, full width, plus a strip to move between them.
+ *
+ * Only the visible pane is attached. That is not just tidiness: each attach is a
+ * real client of the zmx session (#44), and the layouts that trigger this mode
+ * are the ones on the weakest devices.
+ */
+function mountSinglePane(key){
+  const wrap = $('termWrap');
+  const leaves = treeLeaves(S.vt.tree);
+  if (!key && leaves.length) key = leaves[0].pane_session_key;
+  const leaf = leaves.find(l => l.pane_session_key === key) || leaves[0];
+  if (!leaf) return;
+
+  // Drop the previous terminal first — its attach client goes with it.
+  for (const [k, entry] of S.vt.panes){
+    if (isLinked()) sendCommand('pane.vt_close', { pane_session_key: k });
+    if (entry.flushT) clearTimeout(entry.flushT);
+    try { entry.term.dispose(); } catch (e) {}
+  }
+  S.vt.panes.clear();
+
+  wrap.innerHTML = '';
+  wrap.appendChild(renderPaneStrip(leaf.pane_session_key));
+  const holder = document.createElement('div');
+  holder.className = 'vt-single';
+  holder.appendChild(buildLayoutLeaf(leaf));
+  wrap.appendChild(holder);
+
+  openMountedPanes();
+  focusPane(leaf.pane_session_key);
   fitAllPanes();
+}
+
+/** Tap targets standing in for the panes we are no longer drawing. */
+function renderPaneStrip(activeKey){
+  const strip = document.createElement('div');
+  strip.className = 'pane-strip';
+  for (const leaf of treeLeaves(S.vt.tree)){
+    const key = leaf.pane_session_key;
+    const known = S.panes.get(key) || {};
+    const chip = document.createElement('button');
+    chip.className = 'pane-chip' + (key === activeKey ? ' on' : '');
+    chip.innerHTML = statusDotHTML(known.status || 'unknown', 'pdot')
+      + `<span>${esc(leaf.title || known.title || shortId(known.pane_id || key))}</span>`;
+    // Explicit tap, not a swipe: a horizontal drag belongs to whatever TUI is
+    // running, and mis-swiping away from the pane you are reading is expensive.
+    chip.onclick = () => { if (key !== S.vt.focus) mountSinglePane(key); };
+    strip.appendChild(chip);
+  }
+  return strip;
 }
 
 function unmountPanes(){
@@ -1205,6 +1464,7 @@ function unmountPanes(){
   S.vt.panes.clear();
   S.vt.focus = null;
   S.vt.worktree = null;
+  S.vt.tree = null;
   renderTermKeys();
 }
 
@@ -1372,9 +1632,21 @@ function handleVT(paneKey, v){
   if (v.type !== 'vt.snapshot' && !bytes.length) return;
   const t = entry.term;
   if (v.type === 'vt.snapshot'){
-    if (v.cols && v.rows && (t.cols !== v.cols || t.rows !== v.rows)){
-      t.resize(v.cols, v.rows);
-      log('sys','(vt resize)', `${v.cols}x${v.rows} — matched session geometry`);
+    if (v.cols && v.rows){
+      const was = S.geom.get(paneKey);
+      if (!was || was.cols !== v.cols || was.rows !== v.rows){
+        S.geom.set(paneKey, { cols: v.cols, rows: v.rows });
+        saveGeom();
+        // Learning a pane is wider than assumed can invalidate a mirror already
+        // on screen; re-check rather than leave it clipping. Deferred a tick:
+        // re-checking can dispose this very terminal, and the snapshot below
+        // still has to be written to it.
+        setTimeout(handleViewportResize, 0);
+      }
+      if (t.cols !== v.cols || t.rows !== v.rows){
+        t.resize(v.cols, v.rows);
+        log('sys','(vt resize)', `${v.cols}x${v.rows} — matched session geometry`);
+      }
     }
     t.reset();
     if (bytes.length) t.write(bytes, () => fitPaneFont(entry));
@@ -1427,10 +1699,11 @@ function sendCommand(method, params, onReply){
   S.client.publish(`${base()}/command`, JSON.stringify(payload), {qos:1});
   log('tx', `${base()}/command`, payload);
 }
-function toggleDnd(){
-  const on = !(S.dnd && S.dnd.on);
-  sendCommand('dnd.set', {on, minutes:25});
-}
+// DND was an MQTT-era control: `dnd.set` is implemented in MqttChannel and
+// deliberately kept out of ControlRouter, so it cannot be reached over the Host
+// Gateway the web client now uses. The button is gone rather than silently
+// inert; `S.dnd` still tracks the retained MQTT topic for the devbroker path,
+// and is what a gateway-side implementation would render from.
 
 // ── mock publisher (drive UI without Seahelm) ────────────────────────────────
 function pubMock(){
@@ -1449,14 +1722,12 @@ function pubMock(){
 }
 
 // ── wire ─────────────────────────────────────────────────────────────────────
-renderPairZone();   // pairing-first: 配对 button (or paired chip) is the primary control
-$('connectBtn').onclick=connect;
+renderGate();   // the gate is the page until a connection exists
 // Restore a saved pairing so a reload stays logged in (creds derived, not stored raw).
 (function restorePair(){
   const saved = localStorage.getItem('seahelm_pair');
   if (saved) applyPair(saved).catch(()=>localStorage.removeItem('seahelm_pair'));
 })();
-$('dndBtn').onclick=toggleDnd;
 $('drawerBtn').onclick=()=>setDrawer(!$('leftcol').classList.contains('open'));
 $('scrim').onclick=()=>setDrawer(false);
 $('toBottom').onclick=()=>{
@@ -1466,20 +1737,38 @@ $('toBottom').onclick=()=>{
 };
 // Debug panel is a developer surface — remembered per browser so it stays out
 // of the way once you've dismissed it.
+// Stored as "shown", absent meaning hidden. The previous key recorded the
+// opposite and every browser that had ever touched the toggle carried a value
+// for it, so flipping the default alone changed nothing for exactly the people
+// who had used the thing. A new key is how a default actually moves.
+const LOG_SHOWN_KEY = 'seahelm_log_shown';
+try { localStorage.removeItem('seahelm_log_off'); } catch (e) {}
+
+function logShown(){ return localStorage.getItem(LOG_SHOWN_KEY) === '1'; }
+
 function applyLogVisibility(){
-  const off = localStorage.getItem('seahelm_log_off') === '1';
+  // Hidden by default: it is a developer surface, and since the mirrored layout
+  // it also costs the terminals ~380px — enough to push a worktree from a
+  // mirrored split down to one pane at a time.
+  const off = !logShown();
   document.querySelector('main').classList.toggle('nolog', off);
   const btn = $('logBtn');
   btn.classList.toggle('on', !off);
   btn.title = off ? '显示报文日志' : '隐藏报文日志';
   setTimeout(fitAllPanes, 200);   // the panes just got wider
 }
+$('disconnectBtn').onclick = () => {
+  disconnectAll();
+  unmountPanes();
+  setStatus(false, '离线');
+};
 $('logBtn').onclick = () => {
-  const off = localStorage.getItem('seahelm_log_off') === '1';
-  localStorage.setItem('seahelm_log_off', off ? '0' : '1');
+  localStorage.setItem(LOG_SHOWN_KEY, logShown() ? '0' : '1');
   applyLogVisibility();
 };
 applyLogVisibility();
+$('logVtBtn').onclick = () => setShowVTFrames(!showVTFrames);
+setShowVTFrames(showVTFrames);
 $('clearLog').onclick=()=>$('log').innerHTML='';
 $('pubMock').onclick=pubMock;
 </script>

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -292,7 +292,11 @@
     border-radius:var(--r);padding:10px;margin-bottom:8px}
   .ev .eb{font-family:var(--mono);font-size:10px;color:var(--attention);text-transform:uppercase;letter-spacing:.16em}
   .ev .ev-meta{font-size:10px;color:var(--muted);margin-top:2px}
-  .ev .prompt{margin:6px 0 4px;font-size:12px;line-height:1.45}
+  /* The dock floats over the terminal, so an agent that wrote three paragraphs
+     before its options must not bury the thing it is asking. Clamped, with the
+     full text one tap away in the pane itself. */
+  .ev .prompt{margin:6px 0 4px;font-size:12px;line-height:1.45;white-space:pre-wrap;
+    display:-webkit-box;-webkit-line-clamp:6;-webkit-box-orient:vertical;overflow:hidden}
   .ev .opt{display:block;width:100%;text-align:left;background:var(--panel2);border:1px solid var(--line-20);
     color:var(--text);border-radius:var(--r);padding:7px 10px;margin-top:5px;cursor:pointer;font-size:12px;
     font-family:var(--mono);transition:border-color .1s}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		5B886E1FEAC1891962201C01 /* GmailMailConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17703086C94D05EDA9B85B21 /* GmailMailConfigTests.swift */; };
 		5BFD525836B15C48CC54A5D8 /* WatchFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0982B809334A31181947736 /* WatchFeed.swift */; };
 		5D6CF18A7384A74B640EFAAC /* WorktreeStatusAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4775959C72857610AC1F12DC /* WorktreeStatusAggregator.swift */; };
+		5E77C3E6AA55F970F5DD877E /* HostGatewayDecisions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399B19A39BB25DDA3D401B60 /* HostGatewayDecisions.swift */; };
 		5F16B6F4A4D85F5E6F515A4E /* WebhookSuggestEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54322E1FB43B65F94D1AAC20 /* WebhookSuggestEventTests.swift */; };
 		5F1EAF9EF49C5686FF50F689 /* CommandParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B43315E436E0794D28C474 /* CommandParser.swift */; };
 		5F7CEFC99E339F7621D6509A /* ZmxLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063BC4CAFB28A7B7DEA60474 /* ZmxLocatorTests.swift */; };
@@ -195,6 +196,7 @@
 		75772A087B197B7F7050BC43 /* WorktreeShellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FA2EB699654E9A701124D1 /* WorktreeShellActions.swift */; };
 		75DF92B7A3EDC695B4BA5E9B /* WorktreeTitleResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BDC0C3284F3CAF4BD18C62 /* WorktreeTitleResolverTests.swift */; };
 		7839409D46CC0B8E4810B869 /* WorktreeCreatorEnvCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A028D76F177CA1C4379BC3 /* WorktreeCreatorEnvCopyTests.swift */; };
+		785DB0B4417DD04E94CD58AD /* HostGatewayDecisionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09525B8D6C093323B62D10B /* HostGatewayDecisionsTests.swift */; };
 		79F532FA70B21691FB226AF8 /* GitHubDiffAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3492399099DDDAE527C6CA /* GitHubDiffAdapter.swift */; };
 		7A4F6892F9AE56EF60508D89 /* FirstMateConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08FEEAC5D86CEE353749EA /* FirstMateConfigTests.swift */; };
 		7AD64F51F6EE5BA663EEF30D /* AgentRegistryWebhookPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F4985A21CB0E9D8B4708E26 /* AgentRegistryWebhookPathTests.swift */; };
@@ -548,6 +550,7 @@
 		376AB999E829F6B1298D7B05 /* OverviewFocusModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewFocusModelTests.swift; sourceTree = "<group>"; };
 		37A61F49272C1D9D5FAF19F2 /* ChromeCollapseUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeCollapseUITests.swift; sourceTree = "<group>"; };
 		38FD43578EB5A227077BAA11 /* ChromeCollapseAnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeCollapseAnimationTests.swift; sourceTree = "<group>"; };
+		399B19A39BB25DDA3D401B60 /* HostGatewayDecisions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayDecisions.swift; sourceTree = "<group>"; };
 		39DD3FFFF216C576CFDC7683 /* XCUIElementExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIElementExtensions.swift; sourceTree = "<group>"; };
 		3A09155A1FFCC67267E9F246 /* EditorTheme+Seahelm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditorTheme+Seahelm.swift"; sourceTree = "<group>"; };
 		3A85CAE555196AE450DDD90E /* WorktreeCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeCreatorTests.swift; sourceTree = "<group>"; };
@@ -813,6 +816,7 @@
 		CF9A024C6CD76762DD132684 /* AgentRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistry.swift; sourceTree = "<group>"; };
 		CFB1ED030DFAE92B65E7E8D1 /* HostGatewayConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayConfig.swift; sourceTree = "<group>"; };
 		CFD256925C8144E1C18DEC0E /* AIPanelPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIPanelPage.swift; sourceTree = "<group>"; };
+		D09525B8D6C093323B62D10B /* HostGatewayDecisionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayDecisionsTests.swift; sourceTree = "<group>"; };
 		D0D0A2190D518447C76BAB37 /* GitDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitDiffTests.swift; sourceTree = "<group>"; };
 		D18A2E8441934257374C57B2 /* CoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTests.swift; sourceTree = "<group>"; };
 		D2343249B5B46DF1CACF3E11 /* EmailAttachmentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailAttachmentStore.swift; sourceTree = "<group>"; };
@@ -985,6 +989,7 @@
 				97A7E8E322E5A353D4457DBC /* HooksChannel.swift */,
 				FF616B03B16048B3C1157313 /* HostGatewayAuth.swift */,
 				CFB1ED030DFAE92B65E7E8D1 /* HostGatewayConfig.swift */,
+				399B19A39BB25DDA3D401B60 /* HostGatewayDecisions.swift */,
 				A0FFC00EE90A3DAECD6396FC /* HostGatewayFrame.swift */,
 				1EA61698D1160080DD9E900B /* HostGatewayPairing.swift */,
 				AE7778575158B23A9C90C792 /* HostGatewayServer.swift */,
@@ -1361,6 +1366,7 @@
 				EB82719AC58E2E0289564007 /* HookDecoderTests.swift */,
 				16C8F047AD222C44B3E5DD1A /* HostGatewayAuthTests.swift */,
 				BDF8548571F540C914ACA11E /* HostGatewayConfigTests.swift */,
+				D09525B8D6C093323B62D10B /* HostGatewayDecisionsTests.swift */,
 				CBC709BF6C114756E9794146 /* HostGatewayFrameTests.swift */,
 				148C3573E73EB0680BE0D550 /* HostGatewayPairingURLTests.swift */,
 				A7F8EA0DFCBD7F74049EA635 /* HostGatewayServerTests.swift */,
@@ -1878,6 +1884,7 @@
 				6D66FA7BE6A91F8748F3F780 /* HookDecoderTests.swift in Sources */,
 				4DC9B67D9DB3EE1C96C65503 /* HostGatewayAuthTests.swift in Sources */,
 				FAF2ABF4372E190D0A42EE2A /* HostGatewayConfigTests.swift in Sources */,
+				785DB0B4417DD04E94CD58AD /* HostGatewayDecisionsTests.swift in Sources */,
 				50C0E2D95435EA0741D4BFE4 /* HostGatewayFrameTests.swift in Sources */,
 				4783FC9B272C628F79A218AF /* HostGatewayPairingURLTests.swift in Sources */,
 				9684C23FB2CD701D95E47EDA /* HostGatewayServerTests.swift in Sources */,
@@ -2098,6 +2105,7 @@
 				90650F907FCC7FB24383A44D /* HooksChannel.swift in Sources */,
 				C85F0294741CB37B07986458 /* HostGatewayAuth.swift in Sources */,
 				4DEB41D0F7E47035706006E2 /* HostGatewayConfig.swift in Sources */,
+				5E77C3E6AA55F970F5DD877E /* HostGatewayDecisions.swift in Sources */,
 				506FABB5322B42EDC75221F8 /* HostGatewayFrame.swift in Sources */,
 				88CCF79393F2D978227B95E9 /* HostGatewayPairing.swift in Sources */,
 				C2733167BB2AB84E425AC1D1 /* HostGatewayServer.swift in Sources */,
@@ -2295,7 +2303,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.45;
+				MARKETING_VERSION = 2.0.47;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",
@@ -2533,7 +2541,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.45;
+				MARKETING_VERSION = 2.0.47;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",


### PR DESCRIPTION
## Suggestions and questions never worked over the gateway

The web client already had the whole suggestion UI — dock, cards, option buttons, the handlers that answer them. None of it could ever fire.

`S.events` was only ever filled from MQTT topics, and `question.answer` / `suggest.pick` are implemented in `MqttChannel`, **deliberately** outside `ControlRouter`. Over the Host Gateway both directions were dead, and dead *silently*: the dock has `:empty{display:none}` so it simply never appeared, and the answers resolved to method-not-found with no callback to notice.

**Inbound rides `EventHub`** — already the fan-out seam `AgentRegistry` publishes to and both the control socket and MQTT subscribe to. The gateway becomes a third subscriber rather than growing a second path out of the registry.

**`HostGatewayDecisions`** holds what is open, because a socket has no equivalent of MQTT's retained topics. Without it a client connecting one second after a question is raised waits forever for an event it already missed; the store is replayed on authentication instead. It also resolves `suggest.pick`'s index — which only means something next to the options we actually pushed — and answering broadcasts a clear so a second client's card does not linger.

One rule is easy to get backwards and is pinned by a test: **a status event that is still `waiting` must not clear the decision it belongs to**, or the prompt vanishes the instant it appears.

### Verified end to end, in a real browser

Driven headlessly over CDP against the live app — push a suggestion from a second client, watch the page:

```
已连接: 已连接
注入建议…
  +1.5s → 卡片 1 张 | SUGGEST | ✳ 拉取最新合并代码 · teamclaw · fix/flaky-pool-tests-busy-wait
                     | 0跑一下测试 | 1提交这批改动 | 2看看资源占用
页面异常: 0
```

Replay-on-auth checked separately: a fresh connection receives whatever is still open.

### An expiry rule that made it look like nothing arrived

The first version of this shipped a bug worth recording, because the symptom pointed at the wrong half of the system: suggestions reached the browser and vanished about two seconds later, so the desktop island held a card the web client never showed.

The event was never the problem — the island renders FirstMate's pending orders and the gateway subscribes to `EventHub`, the same event. The **expiry rule** was. It treated any status that is not `waiting` as the decision being over, but `::seahelm-suggest::` is emitted by the *Stop* hook: the agent has finished, so the pane is **already idle** when the options arrive. Every suggestion was deleted by the first status poll after it appeared.

The rule is now split by what each kind actually depends on:

| kind | ends when |
|---|---|
| question | the pane stops waiting — the prompt is gone from the screen, so answering would key nothing |
| suggest | the pane starts working again, or it is picked or replaced |

An idle pane is where a suggestion lives, not where it dies. Three tests pin this, including the exact regression.

Verified against the live app: a suggestion still present after eight seconds of status polling, where before it could not survive one.

## One pane at a time when a mirror would clip

A terminal grid cannot reflow — the Mac fixes its column count — so a slot too narrow does not wrap, it **clips**. The numbers decide this, not a device class:

| | |
|---|---|
| pane in a 3-way split | **69 columns** |
| 390px phone at the readable floor (9px) | **~72 columns** |

One pane fits almost exactly. Any split does not — which is exactly the "every pane shows half a line" report.

So the trigger is the constraint itself rather than a width breakpoint, and a narrow window on a laptop degrades for the same reason a phone does. Only *horizontal* splits count against it: rows are the axis a terminal is allowed to lose, because it scrolls in that direction.

Switching is an **explicit tap** on a pane strip — a horizontal swipe belongs to whatever TUI is running, and mis-swiping away from the pane you are reading is expensive. Only the visible pane is attached, which matters beyond tidiness: each attach is a real client of the zmx session (#44), and the layouts that trigger this mode are the ones on the weakest devices.

## Connecting is one step

Pairing and connecting were two buttons in a corner, which asked the user to know they were two steps — the first exactly once, and never again. The page now has three states and shows only the one you are in: paste a link, press connect, or get out of the way. The header keeps status / log / disconnect and nothing else.

The paste box replaces a native `prompt()` and names the one failure worth naming: no `SubtleCrypto` means the page is not in a secure context, which is why a LAN address over plain HTTP can never pair.

## DND removed

`dnd.set` lives in `MqttChannel`, deliberately outside `ControlRouter`, so over the gateway it resolved to method-not-found with the error dropped — and its state came from a retained MQTT topic that does not exist here. A button that does nothing is worse than no button. The MQTT state parser stays for the devbroker path and is what a gateway-side implementation would render from.

## The log, quiet and out of the way

It logs *gateway* frames, not MQTT, so it is still the only window onto the wire — but VT frames arrive per keystroke and per screen update and the panel was a wall of `RX vt.data`. Filtered by default, with a switch.

Collapsed by default too: since the mirrored layout it costs the terminals ~380px, enough to push a worktree from a split down to a single pane. The preference moves to a **new key**, because every browser that had ever touched the old toggle carried a value for it — flipping the default alone changed nothing for exactly the people who had used it.

## Tests

24 gateway tests pass, including 9 new for the decision store (open, clear, replay order, the still-waiting rule, wire shape). Browser behaviour verified over CDP as above, with zero page exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

