### PR TITLE
fix: scrub NO_COLOR from the app environment

### DIFF
--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -16,13 +16,22 @@ import AppKit
 // is left alone — it names a binary, not a session, and a pane may legitimately
 // want the same one.
 //
+// NO_COLOR is not a session identity, but it leaks by the same route and does
+// more damage, because it outlives the launch that carried it: a pane's
+// environment is fixed when its zmx session is created, and re-attaching never
+// re-execs the agent. So one relaunch from a shell that happened to have
+// NO_COLOR set leaves those panes rendering monochrome forever, surviving every
+// later app restart. A pane is always a real terminal, so the launching shell's
+// opinion about color never applies to it.
+//
 // Scrub before anything can spawn a child.
-let leakedSessionEnv = [
+let leakedEnv = [
     "ZMX_SESSION", "SEAHELM_ENV", "SEAHELM_SOCKET_PATH", "SEAHELM_PANE_ID",
     "CLAUDE_CODE_CHILD_SESSION", "CLAUDE_CODE_SESSION_ID", "CLAUDE_CODE_ENTRYPOINT",
     "CLAUDE_CODE_MESSAGING_SOCKET", "CLAUDE_CODE_MESSAGING_TOKEN",
+    "NO_COLOR",
 ]
-for leaked in leakedSessionEnv {
+for leaked in leakedEnv {
     unsetenv(leaked)
 }
 


### PR DESCRIPTION
## Symptom

Claude Code sometimes renders entirely monochrome in a pane — logo, spinner and progress bars all grey, layout otherwise intact. Seahelm's own sidebar and status bar keep their colour, because those are drawn by AppKit and don't go through the terminal.

## Cause

`NO_COLOR=1` had leaked into those panes' `claude` processes. Two panes on the same machine differed by exactly that one variable:

```
monochrome pane (sre-monitoring)     coloured pane (teamclaw-1)
  TERM=xterm-ghostty                   TERM=xterm-ghostty
  COLORTERM=truecolor                  COLORTERM=truecolor
  NO_COLOR=1                           (absent)
  TERMINFO=.../DerivedData/...         TERMINFO=.../.build/...
```

Claude Code honours the `NO_COLOR` convention and drops all ANSI colour.

## Why it looked intermittent

A pane's environment is fixed when its zmx session is created, and re-attaching never re-execs the agent. One relaunch of Seahelm from a shell that happened to have `NO_COLOR` set left every pane created by that instance monochrome *forever*, surviving each later app restart — the offending value lives on in the long-running session, not in the app. The differing `TERMINFO` paths above confirm it: the affected sessions were created by an Xcode-launched (DerivedData) instance, the healthy ones by the `.build` instance.

Ruled out as sources: the user's shell profiles, launchd (`launchctl getenv NO_COLOR`), anything in this repo, and the `rtk` command proxy.

## Fix

`main.swift` already scrubs environment that leaks in when the app is relaunched from inside a pane (`ZMX_SESSION`, `SEAHELM_*`, `CLAUDE_CODE_*`). `NO_COLOR` is not a session identity, but it leaks by the same route and does more damage by outliving the launch that carried it — so it joins the list. A pane is always a real terminal; the launching shell's opinion about colour never applies to it.

`leakedSessionEnv` is renamed to `leakedEnv` to match (two references, same file).

## Verification

Launched the app with `NO_COLOR=1` deliberately set. Every child it spawned came up without it:

```
app itself (78252)        NO_COLOR=1     <- ps reads the stack; expected false negative
its 10 spawned children   NO_COLOR=0     <- all clean
```

Worth recording: `ps eww` reads the exec-time environment block off the process stack, while `unsetenv()` only rewrites the heap `environ` that children inherit. So the scrubbing process itself always still shows the variable — a child is the only honest place to check.

## Not covered by this change

Already-affected zmx sessions stay monochrome; their `claude` processes have the variable baked in and no app restart reaches them. Recovering one means `unset NO_COLOR && claude -c` in that pane, which interrupts whatever agent is running there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)