### PR TITLE
Announce a completion once, not once per screen settle

### DIFF
--- a/Sources/Status/NotificationManager.swift
+++ b/Sources/Status/NotificationManager.swift
@@ -20,7 +20,16 @@ class NotificationManager: NSObject {
     /// is allowed to correct a scan-derived banner inside the cooldown window.
     enum NotificationSource { case scan, agent }
 
-    private var lastNotified: [String: (at: Date, source: NotificationSource)] = [:]
+    /// What was last announced for a key: when, by whom, and *which turn* it was.
+    /// The turn identity is what stops one completion being announced twice.
+    private struct Delivery {
+        let at: Date
+        let source: NotificationSource
+        /// Identifies the turn being announced — see `turnFingerprint`.
+        let turn: String
+    }
+
+    private var lastNotified: [String: Delivery] = [:]
 
     /// Minimum seconds between delivered notifications for the same key. Injected
     /// from `Config.notifications` at startup.
@@ -149,23 +158,51 @@ class NotificationManager: NSObject {
     /// agent-reported events really are two events, and the cooldown is what keeps
     /// a blocked-then-resumed Stop pair from bannering twice.
     func shouldNotify(cooldownKey: String, oldStatus: AgentStatus, newStatus: AgentStatus,
-                      source: NotificationSource = .scan, now: Date = Date()) -> Bool {
-        Self.shouldNotify(oldStatus: oldStatus, newStatus: newStatus, source: source,
-                          lastDelivery: lastNotified[cooldownKey], cooldown: cooldown, now: now)
+                      source: NotificationSource = .scan, turn: String = "",
+                      now: Date = Date()) -> Bool {
+        let last = lastNotified[cooldownKey]
+        return Self.shouldNotify(
+            oldStatus: oldStatus, newStatus: newStatus, source: source, turn: turn,
+            lastDelivery: last.map { (at: $0.at, source: $0.source, turn: $0.turn) },
+            cooldown: cooldown, now: now)
     }
 
     /// Pure core of the eligibility gate — extracted so the cooldown/override
     /// policy is testable without the shared instance's accumulated deliveries.
+    ///
+    /// A turn is announced at most once. A finished pane keeps moving: Claude Code
+    /// compacts its conversation, a shell it left running paints, a monitor ticks —
+    /// each of those retakes the screen, and when the screen settles the status
+    /// makes another running → idle edge out of the *same* completion. Judged on
+    /// timing alone those repeats look legitimate (minutes apart, well past the
+    /// cooldown), so they were delivered: the same banner, carrying the same
+    /// now-stale text, arriving long after the agent actually finished. Identity,
+    /// not timing, is what tells them apart.
     static func shouldNotify(oldStatus: AgentStatus, newStatus: AgentStatus,
-                             source: NotificationSource,
-                             lastDelivery: (at: Date, source: NotificationSource)?,
+                             source: NotificationSource, turn: String,
+                             lastDelivery: (at: Date, source: NotificationSource, turn: String)?,
                              cooldown: TimeInterval, now: Date) -> Bool {
         guard oldStatus == .running else { return false }
         guard newStatus == .waiting || newStatus == .error || newStatus == .idle else { return false }
-        if let last = lastDelivery, now.timeIntervalSince(last.at) < cooldown {
+        guard let last = lastDelivery else { return true }
+        // Already announced, however long ago. An empty fingerprint identifies
+        // nothing, so it never matches itself.
+        if !turn.isEmpty, turn == last.turn { return false }
+        if now.timeIntervalSince(last.at) < cooldown {
             return source == .agent && last.source == .scan
         }
         return true
+    }
+
+    /// Identifies the turn a notification is about: its outcome plus the words it
+    /// would show. Two edges carrying the same answer to the same prompt are the
+    /// same completion seen twice, whatever the status did in between.
+    static func turnFingerprint(status: AgentStatus, lastAssistantMessage: String,
+                                lastMessage: String, lastUserPrompt: String) -> String {
+        let body = lastAssistantMessage.isEmpty ? lastMessage : lastAssistantMessage
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        return "\(status.rawValue)|\(lastUserPrompt.trimmingCharacters(in: .whitespacesAndNewlines))|\(trimmed)"
     }
 
     /// Whether a pending (delayed) notification for `targetStatus` should still
@@ -482,14 +519,16 @@ class NotificationManager: NSObject {
         // flicker that flips back to running mid-turn).
         latestStatus[key] = newStatus
 
-        guard shouldNotify(cooldownKey: key, oldStatus: oldStatus,
-                           newStatus: newStatus, source: source) else { return }
+        let turn = Self.turnFingerprint(status: newStatus, lastAssistantMessage: lastAssistantMessage,
+                                        lastMessage: lastMessage, lastUserPrompt: lastUserPrompt)
+        guard shouldNotify(cooldownKey: key, oldStatus: oldStatus, newStatus: newStatus,
+                           source: source, turn: turn) else { return }
 
         // The delivery closure captures the fully-formed payload. Invoked either
         // immediately or when the stability timer fires and the status still holds.
         let deliver = { [weak self] in
             guard let self else { return }
-            self.lastNotified[key] = (at: Date(), source: source)
+            self.lastNotified[key] = Delivery(at: Date(), source: source, turn: turn)
             self.deliver(
                 worktreePath: worktreePath,
                 workspaceName: workspaceName,

--- a/Tests/NotificationManagerTests.swift
+++ b/Tests/NotificationManagerTests.swift
@@ -199,11 +199,14 @@ final class NotificationManagerTests: XCTestCase {
 
     private func gate(_ source: NotificationManager.NotificationSource,
                       after last: (at: Date, source: NotificationManager.NotificationSource)?,
-                      elapsed: TimeInterval) -> Bool {
+                      elapsed: TimeInterval,
+                      turn: String = "turn-a", lastTurn: String = "turn-b") -> Bool {
         let now = Date()
-        let previous = last.map { (at: now.addingTimeInterval(-elapsed), source: $0.source) }
+        let previous = last.map {
+            (at: now.addingTimeInterval(-elapsed), source: $0.source, turn: lastTurn)
+        }
         return NotificationManager.shouldNotify(
-            oldStatus: .running, newStatus: .idle, source: source,
+            oldStatus: .running, newStatus: .idle, source: source, turn: turn,
             lastDelivery: previous, cooldown: 30, now: now)
     }
 
@@ -236,5 +239,59 @@ final class NotificationManagerTests: XCTestCase {
 
     func testFirstEverEdgeFires() {
         XCTAssertTrue(gate(.scan, after: nil, elapsed: 0))
+    }
+
+    // MARK: - One announcement per turn
+
+    /// The regression the user actually felt: a banner arriving "minutes late".
+    /// It was not late — it was a second banner for a completion already
+    /// announced. A finished Claude pane keeps painting (conversation
+    /// compaction, a leftover shell), which retakes the screen; when the screen
+    /// settles, the status makes another running → idle edge out of the same
+    /// turn, minutes past the cooldown, carrying the same stale text.
+    func testTheSameTurnIsNeverAnnouncedTwice() {
+        XCTAssertFalse(gate(.scan, after: (at: Date(), source: .agent), elapsed: 300,
+                            turn: "same", lastTurn: "same"))
+    }
+
+    func testANewTurnPastTheCooldownStillFires() {
+        XCTAssertTrue(gate(.scan, after: (at: Date(), source: .agent), elapsed: 300,
+                           turn: "second answer", lastTurn: "first answer"))
+    }
+
+    /// Turn identity outranks the agent-over-scan override too: correcting an
+    /// early banner is worth a second delivery, repeating one is not.
+    func testTheOverrideDoesNotResurrectAnAlreadyAnnouncedTurn() {
+        XCTAssertFalse(gate(.agent, after: (at: Date(), source: .scan), elapsed: 5,
+                            turn: "same", lastTurn: "same"))
+    }
+
+    /// A pane with nothing to say identifies no turn, so it must not match itself
+    /// and mute every later completion.
+    func testAnUnidentifiedTurnNeverMatches() {
+        XCTAssertTrue(gate(.scan, after: (at: Date(), source: .agent), elapsed: 300,
+                           turn: "", lastTurn: ""))
+    }
+
+    func testFingerprintPrefersTheAgentsOwnProse() {
+        let f = NotificationManager.turnFingerprint(
+            status: .idle, lastAssistantMessage: "shipped it",
+            lastMessage: "npm test", lastUserPrompt: "ship")
+        XCTAssertTrue(f.contains("shipped it"))
+        XCTAssertFalse(f.contains("npm test"), "the scanned command line is the weaker signal")
+    }
+
+    /// Same words, different question — still two turns.
+    func testSamePoseToADifferentPromptIsADifferentTurn() {
+        let a = NotificationManager.turnFingerprint(
+            status: .idle, lastAssistantMessage: "Done.", lastMessage: "", lastUserPrompt: "fix the test")
+        let b = NotificationManager.turnFingerprint(
+            status: .idle, lastAssistantMessage: "Done.", lastMessage: "", lastUserPrompt: "now ship it")
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testEmptyPayloadYieldsNoFingerprint() {
+        XCTAssertEqual(NotificationManager.turnFingerprint(
+            status: .idle, lastAssistantMessage: "  ", lastMessage: "", lastUserPrompt: "x"), "")
     }
 }


### PR DESCRIPTION
Reported as "the banner showed up minutes late". It was not late — it was a
second banner for a completion already announced, carrying text that had gone
stale in the meantime. Follow-up to #62.

## What was happening

A finished pane keeps painting. Caught in the act on a live pane:

```
14:53:09 status=Running scan=Running hook=Idle by=screen rule=working_spinner
         evidence: '✢ compacting conversation… (1m 10s)'
```

The turn had ended — the hook said so — while Claude Code compacted its
conversation. That spinner matches `working_spinner`, so the screen retook the
pane as running. When compaction finished and the screen settled, the status
produced another `running -> idle` edge out of the same turn, and that edge
notified.

The pane's event log shows one turn's message flapping through a dozen such
edges. Of 31 entries in the live notification history, **14 were repeats** — six
distinct completions announced two to four times each:

```
06:48:10  Idle  teamclaw  '先说明:`mqtt-auth` …'
06:51:01  Idle  teamclaw  '先说明:`mqtt-auth` …'   <- same turn
06:52:02  Idle  teamclaw  '先说明:`mqtt-auth` …'   <- same turn
```

Judged on timing those look legitimate: minutes apart, long past the cooldown,
from a genuine edge. Only identity separates them.

## What changed

`turnFingerprint` names the turn by its outcome, the agent's own final prose,
and the prompt it answered. A turn matching the last delivered one is dropped,
however long ago that was.

The check sits ahead of the cooldown, so not even the agent-over-scan override
from #62 can resurrect an already-announced turn — correcting an early banner
earns a second delivery, repeating one does not. An empty fingerprint identifies
nothing and never matches itself, so a pane with nothing to say cannot mute its
own future completions.

The status flapping is deliberately left alone: you cannot type at a pane that
is compacting, so `running` is the honest answer and the dashboard should keep
showing it. What was wrong was reading each settle as a fresh completion.

## Verification

1649 unit tests pass, including seven new ones covering the repeat itself, a
genuinely new turn past the cooldown, the override not resurrecting an announced
turn, and the same prose answering a different prompt still counting as two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)