### PR TITLE
Fix agent completion notifications: late, wrong, or never

### DIFF
--- a/Resources/Manifests/claude.json
+++ b/Resources/Manifests/claude.json
@@ -1,6 +1,6 @@
 {
   "id": "claude",
-  "version": "2026.07.30.1",
+  "version": "2026.08.21.1",
   "min_engine_version": 1,
   "aliases": ["claude-code"],
   "default_status": "idle",
@@ -50,7 +50,8 @@
         { "line_regex": ["\\d+ shells?\\s*([,·]|$)"] },
         { "line_regex": ["\\d+ monitors?\\s*([,·]|$)"] }
       ],
-      "visible_working": true
+      "visible_working": true,
+      "background_task": true
     },
     {
       "id": "working_interrupt",

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -91,11 +91,11 @@ class MainWindowController: NSWindowController, MailCommandContext {
     // Vibe-island notch overlay
     private let islandController = IslandPanelController()
     private var islandRefreshTimer: Timer?
-    private var islandKnownOrderIDs: Set<String> = []
+    private var islandSeenSuggestions = SuggestionSeenSet()
     /// Suggestion orders already surfaced through the First Mate sidebar. Tracked
-    /// separately from `islandKnownOrderIDs`: the island's set is also advanced by
+    /// separately from `islandSeenSuggestions`: the island's set is also advanced by
     /// its 10s fallback timer, which would eat the "new order" edge this needs.
-    private var revealedSuggestionOrderIDs: Set<String> = []
+    private var revealedSuggestions = SuggestionSeenSet()
 
     // Terminal management
     /// GitHub token 解析，来源优先级：
@@ -266,6 +266,13 @@ class MainWindowController: NSWindowController, MailCommandContext {
         pub.aggregator = statusAggregator
         NotificationManager.shared.stabilityDelay = config.notifications.stabilityDelay
         NotificationManager.shared.cooldown = config.notifications.cooldown
+        // The island popping open with this pane's suggestion card already told
+        // the user, better than a banner can — it carries the buttons. Only
+        // while it is actually expanded: a collapsed pill has said nothing.
+        NotificationManager.shared.isCardOnScreen = { [weak self] terminalID in
+            guard let self, self.islandController.model.isOpened else { return false }
+            return self.islandController.model.orders.contains { $0.action.terminalID == terminalID }
+        }
         // Every desktop banner also goes to whatever chat channels are registered,
         // so a phone hears "agent finished" without seahelm owning a transport or
         // push certificate. No-op until a channel is registered.
@@ -2420,10 +2427,12 @@ extension MainWindowController {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    /// Surface new suggestions in the First Mate sidebar while Seahelm is frontmost.
-    /// The island deliberately stays collapsed then (`openForEvent` bails on an
-    /// active app) — dropping a panel over the notch you are already looking at
-    /// reads as a glitch, and the sidebar is where the card lives anyway.
+    /// Surface new suggestions in the First Mate sidebar while Seahelm is frontmost
+    /// AND the card belongs to the worktree on screen — dropping a panel over the
+    /// notch you are already looking at reads as a glitch, and the sidebar is where
+    /// that card lives anyway. A card from any other worktree goes to the island
+    /// instead (`openForEvent(targetVisible:)`), which is the only surface that can
+    /// show it without navigating the window out from under the user.
     /// Registered independently of the island so it still works with it disabled.
     private func setupSuggestionReveal() {
         guard NSClassFromString("XCTestCase") == nil else { return }
@@ -2434,17 +2443,17 @@ extension MainWindowController {
     }
 
     private func revealFirstMateForNewSuggestions() {
-        let orderIDs = Set(
-            tabCoordinator.pendingOrders.all()
-                .filter { $0.action.kind == .suggestNextOrder }
-                .map(\.id)
-        )
-        let hasNewOrder = !orderIDs.subtracting(revealedSuggestionOrderIDs).isEmpty
-        revealedSuggestionOrderIDs = orderIDs
+        let suggestions = tabCoordinator.pendingOrders.all()
+            .filter { $0.action.kind == .suggestNextOrder }
+        let fresh = revealedSuggestions.absorb(suggestions)
         // Only while frontmost: in the background the island already pops, and
         // re-opening the sidebar on a suggestion the user never saw arrive would
-        // rearrange the window behind their back.
-        guard hasNewOrder, NSApp.isActive else { return }
+        // rearrange the window behind their back. And only for a card this
+        // sidebar can actually show — a suggestion from another worktree is the
+        // island's job, so revealing the current worktree's First Mate tab for
+        // it would rearrange the window and still not show the card.
+        guard NSApp.isActive else { return }
+        guard fresh.contains(where: { tabCoordinator.isWorktreeVisible($0.action.worktreePath) }) else { return }
         guard chromeState.isCollapsed || chromeState.activePane != .firstMate else { return }
         // Layout only — first responder stays in the terminal so the reveal never
         // eats a keystroke mid-sentence.
@@ -2508,14 +2517,15 @@ extension MainWindowController {
 
         // A new suggestion is actionable — expand so the card is visible
         // without hovering. Nothing else opens the island: status changes are
-        // Notification Center's job. This only lands while Seahelm is in the
-        // background (`openForEvent` bails on an active app); frontmost, the
-        // First Mate sidebar carries the suggestion instead.
-        let orderIDs = Set(orders.map(\.id))
-        let hasNewOrder = !orderIDs.subtracting(islandKnownOrderIDs).isEmpty
-        islandKnownOrderIDs = orderIDs
-        if hasNewOrder && !model.isOpened {
-            islandController.openForEvent()
+        // Notification Center's job. Frontmost, this yields to the First Mate
+        // sidebar only for a card that sidebar is actually showing — a
+        // suggestion raised in a worktree that isn't on screen pops here.
+        let fresh = islandSeenSuggestions.absorb(orders)
+        if !fresh.isEmpty, !model.isOpened {
+            let targetVisible = fresh.allSatisfy {
+                tabCoordinator.isWorktreeVisible($0.action.worktreePath)
+            }
+            islandController.openForEvent(targetVisible: targetVisible)
         }
         islandController.updateVisibility()
     }

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -629,6 +629,10 @@ class TabCoordinator {
                         // sessionId made the two never match, so the block fired every turn.
                         // paneId is stable across both; fall back to sessionId outside a pane.
                         let turnKey = event.paneId ?? event.sessionId
+                        // Set when this Stop is answered with a `decision: block` body.
+                        // Held rather than returned early so the event still reaches
+                        // ingest — see the blocking branch below.
+                        var block: String?
                         // Track when the user sent a message to this session; a new
                         // user prompt starts a fresh turn, so the agent must suggest again.
                         if event.event == .userPrompt {
@@ -706,22 +710,30 @@ class TabCoordinator {
                            promptedAt > blockedAt {
                             sessionBlockedAt.removeValue(forKey: turnKey)
                             sessionUserPromptedAt.removeValue(forKey: turnKey)
-                        } else if let block = StopHookResponder.blockBody(
+                        } else if let body = StopHookResponder.blockBody(
                             for: event, suggestOnStop: self.config.webhook.suggestOnStop) {
-                            // Blocking Stop: agent will continue and call seahelm-suggest.
-                            // Do NOT ingest this stop as completion (avoid premature idle), but
-                            // stash the agent's final message so the suggestion card can show it.
+                            // Blocking Stop: the agent will continue and declare its
+                            // options. Stash its final message so the suggestion card
+                            // can show it, and remember that we blocked.
                             sessionBlockedAt[turnKey] = Date()
                             if let msg = event.data?["last_assistant_message"] as? String {
                                 AgentRegistry.shared.noteAssistantMessage(cwd: event.cwd, paneId: event.paneId, message: msg)
                             }
-                            return block
+                            // Fall through to ingest: the turn is over as far as the user
+                            // is concerned — the agent has written its answer — and the
+                            // extra round-trip this block buys is seahelm's own suggestion
+                            // overhead. Withholding the stop here used to delay every
+                            // completion (status, banner, chat mirror) by a whole model
+                            // round-trip: 2.6s to 20s, median ~9s, measured across real
+                            // sessions. The agent's follow-up turn re-reports running and
+                            // stops again; the notification cooldown collapses that pair.
+                            block = body
                         }
                         self.statusPublisher.webhookProvider.handleEvent(event)
                         AgentRegistry.shared.handleWebhookEvent(event)
                         // TODO: Enable when webhook→TODO matching logic is implemented
                         // AgentRegistry.shared.updateTodoFromWebhook(event)
-                        return nil
+                        return block
                       }
                     }
                     // Local control socket is the sole inbound transport: reads
@@ -1388,7 +1400,13 @@ class TabCoordinator {
         // The agent's final prose (Stop hook) — the most informative body line;
         // without it completed panes surface placeholder labels like
         // "Processing prompt".
-        let lastAssistantMessage = AgentRegistry.shared.pane(for: terminalID)?.lastAssistantMessage ?? ""
+        let pane = AgentRegistry.shared.pane(for: terminalID)
+        let lastAssistantMessage = pane?.lastAssistantMessage ?? ""
+        // Did the agent report this itself, or did the screen scan infer it? Only
+        // an agent-reported state is trusted enough to correct a banner already
+        // sent inside the cooldown window — see `NotificationManager.shouldNotify`.
+        let source: NotificationManager.NotificationSource =
+            pane?.hookStatus == newStatus ? .agent : .scan
 
         // A pending order card (AskUserQuestion / suggestion) for this pane
         // already surfaces the "needs input" state in the island and cockpit —
@@ -1411,14 +1429,16 @@ class TabCoordinator {
             lastMessage: lastMessage,
             lastUserPrompt: lastUserPrompt,
             lastAssistantMessage: lastAssistantMessage,
-            isTargetVisible: isPaneFocused(worktreePath: worktreePath, terminalID: terminalID)
+            isTargetVisible: isPaneFocused(worktreePath: worktreePath, terminalID: terminalID),
+            source: source
         )
     }
 
     /// Whether this worktree is the one currently shown in the dashboard (all its
     /// panes are on screen). Combined with app-frontmost in `NotificationManager`
-    /// to decide whether a system banner would be redundant.
-    private func isWorktreeVisible(_ worktreePath: String) -> Bool {
+    /// to decide whether a system banner would be redundant, and by the island /
+    /// First Mate reveal to decide which of the two surfaces a suggestion belongs on.
+    func isWorktreeVisible(_ worktreePath: String) -> Bool {
         dashboardVC?.activeSplitContainer?.tree?.worktreePath == worktreePath
     }
 

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -131,7 +131,8 @@ class TabCoordinator {
                 status: outcome.newStatus,
                 lastMessage: outcome.info.lastMessage,
                 lastUserPrompt: outcome.info.lastUserPrompt,
-                agentType: outcome.info.agentType)
+                agentType: outcome.info.agentType,
+                backgroundBusy: outcome.info.backgroundBusy)
             // Aggregator ignores commandLine-only changes; chrome pane title
             // still needs a refresh when the foreground shell job updates.
             self.delegate?.tabCoordinatorRequestUpdateTitleBar(self)
@@ -347,7 +348,7 @@ class TabCoordinator {
             // dots. The worktree's own status is NOT derived from them here: the
             // aggregator already picked the most recently changed pane, and
             // re-deriving it would let the row and the tab badge disagree.
-            let shipLogPaneStatuses = (agentsByWorktree[agent.worktreePath] ?? []).map(\.status)
+            let shipLogPaneStatuses = (agentsByWorktree[agent.worktreePath] ?? []).map(\.displayStatus)
             let paneStatuses = !shipLogPaneStatuses.isEmpty ? shipLogPaneStatuses
                 : (ws?.statuses ?? [agent.status])
             let rolledUpStatus = ws?.rolledUpStatus ?? agent.status

--- a/Sources/Core/AgentRegistry.swift
+++ b/Sources/Core/AgentRegistry.swift
@@ -30,6 +30,21 @@ class AgentRegistry {
     /// `var` so tests can drive the trailing-edge reclaim deterministically.
     static var hookRunningGrace: TimeInterval = 3.0
 
+    /// When each terminal's hook last asserted `.idle` (a Stop). The trailing-edge
+    /// counterpart to `hookRunningSince`: for a grace window after the agent says
+    /// it stopped, that beats a screen that has not gone quiet yet. Without it a
+    /// session_only agent's completion was simply dropped whenever its TUI still
+    /// had a spinner line in the scanned region — which is the normal case at the
+    /// instant a turn ends, and the whole reason "agent finished" arrived late or
+    /// never at all.
+    private var hookIdleSince: [String: Date] = [:]
+    /// How long a hook-asserted `.idle` outranks a scan `.running`. Deliberately
+    /// short: past it the screen takes authority back, so a stale hook `.idle`
+    /// can never pin a visibly-working pane at idle — and an agent that resumes
+    /// (e.g. to answer a blocking Stop) is shown as running again within seconds.
+    /// `var` so tests can drive the window deterministically.
+    static var hookIdleGrace: TimeInterval = 3.0
+
     /// When each terminal's hook last asserted `.waiting` (an AskUserQuestion /
     /// awaiting-input edge). `.waiting` is urgent, so it outranks *any* scan —
     /// without a reclaim, a single lost clearing hook pins the card on "Needs
@@ -213,8 +228,25 @@ class AgentRegistry {
     ///   - screen_only / unknown: screen only.
     /// An urgent state (waiting/error) from either source always surfaces — never
     /// hide a blocked or errored agent behind an authority rule.
-    static func arbitrate(scan: AgentStatus, hook: AgentStatus, agentType: AgentType) -> AgentStatus {
-        arbitrateDetailed(scan: scan, hook: hook, agentType: agentType).status
+    static func arbitrate(scan: AgentStatus, hook: AgentStatus, agentType: AgentType,
+                          hookIdleFresh: Bool = false) -> AgentStatus {
+        arbitrateDetailed(scan: scan, hook: hook, agentType: agentType,
+                          hookIdleFresh: hookIdleFresh).status
+    }
+
+    /// Whether this pane's hook `.idle` is still inside its trailing-edge window.
+    /// Caller must hold `lock`.
+    private func hookIdleIsFreshLocked(_ terminalID: String, now: Date) -> Bool {
+        guard let since = hookIdleSince[terminalID] else { return false }
+        return now.timeIntervalSince(since) < Self.hookIdleGrace
+    }
+
+    /// Same question from outside the lock — for `pane.explain`, so the diagnostic
+    /// reports the arbitration the pipeline would actually make right now.
+    func hookIdleIsFresh(terminalID: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return hookIdleIsFreshLocked(terminalID, now: Date())
     }
 
     /// Whether the agent's manifest makes the screen authoritative (hooks only fill
@@ -226,7 +258,8 @@ class AgentRegistry {
 
     /// Same as `arbitrate` but also reports which source won (`urgent` / `hook` /
     /// `screen`) and the pane's authority — for `pane.explain`.
-    static func arbitrateDetailed(scan: AgentStatus, hook: AgentStatus, agentType: AgentType)
+    static func arbitrateDetailed(scan: AgentStatus, hook: AgentStatus, agentType: AgentType,
+                                  hookIdleFresh: Bool = false)
         -> (status: AgentStatus, decidedBy: String, authority: String) {
         let authority = ManifestStore.shared.manifest(for: agentType.manifestId)?.manifest.authority ?? "session_only"
         let urgent = AgentStatus.highestPriority([scan, hook].filter { $0.isUrgent })
@@ -235,12 +268,23 @@ class AgentRegistry {
         case "full_lifecycle": return hook != .unknown ? (hook, "hook", authority) : (scan, "screen", authority)
         case "screen_only":    return (scan, "screen", authority)
         default:
-            // session_only: screen is authoritative EXCEPT a hook `.running` edge
-            // promotes over a scan `.idle`, so the leading edge (prompt submitted,
-            // spinner not yet on screen) surfaces immediately instead of waiting for
-            // the next slow scan. `ingest` clears a stale hook `.running` once scan
-            // sees a sustained idle, so the trailing edge stays screen-authoritative.
+            // session_only: screen is authoritative EXCEPT at the two edges, where
+            // the hook knows first and the screen lags.
+            //
+            // Leading edge: a hook `.running` promotes over a scan `.idle`, so a
+            // submitted prompt surfaces immediately instead of waiting for the
+            // spinner to reach the screen and the next slow scan to find it.
             if scan == .idle && hook == .running { return (hook, "hook", authority) }
+            // Trailing edge: a *fresh* hook `.idle` (see `hookIdleGrace`) promotes
+            // over a scan `.running`. The agent has stated it stopped; its TUI has
+            // not caught up, and typically still carries a spinner line in the
+            // scanned region at that exact moment — so screen authority alone
+            // dropped the completion entirely, which is why banners for finished
+            // agents arrived late or never. Time-boxed, so the screen reclaims
+            // authority the moment the window lapses and a stale hook `.idle` can
+            // never pin a working pane at idle. (`ingest` still reclaims a stale
+            // hook `.running` from the other direction.)
+            if hookIdleFresh && hook == .idle && scan == .running { return (hook, "hook", authority) }
             return scan != .unknown ? (scan, "screen", authority) : (hook, "hook", authority)
         }
     }
@@ -324,6 +368,9 @@ class AgentRegistry {
             next.hookStatus = success ? .idle : .error
             hookRunningSince[event.terminalID] = nil
             hookWaitingSince[event.terminalID] = nil
+            // Fresh trailing edge — overwritten by each Stop, since every one of
+            // them is the agent stating anew that it finished.
+            hookIdleSince[event.terminalID] = now
             next.activityEvents.removeAll()
             isCompletion = true
         case .notification(let level, let text):
@@ -346,7 +393,8 @@ class AgentRegistry {
         next.lastMessage = message
         let oldStatus = current.status
         let newStatus = Self.arbitrate(scan: next.scanStatus, hook: next.hookStatus,
-                                       agentType: next.agentType)
+                                       agentType: next.agentType,
+                                       hookIdleFresh: hookIdleIsFreshLocked(event.terminalID, now: now))
         next.status = newStatus
         agents[event.terminalID] = next
 

--- a/Sources/Core/AgentRegistry.swift
+++ b/Sources/Core/AgentRegistry.swift
@@ -148,6 +148,7 @@ class AgentRegistry {
         orderedIDs.removeAll { $0 == terminalID }
         statusEnteredAt.removeValue(forKey: terminalID)
         hookRunningSince.removeValue(forKey: terminalID)
+        hookIdleSince.removeValue(forKey: terminalID)
         hookWaitingSince.removeValue(forKey: terminalID)
         eventLog.removeValue(forKey: terminalID)
         globalSeq += 1
@@ -302,8 +303,9 @@ class AgentRegistry {
         let now = Date()
 
         switch event.kind {
-        case .screenObserved(let status, let msg, let activity, let commandLine, let agentType, let roundDuration, let tasks):
+        case .screenObserved(let status, let msg, let activity, let commandLine, let agentType, let roundDuration, let tasks, let backgroundBusy):
             next.scanStatus = status
+            next.backgroundBusy = backgroundBusy
             next.roundDuration = roundDuration
             if !tasks.isEmpty { next.tasks = tasks }
             if !msg.isEmpty { message = msg }

--- a/Sources/Core/PaneInfo.swift
+++ b/Sources/Core/PaneInfo.swift
@@ -23,6 +23,19 @@ struct PaneInfo {
     var activityEvents: [ActivityEvent] = []
     var scanStatus: AgentStatus = .unknown   // latest screen-scan observation (component)
     var hookStatus: AgentStatus = .unknown   // webhook-accumulated inference (component)
+    /// The session has background work of its own — a shell it launched, a monitor
+    /// it watches. A separate axis from `status` on purpose: the agent can be idle
+    /// at an empty prompt while this is true, and folding it into the status
+    /// pinned such a pane on `running` for the life of the monitor, which cost it
+    /// every completion edge (and so every notification) it would have produced.
+    var backgroundBusy: Bool = false
+
+    /// What the dashboard draws. Background work still reads as busy — a worktree
+    /// watching CI is not "done" — while `status` stays the honest answer to
+    /// "what is the agent doing", which is what edges and notifications ride on.
+    var displayStatus: AgentStatus {
+        (status == .idle && backgroundBusy) ? .running : status
+    }
 
     /// Total duration computed live from startedAt
     var totalDuration: TimeInterval {

--- a/Sources/Core/PendingOrdersQueue.swift
+++ b/Sources/Core/PendingOrdersQueue.swift
@@ -5,6 +5,51 @@ struct PendingOrder: Equatable, Identifiable {
     let action: FirstMateAction
 }
 
+/// Remembers which suggestion cards a surface (the island, the First Mate
+/// sidebar) has already shown, so it can pop for a genuinely new ask and stay
+/// quiet for one already on screen.
+///
+/// Ids alone cannot answer that. `PendingOrdersQueue.key` is stable per pane, so
+/// a second suggestion from the same pane reuses the id: `upsert` swaps the card's
+/// contents in place and an id-set comparison sees nothing new — the surface stayed
+/// collapsed for every suggestion after the first, until the user happened to
+/// resolve one. Fingerprinting what the card actually *shows* is what fixes that.
+struct SuggestionSeenSet {
+    struct Fingerprint: Equatable {
+        let message: String
+        let options: [String]
+
+        init(_ order: PendingOrder) {
+            message = order.action.message
+            options = order.action.options ?? []
+        }
+    }
+
+    private var seen: [String: Fingerprint] = [:]
+
+    /// Record `orders` as the full set now on offer and return the ones this
+    /// surface has not shown yet. Cards that left the queue are forgotten, so a
+    /// re-raised card counts as new again.
+    mutating func absorb(_ orders: [PendingOrder]) -> [PendingOrder] {
+        let fresh = orders.filter { Self.isFresh($0, seen: seen[$0.id]) }
+        seen = Dictionary(orders.map { ($0.id, Fingerprint($0)) }, uniquingKeysWith: { _, last in last })
+        return fresh
+    }
+
+    /// A card is fresh when its id is new, when its options changed, or when its
+    /// summary was rewritten into something other than a late prose upgrade.
+    /// `PendingOrdersQueue.refreshSuggestMessage` swaps a junk summary (tool
+    /// chrome) for the agent's real prose while leaving the options alone — that
+    /// is the same ask reading better, not a new one, and must not re-pop.
+    private static func isFresh(_ order: PendingOrder, seen: Fingerprint?) -> Bool {
+        guard let seen else { return true }
+        let now = Fingerprint(order)
+        if seen.options != now.options { return true }
+        if seen.message == now.message { return false }
+        return !FirstMate.isJunkSuggestionSummary(seen.message)
+    }
+}
+
 /// Red-zone pending-orders queue. At most one entry per (worktreePath, kind) — idempotent.
 /// Must be used on the main thread.
 final class PendingOrdersQueue {

--- a/Sources/Core/SeahelmControlDataSource.swift
+++ b/Sources/Core/SeahelmControlDataSource.swift
@@ -269,6 +269,9 @@ final class SeahelmControlDataSource: ControlDataSource {
             "status": decided.status.rawValue,
             "decided_by": decided.decidedBy,
             "scan_status": scan.state.rawValue,
+            // True when no rule matched and `scan_status` is just the manifest's
+            // default — the screen is saying nothing, not saying "idle".
+            "scan_defaulted": scan.isDefaulted,
             "hook_status": hookStatus.rawValue,
             "process_status": "\(station.processStatus)",
             "osc_title": osc.title,

--- a/Sources/Core/SeahelmControlDataSource.swift
+++ b/Sources/Core/SeahelmControlDataSource.swift
@@ -274,6 +274,9 @@ final class SeahelmControlDataSource: ControlDataSource {
             // True when no rule matched and `scan_status` is just the manifest's
             // default — the screen is saying nothing, not saying "idle".
             "scan_defaulted": scan.isDefaulted,
+            // Background work (a shell / monitor this session started). A separate
+            // axis from status: the agent can be idle at a prompt while it is true.
+            "background_busy": scan.backgroundBusy,
             "hook_status": hookStatus.rawValue,
             // True while a Stop is still inside its trailing-edge window, where a
             // hook `.idle` outranks a screen that has not gone quiet yet.

--- a/Sources/Core/SeahelmControlDataSource.swift
+++ b/Sources/Core/SeahelmControlDataSource.swift
@@ -257,7 +257,9 @@ final class SeahelmControlDataSource: ControlDataSource {
             processStatus: station.processStatus, shellInfo: nil, content: content,
             manifest: manifest, osc: osc)
         let hookStatus = pane?.hookStatus ?? .unknown
-        let decided = AgentRegistry.arbitrateDetailed(scan: scan.state, hook: hookStatus, agentType: agentType)
+        let hookIdleFresh = AgentRegistry.shared.hookIdleIsFresh(terminalID: station.id)
+        let decided = AgentRegistry.arbitrateDetailed(scan: scan.state, hook: hookStatus,
+                                                      agentType: agentType, hookIdleFresh: hookIdleFresh)
 
         var result: [String: Any] = [
             "pane_id": station.id,
@@ -273,6 +275,9 @@ final class SeahelmControlDataSource: ControlDataSource {
             // default — the screen is saying nothing, not saying "idle".
             "scan_defaulted": scan.isDefaulted,
             "hook_status": hookStatus.rawValue,
+            // True while a Stop is still inside its trailing-edge window, where a
+            // hook `.idle` outranks a screen that has not gone quiet yet.
+            "hook_idle_fresh": hookIdleFresh,
             "process_status": "\(station.processStatus)",
             "osc_title": osc.title,
             "osc_progress": osc.progress,

--- a/Sources/Status/AgentManifest.swift
+++ b/Sources/Status/AgentManifest.swift
@@ -93,6 +93,13 @@ struct ManifestRule: Codable {
     var visibleIdle: Bool = false
     var visibleBlocker: Bool = false
     var visibleWorking: Bool = false
+    /// This rule reports *background* work (a shell or monitor the session
+    /// started), not the agent's own state. Such a rule never decides `state`:
+    /// it only raises `Detection.backgroundBusy`, and evaluation carries on to
+    /// find the rule that does. Conflating the two pinned a pane parked at an
+    /// empty prompt on `running` for as long as its monitor lived — and a pane
+    /// that never leaves running never produces the edge that notifies.
+    var backgroundTask: Bool = false
 
     // inline MatchGate
     var contains: [String] = []
@@ -108,6 +115,7 @@ struct ManifestRule: Codable {
         case visibleIdle = "visible_idle"
         case visibleBlocker = "visible_blocker"
         case visibleWorking = "visible_working"
+        case backgroundTask = "background_task"
         case lineRegex = "line_regex"
     }
 
@@ -126,6 +134,7 @@ struct ManifestRule: Codable {
         visibleIdle = try c.decodeIfPresent(Bool.self, forKey: .visibleIdle) ?? false
         visibleBlocker = try c.decodeIfPresent(Bool.self, forKey: .visibleBlocker) ?? false
         visibleWorking = try c.decodeIfPresent(Bool.self, forKey: .visibleWorking) ?? false
+        backgroundTask = try c.decodeIfPresent(Bool.self, forKey: .backgroundTask) ?? false
         contains = try c.decodeIfPresent([String].self, forKey: .contains) ?? []
         regex = try c.decodeIfPresent([String].self, forKey: .regex) ?? []
         lineRegex = try c.decodeIfPresent([String].self, forKey: .lineRegex) ?? []

--- a/Sources/Status/ManifestEngine.swift
+++ b/Sources/Status/ManifestEngine.swift
@@ -69,14 +69,31 @@ final class CompiledManifest {
     /// Default fallback when no rule matched a known agent.
     var defaultStatus: AgentStatus { AgentStatus.fromManifest(manifest.defaultStatus) }
 
-    /// Explainability: the winning rule plus the region text it matched against
-    /// (evidence), or nil if no rule matched. Same evaluation order as `evaluate`.
+    /// Explainability: the winning rule plus the evidence it matched on, or nil if
+    /// no rule matched. Same evaluation order as `evaluate`.
+    ///
+    /// Evidence is narrowed to the single line responsible whenever one line is
+    /// enough to satisfy the gate. Reporting the whole region instead is actively
+    /// misleading — it reads as "the rule matched this footer" when the real match
+    /// was some line of transcript higher up, which is exactly how a false
+    /// `running` gets blamed on the wrong rule.
     func matchDetail(_ input: DetectionInput) -> (rule: ManifestRule, regionText: String)? {
         for cr in compiledRules {
             let text = Self.regionText(cr.region, input)
-            if cr.gate.matches(text) { return (cr.rule, text) }
+            guard cr.gate.matches(text) else { continue }
+            return (cr.rule, Self.narrowEvidence(text, gate: cr.gate))
         }
         return nil
+    }
+
+    /// The first line that satisfies the gate on its own, else the region text.
+    /// Only ever called from the explain path, so the extra passes are free.
+    private static func narrowEvidence(_ text: String, gate: CompiledGate) -> String {
+        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            let s = String(line)
+            if gate.matches(s) { return s.trimmingCharacters(in: .whitespaces) }
+        }
+        return text
     }
 
     // MARK: Region extraction

--- a/Sources/Status/ManifestEngine.swift
+++ b/Sources/Status/ManifestEngine.swift
@@ -12,6 +12,10 @@ struct Detection: Equatable {
     var visibleWorking: Bool = false
     var skipStateUpdate: Bool = false
     var matchedRuleId: String? = nil
+    /// No rule matched — `state` is the manifest's `default_status` filling the
+    /// gap, not something observed on screen. Callers must treat it as weaker
+    /// than a matched rule: see `DebouncedStatusTracker.update`.
+    var isDefaulted: Bool = false
 
     static let unknown = Detection(state: .unknown)
 }

--- a/Sources/Status/ManifestEngine.swift
+++ b/Sources/Status/ManifestEngine.swift
@@ -16,6 +16,12 @@ struct Detection: Equatable {
     /// gap, not something observed on screen. Callers must treat it as weaker
     /// than a matched rule: see `DebouncedStatusTracker.update`.
     var isDefaulted: Bool = false
+    /// The session has background work of its own (a shell it launched, a monitor
+    /// it is watching). Deliberately NOT a status: the agent can be parked at an
+    /// empty prompt, ready for input, while this is true. Kept separate so the
+    /// dashboard can still show the worktree as busy without the status axis
+    /// losing the running → idle edge that notifications ride on.
+    var backgroundBusy: Bool = false
 
     static let unknown = Detection(state: .unknown)
 }
@@ -34,6 +40,9 @@ struct DetectionInput {
 final class CompiledManifest {
     let manifest: AgentManifest
     private let compiledRules: [CompiledRule]
+    /// Rules flagged `background_task` — evaluated on their own pass, never as
+    /// candidates for the status decision.
+    private let backgroundRules: [CompiledRule]
 
     struct CompiledRule {
         let rule: ManifestRule
@@ -43,14 +52,30 @@ final class CompiledManifest {
 
     init(_ manifest: AgentManifest) {
         self.manifest = manifest
-        self.compiledRules = manifest.rules
+        let compiled = manifest.rules
             .sorted { $0.priority > $1.priority }   // stable: ties keep source order
             .map { CompiledRule(rule: $0, region: ManifestRegion($0.region), gate: CompiledGate($0.gate)) }
+        // Two independent questions, two rule sets. Priority orders the status
+        // rules against each other; a background rule competes with nothing,
+        // because "the session has a shell running" and "the agent is working"
+        // are not answers to the same question and must not shadow one another.
+        self.compiledRules = compiled.filter { !$0.rule.backgroundTask }
+        self.backgroundRules = compiled.filter { $0.rule.backgroundTask }
     }
 
     /// Evaluate all rules; highest-priority match wins. Returns `.unknown`
     /// (falling through to default_status handling by the caller) if none match.
+    ///
+    /// `background_task` rules run on their own pass and only raise
+    /// `backgroundBusy`: "this session has a shell running" answers a different
+    /// question than "what is the agent doing". Letting one decide the status made
+    /// a pane parked at an empty prompt read as running for as long as its monitor
+    /// lived — and a pane that never leaves running never emits the edge that
+    /// notifies.
     func evaluate(_ input: DetectionInput) -> Detection {
+        let backgroundBusy = backgroundRules.contains {
+            $0.gate.matches(Self.regionText($0.region, input))
+        }
         for cr in compiledRules {
             let text = Self.regionText(cr.region, input)
             guard cr.gate.matches(text) else { continue }
@@ -60,10 +85,11 @@ final class CompiledManifest {
                 visibleBlocker: cr.rule.visibleBlocker,
                 visibleWorking: cr.rule.visibleWorking,
                 skipStateUpdate: cr.rule.skipStateUpdate,
-                matchedRuleId: cr.rule.id
+                matchedRuleId: cr.rule.id,
+                backgroundBusy: backgroundBusy
             )
         }
-        return Detection.unknown
+        return Detection(state: .unknown, backgroundBusy: backgroundBusy)
     }
 
     /// Default fallback when no rule matched a known agent.

--- a/Sources/Status/NormalizedEvent.swift
+++ b/Sources/Status/NormalizedEvent.swift
@@ -35,7 +35,8 @@ enum NormalizedEventKind {
                         commandLine: String?,
                         agentType: AgentType,
                         roundDuration: TimeInterval,
-                        tasks: [TaskItem])
+                        tasks: [TaskItem],
+                        backgroundBusy: Bool = false)
 }
 
 struct NormalizedEvent {

--- a/Sources/Status/NotificationManager.swift
+++ b/Sources/Status/NotificationManager.swift
@@ -14,7 +14,13 @@ extension Notification.Name {
 class NotificationManager: NSObject {
     static let shared = NotificationManager()
 
-    private var lastNotified: [String: Date] = [:]
+    /// Which channel a status change came from. The agent reporting its own stop
+    /// (hook) is worth more than the screen scan inferring one: the scan cannot
+    /// tell a thinking pause from a finished turn, so an agent-reported completion
+    /// is allowed to correct a scan-derived banner inside the cooldown window.
+    enum NotificationSource { case scan, agent }
+
+    private var lastNotified: [String: (at: Date, source: NotificationSource)] = [:]
 
     /// Minimum seconds between delivered notifications for the same key. Injected
     /// from `Config.notifications` at startup.
@@ -136,12 +142,28 @@ class NotificationManager: NSObject {
     /// only when a notification is actually *delivered* (`recordDelivery`), so a
     /// notification held by the stability gate and then dropped does not burn the
     /// cooldown window.
+    /// `source` says who reported this change (see `NotificationSource`): an
+    /// agent-reported event may overtake a still-warm scan-derived one, because
+    /// that earlier banner was quite possibly wrong — a thinking pause read as a
+    /// finished turn. It gets that right exactly once per window: two
+    /// agent-reported events really are two events, and the cooldown is what keeps
+    /// a blocked-then-resumed Stop pair from bannering twice.
     func shouldNotify(cooldownKey: String, oldStatus: AgentStatus, newStatus: AgentStatus,
-                      now: Date = Date()) -> Bool {
+                      source: NotificationSource = .scan, now: Date = Date()) -> Bool {
+        Self.shouldNotify(oldStatus: oldStatus, newStatus: newStatus, source: source,
+                          lastDelivery: lastNotified[cooldownKey], cooldown: cooldown, now: now)
+    }
+
+    /// Pure core of the eligibility gate — extracted so the cooldown/override
+    /// policy is testable without the shared instance's accumulated deliveries.
+    static func shouldNotify(oldStatus: AgentStatus, newStatus: AgentStatus,
+                             source: NotificationSource,
+                             lastDelivery: (at: Date, source: NotificationSource)?,
+                             cooldown: TimeInterval, now: Date) -> Bool {
         guard oldStatus == .running else { return false }
         guard newStatus == .waiting || newStatus == .error || newStatus == .idle else { return false }
-        if let last = lastNotified[cooldownKey], now.timeIntervalSince(last) < cooldown {
-            return false
+        if let last = lastDelivery, now.timeIntervalSince(last.at) < cooldown {
+            return source == .agent && last.source == .scan
         }
         return true
     }
@@ -365,6 +387,20 @@ class NotificationManager: NSObject {
     /// Set by MainWindowController; nil in tests and headless runs.
     var onDeliverExternal: ((_ status: AgentStatus, _ title: String, _ subtitle: String, _ body: String) -> Void)?
 
+    /// Whether a suggestion card for this pane is already expanded on screen (the
+    /// island popped open with it). Set by MainWindowController; nil in tests and
+    /// headless runs, where nothing is on screen to be redundant with.
+    var isCardOnScreen: ((_ terminalID: String) -> Bool)?
+
+    /// Whether the system banner would only repeat something the user is already
+    /// looking at. Both surfaces that can pre-empt it — the focused pane itself and
+    /// an expanded island card — only count while seahelm is frontmost: in the
+    /// background the island collapses on its own after ten seconds and may never
+    /// have been seen at all, so the banner is the only durable record.
+    static func shouldSuppressBanner(appActive: Bool, targetVisible: Bool, cardOnScreen: Bool) -> Bool {
+        appActive && (targetVisible || cardOnScreen)
+    }
+
     static func formatSystemTitle(status: AgentStatus) -> String {
         switch status {
         case .idle:
@@ -421,6 +457,9 @@ class NotificationManager: NSObject {
     ///   - paneIndex/paneCount: 1-based; `paneCount > 1` adds a `[Pane N]` label
     ///     and records the pane in history so a click can mark just that pane read.
     ///   - isTargetVisible: whether this worktree is the one currently shown.
+    ///   - source: who reported the change — the agent's own hook, or the screen
+    ///     scan inferring it. Only the former may correct a banner already sent
+    ///     inside the cooldown window.
     func notify(
         worktreePath: String,
         workspaceName: String,
@@ -433,7 +472,8 @@ class NotificationManager: NSObject {
         lastMessage: String,
         lastUserPrompt: String = "",
         lastAssistantMessage: String = "",
-        isTargetVisible: Bool = false
+        isTargetVisible: Bool = false,
+        source: NotificationSource = .scan
     ) {
         let key = Self.cooldownKey(terminalID: terminalID, worktreePath: worktreePath)
 
@@ -442,19 +482,21 @@ class NotificationManager: NSObject {
         // flicker that flips back to running mid-turn).
         latestStatus[key] = newStatus
 
-        guard shouldNotify(cooldownKey: key, oldStatus: oldStatus, newStatus: newStatus) else { return }
+        guard shouldNotify(cooldownKey: key, oldStatus: oldStatus,
+                           newStatus: newStatus, source: source) else { return }
 
         // The delivery closure captures the fully-formed payload. Invoked either
         // immediately or when the stability timer fires and the status still holds.
         let deliver = { [weak self] in
             guard let self else { return }
-            self.lastNotified[key] = Date()
+            self.lastNotified[key] = (at: Date(), source: source)
             self.deliver(
                 worktreePath: worktreePath,
                 workspaceName: workspaceName,
                 branch: branch,
                 paneIndex: paneIndex,
                 paneCount: paneCount,
+                terminalID: terminalID,
                 newStatus: newStatus,
                 lastMessage: lastMessage,
                 lastUserPrompt: lastUserPrompt,
@@ -493,6 +535,7 @@ class NotificationManager: NSObject {
         branch: String,
         paneIndex: Int,
         paneCount: Int,
+        terminalID: String,
         newStatus: AgentStatus,
         lastMessage: String,
         lastUserPrompt: String,
@@ -537,8 +580,13 @@ class NotificationManager: NSObject {
         ))
 
         // Suppress the system banner only when the user can already see this
-        // target (frontmost AND the worktree is on screen).
-        if isTargetVisible && NSApp.isActive { return }
+        // event — the pane itself is on screen and focused, or the island is
+        // expanded showing this pane's suggestion card (the same completion,
+        // rendered with the buttons that act on it).
+        let cardOnScreen = !terminalID.isEmpty && isCardOnScreen?(terminalID) == true
+        if Self.shouldSuppressBanner(appActive: NSApp.isActive,
+                                     targetVisible: isTargetVisible,
+                                     cardOnScreen: cardOnScreen) { return }
 
         // Mirror the banner, not the history entry: this fires on exactly the
         // edges that earn a banner, and is skipped by the return above when the

--- a/Sources/Status/PaneStatus.swift
+++ b/Sources/Status/PaneStatus.swift
@@ -13,6 +13,16 @@ struct PaneStatus: Equatable {
     /// waiting.
     var statusChangedAt: Date
     var agentType: AgentType = .unknown
+    /// The pane's session has background work of its own (see
+    /// `PaneInfo.backgroundBusy`). Carried alongside `status`, never folded into
+    /// it: `paneStatusDidChange` — the edge notifications ride on — must keep
+    /// seeing the agent's own state.
+    var backgroundBusy: Bool = false
+
+    /// What the dashboard draws for this pane. Mirrors `PaneInfo.displayStatus`.
+    var displayStatus: AgentStatus {
+        (status == .idle && backgroundBusy) ? .running : status
+    }
 }
 
 struct WorktreeStatus: Equatable {
@@ -44,6 +54,6 @@ struct WorktreeStatus: Equatable {
     }
 
     var rolledUpStatus: AgentStatus {
-        representative?.status ?? .unknown
+        representative?.displayStatus ?? .unknown
     }
 }

--- a/Sources/Status/ScanDecoder.swift
+++ b/Sources/Status/ScanDecoder.swift
@@ -16,6 +16,14 @@ struct ScanDecoder: SignalDecoder {
     let tasks: [TaskItem]
 
     func decode() -> NormalizedEvent? {
+        let detection = detector.detectDetailed(
+            processStatus: processStatus,
+            shellInfo: shellInfo,
+            content: content,
+            manifest: manifest
+        )
+        // `detect` is still the answer for the legacy AgentDef path, which
+        // `detectDetailed` does not cover; the rich call only adds the flags.
         let status = detector.detect(
             processStatus: processStatus,
             shellInfo: shellInfo,
@@ -27,7 +35,8 @@ struct ScanDecoder: SignalDecoder {
         let kind = NormalizedEventKind.screenObserved(
             status: status, message: "", activity: events,
             commandLine: commandLine, agentType: agentType,
-            roundDuration: roundDuration, tasks: tasks)
+            roundDuration: roundDuration, tasks: tasks,
+            backgroundBusy: detection.backgroundBusy)
         return NormalizedEvent(terminalID: terminalID, source: .scan, kind: kind)
     }
 }

--- a/Sources/Status/StatusDetector.swift
+++ b/Sources/Status/StatusDetector.swift
@@ -98,7 +98,14 @@ class StatusDetector {
         let lower = lowercasedContent ?? content.lowercased()
         let d = manifest.evaluate(DetectionInput(screen: lower, oscTitle: osc.title, oscProgress: osc.progress))
         if d.state == .unknown {
-            return Detection(state: manifest.defaultStatus, visibleIdle: manifest.defaultStatus == .idle)
+            // Nothing matched, so the manifest's default fills the gap. That is a
+            // baseline classification, not an observation — no shipped manifest has
+            // an idle rule, which makes a defaulted `.idle` mean only "no running /
+            // waiting / error rule matched THIS frame". Claiming `visibleIdle` here
+            // (as this used to) told the debounce layer the agent was seen finishing,
+            // so a single frame of a thinking agent — spinner momentarily off screen —
+            // ended its turn and fired a completion banner mid-turn.
+            return Detection(state: manifest.defaultStatus, isDefaulted: true)
         }
         return d
     }
@@ -282,19 +289,27 @@ class DebouncedStatusTracker {
 
     /// Consecutive plain-idle observations required to leave `running`.
     var pendingIdleConfirmations = 2
+    /// Consecutive observations required to leave `running` on a *defaulted* idle —
+    /// one where no rule matched at all (`Detection.isDefaulted`). Absence of
+    /// evidence is far weaker than a matched idle rule: an agent that merely paused
+    /// to think looks exactly like this, so the hold runs long enough (~12s at the
+    /// 2s poll cadence) to outlast a thinking gap. Agents that report through hooks
+    /// never wait on it — their Stop hook ends the turn directly.
+    var defaultedIdleConfirmations = 6
     private var pendingIdleCount = 0
 
     /// Update with detected status. Returns true if status changed.
     @discardableResult
-    func update(status: AgentStatus, visibleIdle: Bool = true) -> Bool {
+    func update(status: AgentStatus, visibleIdle: Bool = true, defaulted: Bool = false) -> Bool {
         // Unknown means "no data" — don't change.
         guard status != .unknown else { return false }
 
         // Hold a bare running→idle flip until it is confirmed (unless a visible
         // idle signal proves the agent really finished).
-        if currentStatus == .running, status == .idle, !visibleIdle {
+        if currentStatus == .running, status == .idle, defaulted || !visibleIdle {
             pendingIdleCount += 1
-            if pendingIdleCount < pendingIdleConfirmations { return false }
+            let needed = defaulted ? defaultedIdleConfirmations : pendingIdleConfirmations
+            if pendingIdleCount < needed { return false }
         }
         pendingIdleCount = 0
 

--- a/Sources/Status/StatusDetector.swift
+++ b/Sources/Status/StatusDetector.swift
@@ -105,7 +105,10 @@ class StatusDetector {
             // (as this used to) told the debounce layer the agent was seen finishing,
             // so a single frame of a thinking agent — spinner momentarily off screen —
             // ended its turn and fired a completion banner mid-turn.
-            return Detection(state: manifest.defaultStatus, isDefaulted: true)
+            // `backgroundBusy` survives the fallback: it was observed, and it is
+            // the one thing the screen did say.
+            return Detection(state: manifest.defaultStatus, isDefaulted: true,
+                             backgroundBusy: d.backgroundBusy)
         }
         return d
     }

--- a/Sources/Status/StatusPublisher.swift
+++ b/Sources/Status/StatusPublisher.swift
@@ -345,7 +345,8 @@ class StatusPublisher {
 
             lock.lock()
             let oldStatus = tracker.currentStatus
-            let statusChanged = tracker.update(status: textStatus, visibleIdle: detection.visibleIdle)
+            let statusChanged = tracker.update(status: textStatus, visibleIdle: detection.visibleIdle,
+                                               defaulted: detection.isDefaulted)
             // The debounced/committed status drives both pipelines, so a held
             // running→idle flip does not leak into AgentRegistry either.
             let committedStatus = tracker.currentStatus

--- a/Sources/Status/StatusPublisher.swift
+++ b/Sources/Status/StatusPublisher.swift
@@ -366,7 +366,8 @@ class StatusPublisher {
                 terminalID: terminalID, source: .scan,
                 kind: .screenObserved(status: committedStatus, message: "", activity: activityEvents,
                                       commandLine: commandLine, agentType: agentType,
-                                      roundDuration: roundDur, tasks: webhookTasks))
+                                      roundDuration: roundDur, tasks: webhookTasks,
+                                      backgroundBusy: detection.backgroundBusy))
             AgentRegistry.shared.ingest(normalized)
 
             // Agent permission dialogs are rendered by the TUI rather than sent

--- a/Sources/Status/WorktreeStatusAggregator.swift
+++ b/Sources/Status/WorktreeStatusAggregator.swift
@@ -65,16 +65,18 @@ class WorktreeStatusAggregator {
     }
 
     func agentDidUpdate(terminalID: String, status: AgentStatus, lastMessage: String,
-                        lastUserPrompt: String = "", agentType: AgentType = .unknown) {
+                        lastUserPrompt: String = "", agentType: AgentType = .unknown,
+                        backgroundBusy: Bool = false) {
         guard let worktreePath = terminalToWorktree[terminalID] else { return }
 
         let now = Date()
         let oldPaneState = paneStates[terminalID]
         let statusChanged = oldPaneState?.status != status
+        let backgroundChanged = oldPaneState?.backgroundBusy != backgroundBusy
         let messageChanged = oldPaneState?.lastMessage != lastMessage
         let promptChanged = oldPaneState?.lastUserPrompt != lastUserPrompt
 
-        guard statusChanged || messageChanged || promptChanged else { return }
+        guard statusChanged || messageChanged || promptChanged || backgroundChanged else { return }
 
         // Advance the worktree's last-activity time. A first-ever detection of a
         // pane (oldPaneState == nil) is launch/restore noise — keep any seeded/
@@ -100,7 +102,8 @@ class WorktreeStatusAggregator {
             lastUserPrompt: effectivePrompt,
             lastUpdated: now,
             statusChangedAt: statusChangedAt,
-            agentType: effectiveType
+            agentType: effectiveType,
+            backgroundBusy: backgroundBusy
         )
         paneStates[terminalID] = newPaneState
 

--- a/Sources/UI/Island/IslandPanelController.swift
+++ b/Sources/UI/Island/IslandPanelController.swift
@@ -126,10 +126,15 @@ final class IslandPanelController {
 
     /// Auto-expand for an arriving suggestion so the card is visible without
     /// hovering. Collapses again after a timeout if the pointer never comes,
-    /// or as soon as it leaves after having engaged. Suppressed while seahelm
-    /// is frontmost — the main window already shows the suggestion.
-    func openForEvent() {
-        guard !NSApp.isActive else { return }
+    /// or as soon as it leaves after having engaged.
+    ///
+    /// Suppressed only when the user is already looking at the card: seahelm
+    /// frontmost AND the raising pane's worktree on screen, where the First Mate
+    /// sidebar carries it. Frontmost on a *different* worktree still pops —
+    /// that sidebar shows its own worktree's cards, so nothing else would
+    /// surface this one and it used to arrive silently.
+    func openForEvent(targetVisible: Bool) {
+        guard !(NSApp.isActive && targetVisible) else { return }
         guard let panel, !model.isOpened else { return }
         if !panel.isVisible { updateVisibility() }
         guard panel.isVisible else { return }

--- a/Tests/AgentRegistryIngestOutcomeTests.swift
+++ b/Tests/AgentRegistryIngestOutcomeTests.swift
@@ -231,4 +231,72 @@ final class AgentRegistryIngestOutcomeTests: XCTestCase {
         XCTAssertTrue(captured?.isCompletionSignal ?? false)
         XCTAssertEqual(captured?.newStatus, .error)
     }
+
+    // MARK: - Trailing edge (hook stop vs a screen that hasn't gone quiet)
+
+    func testFreshHookIdlePromotesOverScanRunning() {
+        XCTAssertEqual(
+            AgentRegistry.arbitrate(scan: .running, hook: .idle, agentType: .claudeCode,
+                                    hookIdleFresh: true), .idle,
+            "the agent said it stopped; its TUI simply has not caught up")
+    }
+
+    func testStaleHookIdleLeavesAuthorityWithTheScreen() {
+        XCTAssertEqual(
+            AgentRegistry.arbitrate(scan: .running, hook: .idle, agentType: .claudeCode,
+                                    hookIdleFresh: false), .running,
+            "past the window a working pane must never be pinned at idle")
+    }
+
+    func testFreshHookIdleNeverOutranksAnUrgentScreen() {
+        XCTAssertEqual(
+            AgentRegistry.arbitrate(scan: .waiting, hook: .idle, agentType: .claudeCode,
+                                    hookIdleFresh: true), .waiting,
+            "a blocked agent outranks a completion from either source")
+    }
+
+    /// End to end: the completion this whole path exists for. A Stop arrives while
+    /// the scan still reports running — the normal state of a TUI at the instant a
+    /// turn ends — and must still produce an Idle outcome to notify on.
+    func testStopWhileScreenStillRunningYieldsIdleOutcome() {
+        var captured: [IngestOutcome] = []
+        let exp = expectation(description: "stop outcome")
+        exp.assertForOverFulfill = false
+        AgentRegistry.shared.onOutcome = { o in
+            captured.append(o)
+            if o.newStatus == .idle { exp.fulfill() }
+        }
+        AgentRegistry.shared.ingest(NormalizedEvent(terminalID: "t1", source: .hook("claude-code"),
+                                                   kind: .userPrompt("do the thing")))
+        AgentRegistry.shared.ingest(NormalizedEvent(terminalID: "t1", source: .scan,
+            kind: .screenObserved(status: .running, message: "", activity: [],
+                                  commandLine: nil, agentType: .claudeCode,
+                                  roundDuration: 0, tasks: [])))
+        AgentRegistry.shared.ingest(NormalizedEvent(terminalID: "t1", source: .hook("claude-code"),
+                                                   kind: .agentStopped(success: true)))
+        wait(for: [exp], timeout: 2)
+        XCTAssertEqual(captured.last?.newStatus, .idle)
+        XCTAssertEqual(captured.last?.oldStatus, .running, "and it is a running -> idle edge, which is what notifies")
+    }
+
+    /// The window is what keeps the promotion honest: once it lapses, the next scan
+    /// frame showing work in progress takes the pane back to running.
+    func testScreenReclaimsRunningOnceTheIdleWindowLapses() {
+        AgentRegistry.hookIdleGrace = 0
+        defer { AgentRegistry.hookIdleGrace = 3.0 }
+        var captured: IngestOutcome?
+        let exp = expectation(description: "reclaim")
+        exp.assertForOverFulfill = false
+        AgentRegistry.shared.onOutcome = { o in
+            if o.newStatus == .running { captured = o; exp.fulfill() }
+        }
+        AgentRegistry.shared.ingest(NormalizedEvent(terminalID: "t1", source: .hook("claude-code"),
+                                                   kind: .agentStopped(success: true)))
+        AgentRegistry.shared.ingest(NormalizedEvent(terminalID: "t1", source: .scan,
+            kind: .screenObserved(status: .running, message: "", activity: [],
+                                  commandLine: nil, agentType: .claudeCode,
+                                  roundDuration: 0, tasks: [])))
+        wait(for: [exp], timeout: 2)
+        XCTAssertEqual(captured?.newStatus, .running)
+    }
 }

--- a/Tests/ManifestEngineTests.swift
+++ b/Tests/ManifestEngineTests.swift
@@ -58,11 +58,17 @@ final class ManifestEngineTests: XCTestCase {
         XCTAssertNotNil(ManifestStore.shared.manifest(for: "pi-coding-agent"))
     }
 
-    /// Regression: Claude Code at an idle prompt but with background tasks still
-    /// running (footer shows "· 1 shell ·" / "← 2 agents", or the transcript
-    /// spinner line ends with "1 shell still running") must detect as running,
-    /// not fall through to the idle default.
-    func testClaudeBackgroundTasksDetectAsRunning() {
+    /// Claude Code at an idle prompt with background work of its own (footer
+    /// "· 1 shell ·", "· 1 monitor ·", or a spinner line ending "1 shell still
+    /// running") must be reported as background-busy, so the dashboard still
+    /// draws the worktree as busy rather than done.
+    ///
+    /// It is deliberately NOT the agent's status any more. A monitor lives as long
+    /// as the thing it watches, so folding it into `state` pinned the pane on
+    /// `running` indefinitely — and a pane that never leaves running never emits
+    /// the running → idle edge that notifications ride on. `displayStatus` is what
+    /// preserves the original dashboard behaviour; see `PaneInfoDisplayStatusTests`.
+    func testClaudeBackgroundTasksDetectAsBackgroundBusy() {
         guard let cm = ManifestStore.shared.manifest(for: "claude") else {
             return XCTFail("missing claude manifest")
         }
@@ -79,8 +85,9 @@ final class ManifestEngineTests: XCTestCase {
         ]
         for screen in footers {
             let d = cm.evaluate(DetectionInput(screen: screen.lowercased()))
-            XCTAssertEqual(d.state, .running, "expected running for: \(screen)")
-            XCTAssertTrue(d.visibleWorking)
+            XCTAssertTrue(d.backgroundBusy, "expected background-busy for: \(screen)")
+            XCTAssertNotEqual(d.state, .running,
+                              "background work must not decide the agent's own status: \(screen)")
         }
         // Idle prompts must NOT match: "← 2 agents" is a persistent connected-
         // agents indicator (not a background task), and transcript prose like
@@ -90,9 +97,29 @@ final class ManifestEngineTests: XCTestCase {
             "done.\n\n❯ \n▸▸ bypass permissions on (shift+tab to cycle) · ← 2 agents",
         ]
         for screen in idles {
-            XCTAssertEqual(cm.evaluate(DetectionInput(screen: screen)).state, .unknown,
-                           "expected no match for: \(screen)")
+            let d = cm.evaluate(DetectionInput(screen: screen))
+            XCTAssertEqual(d.state, .unknown, "expected no match for: \(screen)")
+            XCTAssertFalse(d.backgroundBusy, "expected no background work for: \(screen)")
         }
+    }
+
+    /// A background rule must not shadow the rule that answers the real question.
+    /// Evaluation used to stop at the first match, so a footer shell count hid a
+    /// live spinner (and anything else below its priority) behind `running` — the
+    /// right answer by luck, the wrong reason, and wrong the moment the agent
+    /// stopped.
+    func testBackgroundRuleDoesNotShadowTheStatusRule() {
+        guard let cm = ManifestStore.shared.manifest(for: "claude") else {
+            return XCTFail("missing claude manifest")
+        }
+        let screen = """
+        do you want to proceed?
+        ❯ 
+        ▸▸ bypass permissions on · 1 shell · ← 2 agents
+        """
+        let d = cm.evaluate(DetectionInput(screen: screen))
+        XCTAssertEqual(d.state, .waiting, "a blocked agent still reads as waiting")
+        XCTAssertTrue(d.backgroundBusy, "and the background work is still reported")
     }
 
     /// Regression: Claude Code no longer prints "esc to interrupt" in its spinner

--- a/Tests/ManifestEngineTests.swift
+++ b/Tests/ManifestEngineTests.swift
@@ -328,4 +328,20 @@ final class ManifestEngineTests: XCTestCase {
         XCTAssertEqual(AgentStatus.fromManifest("blocked"), .waiting)
         XCTAssertEqual(AgentStatus.fromManifest("IDLE"), .idle)
     }
+
+    /// Evidence must name the line that actually fired, not the whole region —
+    /// the wrong line sends you rewriting a rule that was innocent.
+    func testMatchDetailNarrowsEvidenceToTheMatchingLine() {
+        guard let cm = ManifestStore.shared.manifest(for: "claude") else {
+            return XCTFail("missing claude manifest")
+        }
+        let screen = """
+        ⏺ read(sources/status/manifestengine.swift)
+        ✳ synthesizing… (12m 12s · ↓ 36.4k tokens)
+          ⏵⏵ bypass permissions on (shift+tab to cycle) · ← 5 agents
+        """
+        let detail = cm.matchDetail(DetectionInput(screen: screen))
+        XCTAssertEqual(detail?.rule.id, "working_spinner")
+        XCTAssertEqual(detail?.regionText, "✳ synthesizing… (12m 12s · ↓ 36.4k tokens)")
+    }
 }

--- a/Tests/NotificationManagerTests.swift
+++ b/Tests/NotificationManagerTests.swift
@@ -170,4 +170,71 @@ final class NotificationManagerTests: XCTestCase {
         // No observation → drop.
         XCTAssertFalse(NotificationManager.shouldDeliverPending(targetStatus: .idle, latestStatus: nil))
     }
+
+    // MARK: - Banner suppression
+
+    func testBannerFiresWhenAppIsInBackgroundEvenWithACardOnScreen() {
+        // The island collapses on its own after ten seconds and may never have
+        // been seen — in the background the banner is the only durable record.
+        XCTAssertFalse(NotificationManager.shouldSuppressBanner(
+            appActive: false, targetVisible: true, cardOnScreen: true))
+    }
+
+    func testBannerSuppressedWhenIslandCardIsExpandedFrontmost() {
+        XCTAssertTrue(NotificationManager.shouldSuppressBanner(
+            appActive: true, targetVisible: false, cardOnScreen: true))
+    }
+
+    func testBannerSuppressedWhenLookingAtThePane() {
+        XCTAssertTrue(NotificationManager.shouldSuppressBanner(
+            appActive: true, targetVisible: true, cardOnScreen: false))
+    }
+
+    func testBannerFiresForAnotherWorktreeWithNoCardShown() {
+        XCTAssertFalse(NotificationManager.shouldSuppressBanner(
+            appActive: true, targetVisible: false, cardOnScreen: false))
+    }
+
+    // MARK: - Cooldown override
+
+    private func gate(_ source: NotificationManager.NotificationSource,
+                      after last: (at: Date, source: NotificationManager.NotificationSource)?,
+                      elapsed: TimeInterval) -> Bool {
+        let now = Date()
+        let previous = last.map { (at: now.addingTimeInterval(-elapsed), source: $0.source) }
+        return NotificationManager.shouldNotify(
+            oldStatus: .running, newStatus: .idle, source: source,
+            lastDelivery: previous, cooldown: 30, now: now)
+    }
+
+    func testCooldownSuppressesASecondScanBanner() {
+        XCTAssertFalse(gate(.scan, after: (at: Date(), source: .scan), elapsed: 5))
+    }
+
+    /// The regression: a screen-inferred banner fired mid-turn (a thinking pause
+    /// read as a finished turn) used to swallow the real completion arriving
+    /// seconds later, with no retry — the user simply never heard about it.
+    func testAgentReportedCompletionOverridesAWarmScanBanner() {
+        XCTAssertTrue(gate(.agent, after: (at: Date(), source: .scan), elapsed: 5))
+    }
+
+    /// A blocked Stop is ingested as completion and the agent's follow-up turn
+    /// stops again moments later. Both are agent-reported, so the cooldown must
+    /// collapse them into one banner.
+    func testSecondAgentReportedCompletionIsStillSuppressed() {
+        XCTAssertFalse(gate(.agent, after: (at: Date(), source: .agent), elapsed: 5))
+    }
+
+    func testScanBannerNeverOverridesAnAgentReportedOne() {
+        XCTAssertFalse(gate(.scan, after: (at: Date(), source: .agent), elapsed: 5))
+    }
+
+    func testPastTheCooldownEitherSourceFires() {
+        XCTAssertTrue(gate(.scan, after: (at: Date(), source: .agent), elapsed: 31))
+        XCTAssertTrue(gate(.agent, after: (at: Date(), source: .agent), elapsed: 31))
+    }
+
+    func testFirstEverEdgeFires() {
+        XCTAssertTrue(gate(.scan, after: nil, elapsed: 0))
+    }
 }

--- a/Tests/PaneInfoDisplayStatusTests.swift
+++ b/Tests/PaneInfoDisplayStatusTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import seahelm
+
+/// The two axes a pane reports on, and the one place they are recombined.
+///
+/// `status` answers "what is the agent doing" — it drives edges, First Mate and
+/// notifications. `backgroundBusy` answers "does this session have work of its
+/// own running" — a shell it launched, a monitor it watches. Folding the second
+/// into the first is what pinned a pane parked at an empty prompt on `running`
+/// for the life of its monitor, costing it every completion notification.
+/// `displayStatus` puts them back together for the dashboard only.
+final class PaneInfoDisplayStatusTests: XCTestCase {
+    private func pane(status: AgentStatus, backgroundBusy: Bool) -> PaneInfo {
+        var info = PaneInfo(id: "t1", worktreePath: "/wt", agentType: .claudeCode,
+                            project: "proj", branch: "main", status: status,
+                            lastMessage: "", commandLine: nil, roundDuration: 0,
+                            startedAt: nil, station: nil, channel: nil,
+                            taskProgress: TaskProgress())
+        info.backgroundBusy = backgroundBusy
+        return info
+    }
+
+    func testIdleWithBackgroundWorkStillDrawsAsBusy() {
+        XCTAssertEqual(pane(status: .idle, backgroundBusy: true).displayStatus, .running,
+                       "a worktree watching CI is not done")
+    }
+
+    func testTheStatusAxisItselfStaysHonest() {
+        XCTAssertEqual(pane(status: .idle, backgroundBusy: true).status, .idle,
+                       "this is the value the running -> idle edge is computed from")
+    }
+
+    func testIdleWithoutBackgroundWorkDrawsAsIdle() {
+        XCTAssertEqual(pane(status: .idle, backgroundBusy: false).displayStatus, .idle)
+    }
+
+    /// Background work never upgrades or masks a state that needs the user.
+    func testUrgentStatesAreUntouched() {
+        XCTAssertEqual(pane(status: .waiting, backgroundBusy: true).displayStatus, .waiting)
+        XCTAssertEqual(pane(status: .error, backgroundBusy: true).displayStatus, .error)
+        XCTAssertEqual(pane(status: .exited, backgroundBusy: true).displayStatus, .exited)
+    }
+
+    func testPaneStatusMirrorsTheSameRule() {
+        var ps = PaneStatus(paneIndex: 1, terminalID: "t1", status: .idle, lastMessage: "",
+                            lastUserPrompt: "", lastUpdated: Date(), statusChangedAt: Date())
+        ps.backgroundBusy = true
+        XCTAssertEqual(ps.displayStatus, .running)
+        XCTAssertEqual(ps.status, .idle)
+    }
+
+    /// The worktree badge follows the same rule as its panes, so the card and the
+    /// dots can never disagree.
+    func testWorktreeRollupUsesDisplayStatus() {
+        var ps = PaneStatus(paneIndex: 1, terminalID: "t1", status: .idle, lastMessage: "",
+                            lastUserPrompt: "", lastUpdated: Date(), statusChangedAt: Date())
+        ps.backgroundBusy = true
+        let ws = WorktreeStatus(worktreePath: "/wt", panes: [ps], mostRecentPaneIndex: 1,
+                                mostRecentMessage: "", mostRecentUserPrompt: "")
+        XCTAssertEqual(ws.rolledUpStatus, .running)
+    }
+}

--- a/Tests/ScanDecoderTests.swift
+++ b/Tests/ScanDecoderTests.swift
@@ -15,7 +15,7 @@ final class ScanDecoderTests: XCTestCase {
             roundDuration: 0,
             tasks: []
         )
-        guard case .screenObserved(let status, _, _, _, _, _, _) = decoder.decode()?.kind else {
+        guard case .screenObserved(let status, _, _, _, _, _, _, _) = decoder.decode()?.kind else {
             return XCTFail("expected screenObserved")
         }
         XCTAssertEqual(status, .exited)
@@ -34,7 +34,7 @@ final class ScanDecoderTests: XCTestCase {
             roundDuration: 0,
             tasks: []
         )
-        guard case .screenObserved(let status, _, _, _, _, _, _) = decoder.decode()?.kind else {
+        guard case .screenObserved(let status, _, _, _, _, _, _, _) = decoder.decode()?.kind else {
             return XCTFail("expected screenObserved")
         }
         XCTAssertEqual(status, .unknown)

--- a/Tests/StatusDetectorTests.swift
+++ b/Tests/StatusDetectorTests.swift
@@ -292,6 +292,39 @@ final class DebouncedStatusTrackerTests: XCTestCase {
         XCTAssertEqual(tracker.currentStatus, .idle)
     }
 
+    /// A defaulted idle — no rule matched, the manifest's `default_status` filled
+    /// the gap — is absence of evidence. It must not end a turn on one frame the
+    /// way a matched idle rule would; that is what fired completion banners
+    /// mid-turn while the agent was only thinking.
+    func testDefaultedIdleHoldsFarLongerThanAMatchedOne() {
+        let tracker = DebouncedStatusTracker()
+        tracker.defaultedIdleConfirmations = 3
+        tracker.update(status: .running)
+        XCTAssertFalse(tracker.update(status: .idle, visibleIdle: true, defaulted: true))
+        XCTAssertFalse(tracker.update(status: .idle, visibleIdle: true, defaulted: true))
+        XCTAssertEqual(tracker.currentStatus, .running, "a thinking pause is not a finished turn")
+        XCTAssertTrue(tracker.update(status: .idle, visibleIdle: true, defaulted: true))
+        XCTAssertEqual(tracker.currentStatus, .idle, "sustained silence still commits eventually")
+    }
+
+    func testDefaultedIdleCounterResetsWhenWorkingReappears() {
+        let tracker = DebouncedStatusTracker()
+        tracker.defaultedIdleConfirmations = 2
+        tracker.update(status: .running)
+        XCTAssertFalse(tracker.update(status: .idle, visibleIdle: true, defaulted: true))
+        XCTAssertFalse(tracker.update(status: .running, visibleIdle: false))
+        XCTAssertFalse(tracker.update(status: .idle, visibleIdle: true, defaulted: true))
+        XCTAssertEqual(tracker.currentStatus, .running)
+    }
+
+    /// Entering idle from anything but `running` is a classification, not the end
+    /// of a turn — the hold must not strand a fresh pane at `unknown`.
+    func testDefaultedIdleFromUnknownCommitsImmediately() {
+        let tracker = DebouncedStatusTracker()
+        XCTAssertTrue(tracker.update(status: .idle, visibleIdle: true, defaulted: true))
+        XCTAssertEqual(tracker.currentStatus, .idle)
+    }
+
     func testPendingIdleResetByRunningReobservation() {
         let tracker = DebouncedStatusTracker()
         tracker.pendingIdleConfirmations = 2

--- a/Tests/SuggestionSeenSetTests.swift
+++ b/Tests/SuggestionSeenSetTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import seahelm
+
+final class SuggestionSeenSetTests: XCTestCase {
+    private func order(message: String, options: [String], terminalID: String = "t1",
+                       wt: String = "/wt/x") -> PendingOrder {
+        let action = FirstMateAction(kind: .suggestNextOrder, zone: .red, worktreePath: wt,
+                                     branch: "b", project: "p", terminalID: terminalID,
+                                     message: message, options: options)
+        return PendingOrder(id: PendingOrdersQueue.key(action), action: action)
+    }
+
+    func testFirstSightIsFresh() {
+        var seen = SuggestionSeenSet()
+        XCTAssertEqual(seen.absorb([order(message: "shipped", options: ["test", "commit"])]).count, 1)
+    }
+
+    func testUnchangedCardIsNotFreshAgain() {
+        var seen = SuggestionSeenSet()
+        let card = order(message: "shipped", options: ["test", "commit"])
+        _ = seen.absorb([card])
+        XCTAssertTrue(seen.absorb([card]).isEmpty, "the 10s fallback refresh must not re-pop a card")
+    }
+
+    /// The regression this type exists for: card ids are stable per pane, so the
+    /// second suggestion from one pane reuses the id an id-set comparison keys on.
+    func testSecondSuggestionForSamePaneIsFresh() {
+        var seen = SuggestionSeenSet()
+        let first = order(message: "shipped", options: ["test", "commit"])
+        let second = order(message: "tests pass", options: ["push", "open PR"])
+        _ = seen.absorb([first])
+        XCTAssertEqual(second.id, first.id, "precondition: ids collide per pane")
+        XCTAssertEqual(seen.absorb([second]).count, 1)
+    }
+
+    func testRewrittenSummaryWithSameOptionsIsFresh() {
+        var seen = SuggestionSeenSet()
+        _ = seen.absorb([order(message: "shipped", options: ["test", "commit"])])
+        let reAsked = order(message: "reverted the migration", options: ["test", "commit"])
+        XCTAssertEqual(seen.absorb([reAsked]).count, 1)
+    }
+
+    /// `PendingOrdersQueue.refreshSuggestMessage` upgrades a junk summary to the
+    /// agent's real prose without touching the options — same ask, better text.
+    func testJunkSummaryUpgradeIsNotFresh() {
+        var seen = SuggestionSeenSet()
+        _ = seen.absorb([order(message: "Shell", options: ["test", "commit"])])
+        let upgraded = order(message: "Removed the dead migration path", options: ["test", "commit"])
+        XCTAssertTrue(seen.absorb([upgraded]).isEmpty)
+    }
+
+    func testResolvedCardIsFreshWhenRaisedAgain() {
+        var seen = SuggestionSeenSet()
+        let card = order(message: "shipped", options: ["test", "commit"])
+        _ = seen.absorb([card])
+        _ = seen.absorb([])
+        XCTAssertEqual(seen.absorb([card]).count, 1)
+    }
+
+    func testFreshEntriesAreReturnedNotJustCounted() {
+        var seen = SuggestionSeenSet()
+        let known = order(message: "shipped", options: ["test"], terminalID: "t1", wt: "/wt/a")
+        _ = seen.absorb([known])
+        let other = order(message: "needs review", options: ["review"], terminalID: "t2", wt: "/wt/b")
+        let fresh = seen.absorb([known, other])
+        XCTAssertEqual(fresh.map(\.action.worktreePath), ["/wt/b"],
+                       "callers route by which worktree the new card belongs to")
+    }
+}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		A919319A74BD84AD1A35EF4D /* AgentRegistryIngestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DAB60224D158B5E58C01717 /* AgentRegistryIngestTests.swift */; };
 		A9484F5D905FF14F920838C0 /* OSC133ParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826B5E1EB796AA82415B329F /* OSC133ParserTests.swift */; };
 		A9F68DDF088D5A32BFC14242 /* GhosttyConfigImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F749E954C706D5C69B5BCD0C /* GhosttyConfigImporter.swift */; };
+		AA20697D1C5A53598DEF9CE9 /* SuggestionSeenSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300BF0C990100B9C582BBB82 /* SuggestionSeenSetTests.swift */; };
 		AA44F31E55A3443F4FED6247 /* StatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64961AFD1B97D23C0490E083 /* StatusBarView.swift */; };
 		ACF7082F13C72511EDEBDA61 /* GitDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D0A2190D518447C76BAB37 /* GitDiffTests.swift */; };
 		AD2BB97C703A9CEAA447467C /* ProcessProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE708AEC9451A9A8135976C /* ProcessProbeTests.swift */; };
@@ -519,6 +520,7 @@
 		2D90204521BAE476A8EF340E /* ClaudeHooksSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeHooksSetup.swift; sourceTree = "<group>"; };
 		2DD9055EFF7EFEF4058A1AD0 /* BridgeCommandRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeCommandRouter.swift; sourceTree = "<group>"; };
 		2E2AD81803E67D6EC8F90EA5 /* CursorSessionTitleLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorSessionTitleLookup.swift; sourceTree = "<group>"; };
+		300BF0C990100B9C582BBB82 /* SuggestionSeenSetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionSeenSetTests.swift; sourceTree = "<group>"; };
 		304981CB302BEC6B00289258 /* ManifestEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManifestEngineTests.swift; sourceTree = "<group>"; };
 		30F9565C3156144526A74B08 /* StationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationManager.swift; sourceTree = "<group>"; };
 		32ED7C4B1150BC7F4AA25A2D /* BridgeCardModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeCardModelTests.swift; sourceTree = "<group>"; };
@@ -1404,6 +1406,7 @@
 				69B9E6C47E654692C3AC6D42 /* StatusPublisherThreadTests.swift */,
 				7AD4898C898C52B4C1DDEEC0 /* StopHookResponderTests.swift */,
 				87CF73B862D4CB3AA19021D9 /* SuggestGuidanceWriterTests.swift */,
+				300BF0C990100B9C582BBB82 /* SuggestionSeenSetTests.swift */,
 				BD4237377AB298C49CC68D6D /* SuggestOrderTests.swift */,
 				BF2913334B3D03D7CCD3E80D /* TabCoordinatorTests.swift */,
 				DC183C3A20588D380EF62682 /* TabSelectionTests.swift */,
@@ -1917,6 +1920,7 @@
 				7366EFB1C4C5E0E8A0B31FBA /* StopHookResponderTests.swift in Sources */,
 				AE8C876E082268C163A07A0B /* SuggestGuidanceWriterTests.swift in Sources */,
 				029DC163355449B1C4B3BE23 /* SuggestOrderTests.swift in Sources */,
+				AA20697D1C5A53598DEF9CE9 /* SuggestionSeenSetTests.swift in Sources */,
 				2215E8F6A1F2571870A122F6 /* TabCoordinatorTests.swift in Sources */,
 				65BBAC7799C70383810BFEE3 /* TabSelectionTests.swift in Sources */,
 				B658CA193508F17D6F6BA66D /* TaskProgressParserTests.swift in Sources */,


### PR DESCRIPTION
Traced why "agent finished" banners arrive late, carry stale text, or never
arrive. macOS was never the bottleneck — `usernoted` delivers ~100ms after
submit. Every defect was ours.

## What was wrong

**The completion waited on a round-trip we forced.** A Stop hook answered with
`decision: block` returned early, skipping ingest, so the agent's real
end-of-turn only registered after it had run another full model round-trip to
produce its `::seahelm-suggest::` line — 2.6s to 20.2s, median ~9s, measured
across this repo's own transcripts.

**Then the screen threw it away anyway.** For `session_only` agents (claude,
codex, cursor) the screen is authoritative, and at the instant a turn ends the
TUI still carries a spinner line. Verified live: an `is_completion: true` event
landed while the pane stayed Running and nothing notified.

**Absence of evidence was read as "finished".** No shipped manifest has an idle
rule, so `default_status: idle` only ever means "no running/waiting/error rule
matched this frame" — yet the fallback claimed `visibleIdle`, the flag that
bypasses the debounce hold. One frame of a thinking agent fired a completion
banner mid-turn with a body three minutes stale.

**The cooldown then swallowed the correction.** That early banner burned the 30s
window and the real completion, seconds later, was dropped with no retry.

**Background work was reported as agent status.** A monitor lives as long as the
thing it watches, so a pane parked at an empty prompt was pinned on `running`
for its whole lifetime — and a pane that never leaves running never emits the
edge that notifies.

**Suggestion cards stopped surfacing after the first.** Card ids are stable per
pane, so a second suggestion swapped contents in place and both the island and
the First Mate reveal, comparing id sets, saw nothing new.

## What changed

- The blocked Stop is ingested before the block body is returned.
- A fresh hook `.idle` outranks a scan `.running` for 3s (`hookIdleGrace`),
  symmetric to the leading edge that already existed. Time-boxed, so a stale
  hook idle can never pin a working pane.
- Defaulted statuses are marked as such and held for `defaultedIdleConfirmations`
  (~12s) before they can end a running turn.
- An agent-reported event may override a still-warm scan-derived banner, once
  per window.
- Rules can declare `background_task: true`: they raise `Detection.backgroundBusy`
  on a pass of their own and never decide `state`. `displayStatus` recombines the
  axes for the dashboard only, so a worktree watching CI still draws as busy.
- `SuggestionSeenSet` fingerprints what a card shows instead of its id; the island
  pops for cards the sidebar cannot show; banners no longer stack on an expanded
  island card while frontmost.
- `pane.explain` gained `scan_defaulted`, `hook_idle_fresh` and `background_busy`,
  and reports the line a rule matched instead of the whole region — the
  mis-attribution that sent two rounds of this investigation after an innocent
  rule.

## Verification

1642 unit tests pass. The end-to-end path was confirmed on a live pane: the
completion edge now lands at the moment the answer is written (`Running -> Idle`
on the blocked Stop), the agent's resumed round-trip shows as running again, and
the second Stop collapses into the same cooldown window.

Deliberately **not** changed: the `1 monitor` pattern itself, which was added on
purpose so a watching-CI pane would not read as Idle. Its test was rewritten to
the new contract rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)