### PR TITLE
fix: control socket self-heal + agent resume-after-restart fixes

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -310,7 +310,13 @@ class MainWindowController: NSWindowController, MailCommandContext {
         let iso = Self.activityISO8601.string(from: date)
         config.worktreeLastActivityAt[path] = iso
         tabCoordinator.config.worktreeLastActivityAt[path] = iso
-        config.save()
+        // This fires on nearly every status change across every worktree, so a
+        // raw `config.save()` here — Config is a value type, and `config` is a
+        // snapshot from launch — reliably clobbered fields owned elsewhere
+        // (agentSessions chief among them: a resume ref recorded via
+        // TerminalCoordinator moments earlier never survived to disk). Route
+        // through the shared sync instead of saving this stale copy directly.
+        saveConfig()
     }
 
     convenience init() {
@@ -391,6 +397,7 @@ class MainWindowController: NSWindowController, MailCommandContext {
         config.worktreeStartedAt = tabCoordinator.config.worktreeStartedAt
         config.selectedWorktreePath = tabCoordinator.config.selectedWorktreePath
         config.splitLayouts = terminalCoordinator.config.splitLayouts
+        config.agentSessions = terminalCoordinator.config.agentSessions
         // Chrome layout is owned here — push into TabCoordinator so its saves
         // don't clobber sidebar_collapsed / sidebar_active_pane with defaults.
         tabCoordinator.config.sidebarWidth = config.sidebarWidth
@@ -2667,7 +2674,7 @@ extension MainWindowController: SettingsDelegate {
                 if self.config.gmailMail == nil {
                     self.config.gmailMail = GmailMailConfig(accountEmail: email,
                                                             inboundAlias: GmailMailConfig(accountEmail: email).derivedInboundAlias)
-                    self.config.save()
+                    self.saveConfig()
                 }
             case .failure(let error):
                 NSLog("[Gmail] OAuth failed: %@", error.localizedDescription)

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -2461,6 +2461,24 @@ extension MainWindowController {
         applyChromeState(animated: true)
     }
 
+    /// Non-nil only for the states the app cannot resolve by itself —
+    /// `ControlSocketServer` silently reclaims a vanished or stale socket path
+    /// on its own, and telling the user to restart for something already being
+    /// fixed would train them to ignore this.
+    fileprivate func controlChannelWarning() -> String? {
+        guard let server = tabCoordinator.terminalCoordinator?.controlSocketServer else {
+            return nil  // never started (e.g. the screenshot instance stands down)
+        }
+        switch server.state {
+        case .listening:
+            return nil
+        case .standby:
+            return "Another Seahelm instance owns the control channel. Agent hooks and the seahelm CLI are inactive in this window — quit the other instance to take it back."
+        case .stopped:
+            return "The control channel could not start. Agent hooks and the seahelm CLI are unavailable — restarting Seahelm usually clears it."
+        }
+    }
+
     fileprivate func refreshIsland() {
         guard config.islandEnabled else { return }
         let model = islandController.model
@@ -2514,6 +2532,14 @@ extension MainWindowController {
         // even when nothing changed.
         let orders = IslandModel.newestSuggestions(from: tabCoordinator.pendingOrders.all())
         if model.orders != orders { model.orders = orders }
+
+        // A dead control channel is invisible everywhere else: the hooks fail
+        // their `[ -S ]` guard and drop events without a word, so the island
+        // just goes quiet — indistinguishable from a fleet with nothing to say.
+        let channelWarning = controlChannelWarning()
+        if model.controlChannelWarning != channelWarning {
+            model.controlChannelWarning = channelWarning
+        }
 
         // A new suggestion is actionable — expand so the card is visible
         // without hovering. Nothing else opens the island: status changes are

--- a/Sources/Core/ControlSocketServer.swift
+++ b/Sources/Core/ControlSocketServer.swift
@@ -8,6 +8,19 @@ import Foundation
 /// The socket lives at ~/.config/seahelm/seahelm.sock with 0600 permissions —
 /// filesystem-scoped to the user, unlike the TCP webhook which any local
 /// process can reach.
+
+/// What the control channel is doing right now.
+///
+/// `standby` is the one state the app cannot resolve on its own: another live
+/// instance owns the socket path, and stealing it back would only strand that
+/// instance in turn — two apps trading `unlink()` forever. Everything else is
+/// either healthy or self-healing, so `standby` is what the island surfaces.
+enum ControlSocketState: Equatable {
+    case stopped
+    case listening
+    case standby
+}
+
 final class ControlSocketServer {
     private let router: ControlRouter
     private let path: String
@@ -18,6 +31,53 @@ final class ControlSocketServer {
     private var boundIdentity: (dev: dev_t, ino: ino_t)?
     private let acceptQueue = DispatchQueue(label: "seahelm.control-socket.accept")
 
+    /// Guards `_state` and `_generation`, both read from the accept loop and
+    /// written from the health timer.
+    private let stateLock = NSLock()
+    private var _state: ControlSocketState = .stopped
+    /// Bumped whenever we drop a listener. The accept loop owns its fd and
+    /// closes it when its generation goes stale, so a rebind can never race a
+    /// blocked `accept()` into the fd number its replacement just claimed.
+    private var _generation = 0
+
+    private let healthQueue = DispatchQueue(label: "seahelm.control-socket.health")
+    private var healthTimer: DispatchSourceTimer?
+
+    /// How often to confirm the socket path still names our listener. The
+    /// whole hook surface dies with that path and every client fails silently
+    /// (see `healthCheck()`), so an outage wants to be seconds long, not
+    /// "until somebody notices the island went quiet".
+    private let healthCheckInterval: TimeInterval
+    static let defaultHealthCheckInterval: TimeInterval = 10
+    /// Accept-loop poll slice — also the worst-case delay before a dropped
+    /// listener's thread notices and exits.
+    private static let acceptPollMs: Int32 = 500
+
+    var state: ControlSocketState {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _state
+    }
+
+    private func setState(_ new: ControlSocketState) {
+        stateLock.lock(); _state = new; stateLock.unlock()
+    }
+
+    private func bumpGeneration() -> Int {
+        stateLock.lock(); defer { stateLock.unlock() }
+        _generation += 1
+        return _generation
+    }
+
+    private func currentGeneration() -> Int {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _generation
+    }
+
+    private func isCurrent(_ generation: Int) -> Bool {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _generation == generation
+    }
+
     static func defaultSocketPath() -> String {
         let dir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/seahelm", isDirectory: true)
@@ -25,73 +85,199 @@ final class ControlSocketServer {
         return dir.appendingPathComponent("seahelm.sock").path
     }
 
-    init(router: ControlRouter, path: String = ControlSocketServer.defaultSocketPath()) {
+    init(router: ControlRouter,
+         path: String = ControlSocketServer.defaultSocketPath(),
+         healthCheckInterval: TimeInterval = ControlSocketServer.defaultHealthCheckInterval) {
         self.router = router
         self.path = path
+        self.healthCheckInterval = healthCheckInterval
     }
 
     var socketPath: String { path }
 
     func start() {
-        guard listenFD < 0 else { return }
-        // sun_path is bounded (~104 bytes); refuse rather than truncate.
+        // sun_path is bounded (~104 bytes); refuse rather than truncate. This
+        // is the one failure with no retry — a too-long path never gets shorter.
         guard path.utf8.count < 104 else {
             NSLog("[ControlSocket] path too long: \(path)"); return
+        }
+        // Every mutation of the listener runs on healthQueue so the periodic
+        // check can never interleave with start()/stop().
+        healthQueue.sync { attemptBind() }
+        startHealthChecks()
+    }
+
+    func stop() {
+        healthTimer?.cancel()
+        healthTimer = nil
+        healthQueue.sync {
+            dropListener()
+            // Only remove the socket file if it is still the one we bound. A
+            // newer instance's bind unlinks this path and rebinds its own
+            // socket; a blind unlink here would delete *its* live socket,
+            // leaving it bound to an fd that no client can reach (hooks then
+            // fail their `[ -S ]` guard and silently drop every event).
+            if let mine = boundIdentity {
+                var st = stat()
+                if stat(path, &st) == 0, st.st_dev == mine.dev, st.st_ino == mine.ino {
+                    unlink(path)
+                }
+            }
+            boundIdentity = nil
+            setState(.stopped)
+        }
+    }
+
+    // MARK: - Binding
+
+    /// One bind attempt. Ends at `.listening` on success, `.standby` when a
+    /// live instance already owns the path, `.stopped` when the OS refused us.
+    /// Must run on `healthQueue`.
+    private func attemptBind() {
+        guard listenFD < 0 else { return }
+
+        // Never unlink a socket someone is still listening on. This used to
+        // clear the path unconditionally, which let a second instance take the
+        // live app's socket without a word: the first stayed bound to an
+        // unlinked inode no client could reach, and every hook fell through its
+        // `[ -S ]` guard in silence. Standing down is the honest outcome —
+        // stealing it back would only strand the other instance in turn.
+        if Self.hasLiveListener(at: path) {
+            if state != .standby {
+                NSLog("[ControlSocket] \(path) belongs to another live instance — standing by")
+            }
+            setState(.standby)
+            return
         }
         unlink(path)  // clear a stale socket from a previous run
 
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else { NSLog("[ControlSocket] socket() failed"); return }
-
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        _ = withUnsafeMutablePointer(to: &addr.sun_path.0) { dst in
-            path.withCString { src in strcpy(dst, src) }
+        guard fd >= 0 else {
+            NSLog("[ControlSocket] socket() failed"); setState(.stopped); return
         }
+
+        var addr = Self.address(for: path)
         let len = socklen_t(MemoryLayout<sockaddr_un>.size)
         let bindResult = withUnsafePointer(to: &addr) {
             $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { bind(fd, $0, len) }
         }
         guard bindResult == 0 else {
-            NSLog("[ControlSocket] bind() failed: \(errno)"); close(fd); return
+            NSLog("[ControlSocket] bind() failed: \(errno)"); close(fd); setState(.stopped); return
         }
         chmod(path, 0o600)
         var st = stat()
         boundIdentity = (stat(path, &st) == 0) ? (st.st_dev, st.st_ino) : nil
         guard listen(fd, 8) == 0 else {
-            NSLog("[ControlSocket] listen() failed: \(errno)"); close(fd); return
+            NSLog("[ControlSocket] listen() failed: \(errno)"); close(fd); setState(.stopped); return
         }
 
         listenFD = fd
         running = true
+        setState(.listening)
         NSLog("[ControlSocket] listening at \(path)")
-        acceptQueue.async { [weak self] in self?.acceptLoop() }
+        let generation = currentGeneration()
+        acceptQueue.async { [weak self] in self?.acceptLoop(fd: fd, generation: generation) }
     }
 
-    func stop() {
+    /// Let go of the current listener without touching the filesystem: bump the
+    /// generation so its thread closes the fd and exits on its own. Deliberately
+    /// does not `close()` here — the fd number must stay claimed until its owner
+    /// is gone, or a rebind could hand the same number to a thread still parked
+    /// in `accept()`. Must run on `healthQueue`.
+    private func dropListener() {
         running = false
-        if listenFD >= 0 { close(listenFD); listenFD = -1 }
-        // Only remove the socket file if it is still the one we bound. A newer
-        // instance's start() unlinks this path and rebinds its own socket; a
-        // blind unlink here would delete *its* live socket, leaving it bound to
-        // an fd that no client can reach (hooks then fail their `[ -S ]` guard
-        // and silently drop every event).
-        if let mine = boundIdentity {
-            var st = stat()
-            if stat(path, &st) == 0, st.st_dev == mine.dev, st.st_ino == mine.ino {
-                unlink(path)
-            }
-        }
-        boundIdentity = nil
+        _ = bumpGeneration()
+        listenFD = -1
     }
 
-    private func acceptLoop() {
-        while running {
-            let clientFD = accept(listenFD, nil, nil)
+    /// True when something is accepting connections on `path` right now. A
+    /// leftover file from a crashed instance refuses the connect, which is
+    /// exactly what makes it safe to unlink.
+    private static func hasLiveListener(at path: String) -> Bool {
+        var st = stat()
+        guard stat(path, &st) == 0, (st.st_mode & S_IFMT) == S_IFSOCK else { return false }
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { return false }
+        defer { close(fd) }
+        var addr = address(for: path)
+        let len = socklen_t(MemoryLayout<sockaddr_un>.size)
+        return withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { connect(fd, $0, len) == 0 }
+        }
+    }
+
+    private static func address(for path: String) -> sockaddr_un {
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        _ = withUnsafeMutablePointer(to: &addr.sun_path.0) { dst in
+            path.withCString { src in strcpy(dst, src) }
+        }
+        return addr
+    }
+
+    // MARK: - Health
+
+    private func startHealthChecks() {
+        guard healthTimer == nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: healthQueue)
+        timer.schedule(deadline: .now() + healthCheckInterval,
+                       repeating: healthCheckInterval)
+        timer.setEventHandler { [weak self] in self?.healthCheck() }
+        healthTimer = timer
+        timer.resume()
+    }
+
+    /// The socket file can vanish out from under a live listener: another
+    /// instance's bind unlinks the path, and when *that* instance exits it takes
+    /// the path with it. Our fd stays valid and the accept loop keeps spinning,
+    /// but there is no longer a name for anyone to connect to — every hook fails
+    /// its `[ -S ]` guard and drops the event in silence, so nothing in this
+    /// process ever learns the channel died. Hence the poll.
+    private func healthCheck() {
+        switch state {
+        case .listening:
+            guard let mine = boundIdentity else { return }
+            var st = stat()
+            if stat(path, &st) != 0 {
+                // Nobody owns the path now, so it is ours to take back.
+                NSLog("[ControlSocket] socket path vanished — rebinding")
+            } else if st.st_dev != mine.dev || st.st_ino != mine.ino {
+                // Somebody rebound it. attemptBind() decides whether that
+                // somebody is alive (stand by) or a leftover file (reclaim).
+                NSLog("[ControlSocket] socket path was replaced — re-checking ownership")
+            } else {
+                return  // healthy: the path still names our listener
+            }
+            dropListener()
+            boundIdentity = nil
+            attemptBind()
+        case .standby, .stopped:
+            // The owner may have exited, or whatever refused the bind last time
+            // may have cleared.
+            attemptBind()
+        }
+    }
+
+    private func acceptLoop(fd: Int32, generation: Int) {
+        // This loop owns the fd for its whole life, including the close.
+        defer { close(fd) }
+        var pfd = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+        while running, isCurrent(generation) {
+            pfd.revents = 0
+            // Poll rather than block in accept(): a dropped listener has to be
+            // able to notice its generation went stale and let go of the fd.
+            let ready = poll(&pfd, 1, Self.acceptPollMs)
+            if ready < 0 {
+                if errno != EINTR { usleep(10_000) }
+                continue
+            }
+            guard ready > 0 else { continue }  // timeout — re-check the guards
+            let clientFD = accept(fd, nil, nil)
             if clientFD < 0 {
                 if running { usleep(10_000) }
                 continue
             }
+            guard running, isCurrent(generation) else { close(clientFD); return }
             Thread.detachNewThread { [weak self] in self?.handleConnection(clientFD) }
         }
     }

--- a/Sources/Core/OpenCodePluginInstaller.swift
+++ b/Sources/Core/OpenCodePluginInstaller.swift
@@ -26,11 +26,14 @@ enum OpenCodePluginInstaller {
     /// ignored, with no error to notice.
     static func pluginContents() -> String {
         return """
-        \(versionMarker) v2 — managed by seahelm. Do not edit; it is overwritten on launch.
+        \(versionMarker) v3 — managed by seahelm. Do not edit; it is overwritten on launch.
         //
         // Registers a `seahelm_suggest` tool that reports next-step options to
         // seahelm's control socket, where they render as clickable buttons, and
         // mirrors opencode's native `question` tool into a seahelm question card.
+        // Also reports session lifecycle (real opencode `sessionID`, not just
+        // seahelm's pane id) so seahelm can resume this exact opencode session
+        // (`opencode resume <id>`) if its zmx session is ever lost and recreated.
         //
         // The @opencode-ai/plugin import needs no setup: opencode writes its own
         // ~/.config/opencode/package.json pinning the package to its version and
@@ -45,9 +48,18 @@ enum OpenCodePluginInstaller {
         const PANE = process.env.SEAHELM_PANE_ID ?? process.env.ZMX_SESSION ?? ""
 
         export const SeahelmSuggest = async ({ $, directory }) => {
+          // Sessions opencode has told us are subagents (Task-tool children), via
+          // their `parentID` on session.created. `session.idle` carries only a bare
+          // sessionID, so this is the one place we can catch them before they'd
+          // otherwise read as the main pane's agent going idle.
+          const subagentSessions = new Set()
+
           // Send a webhook-shaped payload over the control socket's `hook` method.
           // Mimics Claude's event shape so the existing HookDecoder path applies.
-          const send = async (event, data) => {
+          // `sessionId` is opencode's own session id when known (the real resume
+          // handle); PANE is only seahelm's pane name and never means anything to
+          // `opencode resume`, so it's strictly a fallback for status bookkeeping.
+          const send = async (event, data, sessionId) => {
             if (!PANE) return
             const req = JSON.stringify({
               id: "opencode-question",
@@ -55,7 +67,7 @@ enum OpenCodePluginInstaller {
               params: {
                 source: "opencode",
                 event,
-                session_id: PANE,
+                session_id: sessionId || PANE,
                 seahelm_pane_id: PANE,
                 cwd: directory ?? "",
                 data,
@@ -65,6 +77,22 @@ enum OpenCodePluginInstaller {
           }
 
           return {
+            // Session lifecycle, independent of whether the question tool ever
+            // fires — the only reliable place to learn opencode's real sessionID.
+            event: async ({ event }) => {
+              const id = event.properties?.sessionID
+              if (!id) return
+              if (event.type === "session.created") {
+                if (event.properties?.info?.parentID) {
+                  subagentSessions.add(id)
+                  return
+                }
+                await send("session_start", {}, id)
+              } else if (event.type === "session.idle") {
+                if (subagentSessions.has(id)) return
+                await send("agent_stop", {}, id)
+              }
+            },
             // opencode's native question tool blocks the agent on a choice, like
             // Claude's AskUserQuestion. Forward it as that event so seahelm shows
             // the same tappable card. Multi-select questions are skipped entirely:
@@ -77,13 +105,13 @@ enum OpenCodePluginInstaller {
               await send("tool_use_start", {
                 tool_name: "AskUserQuestion",
                 tool_input: { questions },
-              })
+              }, input.sessionID)
             },
             // The dialog is gone once the tool returns (answered in the TUI or via
             // a card tap) — a tool_use_end lets seahelm clear a stale card.
             "tool.execute.after": async (input) => {
               if (input.tool !== "question") return
-              await send("tool_use_end", { tool_name: "AskUserQuestion" })
+              await send("tool_use_end", { tool_name: "AskUserQuestion" }, input.sessionID)
             },
             tool: {
               seahelm_suggest: tool({

--- a/Sources/Core/PiExtensionInstaller.swift
+++ b/Sources/Core/PiExtensionInstaller.swift
@@ -23,7 +23,7 @@ enum PiExtensionInstaller {
 
     static func extensionContents() -> String {
         return """
-        \(versionMarker) v1 — managed by seahelm. Do not edit; it is overwritten on launch.
+        \(versionMarker) v2 — managed by seahelm. Do not edit; it is overwritten on launch.
         //
         // Reports Pi agent lifecycle to seahelm's control socket so a Pi pane shows
         // precise running/idle status. Fire-and-forget: it never blocks or fails the
@@ -36,8 +36,20 @@ enum PiExtensionInstaller {
         // value for panes created before that export existed.
         const PANE = process.env.SEAHELM_PANE_ID || process.env.ZMX_SESSION || ""
 
-        function send(event, data) {
+        // `ctx` is Pi's per-event SessionManager handle. Its own session id/file are
+        // Pi's real resume handle (`pi --session <id>`) — PANE is only seahelm's pane
+        // name, not a Pi session Pi itself would recognize, so a resume built from it
+        // would silently fail to reattach the conversation.
+        function send(event, data, ctx) {
           if (!PANE) return
+          let sessionId = PANE
+          let sessionPath
+          try {
+            if (ctx && ctx.sessionManager) {
+              sessionId = ctx.sessionManager.getSessionId?.() || PANE
+              sessionPath = ctx.sessionManager.getSessionFile?.()
+            }
+          } catch {}
           let line
           try {
             line = JSON.stringify({
@@ -46,7 +58,8 @@ enum PiExtensionInstaller {
               params: {
                 source: "pi",
                 event,
-                session_id: PANE,
+                session_id: sessionId,
+                session_path: sessionPath,
                 seahelm_pane_id: PANE,
                 cwd: process.cwd(),
                 data: data || {},
@@ -65,14 +78,14 @@ enum PiExtensionInstaller {
 
         export default function seahelm(pi) {
           // The agent started working on the user's message → running.
-          pi.on("agent_start", () => send("user_prompt", { message: "Working" }))
+          pi.on("agent_start", (_e, ctx) => send("user_prompt", { message: "Working" }, ctx))
           // Tool calls keep the pane running and add activity detail.
-          pi.on("tool_execution_start", (e) =>
-            send("tool_use_start", { tool_name: (e && e.toolName) || "tool", tool_input: e && e.args }))
-          pi.on("tool_execution_end", (e) =>
-            send((e && e.isError) ? "tool_use_failed" : "tool_use_end", { tool_name: (e && e.toolName) || "tool" }))
+          pi.on("tool_execution_start", (e, ctx) =>
+            send("tool_use_start", { tool_name: (e && e.toolName) || "tool", tool_input: e && e.args }, ctx))
+          pi.on("tool_execution_end", (e, ctx) =>
+            send((e && e.isError) ? "tool_use_failed" : "tool_use_end", { tool_name: (e && e.toolName) || "tool" }, ctx))
           // Fully settled — no retry, compaction, or queued continuation → idle.
-          pi.on("agent_settled", () => send("agent_stop", {}))
+          pi.on("agent_settled", (_e, ctx) => send("agent_stop", {}, ctx))
         }
         """
     }

--- a/Sources/Core/SessionManager.swift
+++ b/Sources/Core/SessionManager.swift
@@ -323,19 +323,23 @@ enum SessionManager {
         name: String,
         cwd: String,
         agentCommandLine: String,
-        shell: String
+        shell: String,
+        terminfoPath: String? = TerminalEnvironment.bundledTerminfoPath()
     ) -> [[String]] {
         switch backend {
         case "zmx":
             // `zmx run` types the command into its own persistent interactive
             // shell (and appends a ZMX_TASK_COMPLETED marker), so the session
             // survives the agent exiting on its own — no `exec "$0"` trick
-            // needed. Wrap in a login shell that cd's and `clear`s before the
-            // agent renders. That inner `cd` only affects the nested shell; the
-            // outer session shell's cwd is set separately by spawning `zmx` with
-            // `Process.currentDirectoryURL = cwd` (see `createDetachedSession`),
-            // so exiting the agent lands you back in the worktree — not in
-            // whatever directory Seahelm itself was launched from.
+            // needed. Wrap in a login shell that cd's and clears the screen
+            // before the agent renders — `zmx run` *types* this whole command
+            // line into the session's interactive shell, so without the clear
+            // the agent's TUI comes up underneath the echoed command plus the
+            // login shell's own startup noise. That inner `cd` only affects the
+            // nested shell; the outer session shell's cwd is set separately by
+            // spawning `zmx` with `Process.currentDirectoryURL = cwd` (see
+            // `createDetachedSession`), so exiting the agent lands you back in
+            // the worktree — not in whatever directory Seahelm was launched from.
             //
             // Export the control-socket context first so the agent (and any tool
             // it spawns, e.g. seahelm-suggest) can reach the multiplexer socket
@@ -345,8 +349,15 @@ enum SessionManager {
             // its own pane across app restarts (the control API resolves it).
             let exports = "export SEAHELM_ENV=1 SEAHELM_SOCKET_PATH=\(ShellEscape.singleQuote(socketPath))"
                 + " SEAHELM_PANE_ID=\(ShellEscape.singleQuote(name))"
-            let inner = "\(exports) && cd \(ShellEscape.singleQuote(cwd)) && clear && \(agentCommandLine)"
-            return [[ZmxLocator.executable(), "run", name, shell, "-lic", inner]]
+            let inner = "\(exports) && cd \(ShellEscape.singleQuote(cwd))"
+                + " && \(TerminalEnvironment.clearScreenCommand) && \(agentCommandLine)"
+            // Prefixed as `env` assignments rather than exported inside `inner`
+            // so the *session* PTY carries them: the shell zmx spawns, the rc
+            // files it sources, and the agent all see the same terminal a pane
+            // opened through Ghostty would have had. `runSync` execs through
+            // /usr/bin/env, so these ride along as plain argv.
+            let termEnv = TerminalEnvironment.envAssignments(terminfoPath: terminfoPath)
+            return [termEnv + [ZmxLocator.executable(), "run", name, shell, "-lic", inner]]
         default:
             return []
         }

--- a/Sources/Core/TerminalEnvironment.swift
+++ b/Sources/Core/TerminalEnvironment.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// The `TERM`/`TERMINFO` pair libghostty injects into every PTY it spawns.
+///
+/// Panes opened through a Ghostty surface get this for free, which is why the
+/// gap below only ever shows up in installed builds. The detached launch path
+/// (`SessionManager.createDetachedSession`) spawns `zmx run` straight from the
+/// app process, bypassing Ghostty entirely — so it inherits whatever launched
+/// Seahelm. From a terminal that is a full environment; from Finder/launchd it
+/// is `PATH`, `HOME`, `USER`, `SHELL` and little else, with **no `TERM` at
+/// all**. Everything downstream that consults terminfo then fails: first the
+/// screen clear (which used to abort the whole `&&` chain before the agent was
+/// ever exec'd), then the agent's own TUI.
+enum TerminalEnvironment {
+    /// What Ghostty sets. Resolvable only against the bundled database below.
+    static let ghosttyTerm = "xterm-ghostty"
+
+    /// Always present in /usr/share/terminfo — the fallback for a bundle whose
+    /// mirrored database is missing, where `xterm-ghostty` would not resolve.
+    static let fallbackTerm = "xterm-256color"
+
+    /// Directory holding the bundled terminfo database, if it shipped.
+    /// `project.yml` mirrors ghostty's copy to `Contents/Resources/terminfo`
+    /// precisely so `xterm-ghostty` resolves without Ghostty.app installed.
+    static func bundledTerminfoPath() -> String? {
+        guard let url = Bundle.main.resourceURL?
+            .appendingPathComponent("terminfo", isDirectory: true),
+            FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return url.path
+    }
+
+    /// `KEY=value` assignments to hand to `/usr/bin/env` ahead of a command, so
+    /// the whole PTY session — session shell, its rc files, and the agent —
+    /// sees the same terminal the attach path would have given it. Pure: the
+    /// caller supplies the database location.
+    static func envAssignments(terminfoPath: String?) -> [String] {
+        guard let terminfoPath else { return ["TERM=\(fallbackTerm)"] }
+        return ["TERM=\(ghosttyTerm)", "TERMINFO=\(terminfoPath)"]
+    }
+
+    /// Clear the screen (and scrollback) without consulting terminfo.
+    ///
+    /// `clear` reads the terminfo database and exits non-zero when it cannot,
+    /// which made it a single point of failure in the middle of an `&&` chain.
+    /// The escapes are unconditional: erase display, erase scrollback, home.
+    static let clearScreenCommand = #"printf '\033[2J\033[3J\033[H'"#
+}

--- a/Sources/UI/Island/ClosedPillView.swift
+++ b/Sources/UI/Island/ClosedPillView.swift
@@ -30,6 +30,7 @@ struct ClosedPillView: View {
         .animation(.timingCurve(0.4, 0, 0.2, 1, duration: 0.45), value: model.orders.count)
         .animation(.timingCurve(0.4, 0, 0.2, 1, duration: 0.45), value: model.rows)
         .animation(.easeInOut(duration: 0.3), value: model.pillUsage)
+        .animation(.easeInOut(duration: 0.3), value: model.controlChannelWarning)
         .onAppear { updatePulse() }
         .onChange(of: pulseTiles) { updatePulse() }
     }
@@ -51,7 +52,23 @@ struct ClosedPillView: View {
     /// wing — status changes go to Notification Center.
     @ViewBuilder
     private var leftWing: some View {
-        if model.orders.isEmpty, let usage = model.pillUsage {
+        if model.controlChannelWarning != nil {
+            // Outranks both quota and pending suggestions: with the control
+            // channel down no new suggestion can arrive, so a count here would
+            // be a stale number sitting exactly where the problem belongs.
+            HStack(spacing: 5) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.orange)
+                Text("CTRL")
+                    .font(.system(size: 10, weight: .bold, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.9))
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(Color.orange.opacity(0.22)))
+            .transition(.opacity.combined(with: .move(edge: .leading)))
+        } else if model.orders.isEmpty, let usage = model.pillUsage {
             UsageReadoutView(logoName: usage.logoName, segments: [usage.segment])
                 // Keyed to the window so a rotation step crossfades instead of
                 // mutating the text in place.

--- a/Sources/UI/Island/IslandModel.swift
+++ b/Sources/UI/Island/IslandModel.swift
@@ -68,6 +68,14 @@ final class IslandModel {
     /// only attention signal — status notifications go to Notification Center
     /// and are not mirrored here.
     var orders: [PendingOrder] = []
+    /// Set when the control channel is down in a way the app cannot fix itself
+    /// — practically always a second live instance owning the socket path.
+    ///
+    /// It earns island space because it is invisible everywhere else: agent
+    /// hooks fail their `[ -S ]` guard and drop events without a word, so the
+    /// island simply goes quiet and looks idle. A quiet island is exactly what
+    /// a healthy one looks like, which is why this has to be said out loud.
+    var controlChannelWarning: String?
 
     static func newestSuggestions(from orders: [PendingOrder]) -> [PendingOrder] {
         Array(orders.lazy

--- a/Sources/UI/Island/OpenedSurfaceView.swift
+++ b/Sources/UI/Island/OpenedSurfaceView.swift
@@ -21,6 +21,9 @@ struct OpenedSurfaceView: View {
 
             VStack(alignment: .leading, spacing: 10) {
                 header
+                if let warning = model.controlChannelWarning {
+                    controlChannelBanner(warning)
+                }
                 middleSection
                 commandBar
             }
@@ -32,6 +35,34 @@ struct OpenedSurfaceView: View {
         // animates instead of hard-swapping.
         .animation(.spring(response: 0.35, dampingFraction: 0.85), value: model.orders)
         .animation(.spring(response: 0.35, dampingFraction: 0.85), value: model.rows)
+        .animation(.spring(response: 0.35, dampingFraction: 0.85), value: model.controlChannelWarning)
+    }
+
+    /// The control channel is the island's supply line. With it down, the rows
+    /// below are the last thing seahelm heard rather than the current state —
+    /// say so, instead of letting a stale-but-plausible list stand.
+    private func controlChannelBanner(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.orange)
+            Text(text)
+                .font(.system(size: 11))
+                .foregroundStyle(.white.opacity(0.85))
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.orange.opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.orange.opacity(0.35), lineWidth: 1)
+                )
+        )
+        .transition(.opacity.combined(with: .move(edge: .top)))
     }
 
     /// Auto-height list area: renders at natural height, and past the cap it

--- a/Tests/ControlSocketServerTests.swift
+++ b/Tests/ControlSocketServerTests.swift
@@ -107,17 +107,24 @@ final class ControlSocketServerTests: XCTestCase {
         XCTAssertEqual(ev?["seq"] as? Int, 42)
     }
 
-    /// Regression: when a second instance rebinds the same path, the first
+    /// Regression: when the path has been rebound by someone else, the first
     /// instance's stop() must not unlink it. It used to, which left the live
     /// server bound to an fd with no path on disk — `lsof` showed the socket,
     /// `ls` did not, and every hook silently no-op'd on its `[ -S ]` guard.
+    ///
+    /// The unlink here is deliberate and stands in for the real incident: a
+    /// build without the standby guard (or any other process) clearing the path
+    /// out from under a live listener. A current instance will not do this —
+    /// see `testSecondInstanceStandsByRatherThanStealLiveSocket`.
     func testStopLeavesSocketRebornUnderNewerInstance() {
         let shared = "/tmp/sh-\(UUID().uuidString.prefix(8)).sock"
         let first = ControlSocketServer(router: ControlRouter(dataSource: FakeDS()), path: shared)
         first.start()
         Thread.sleep(forTimeInterval: 0.1)
 
-        // Second instance takes the path over: unlinks the first socket, binds its own.
+        // Strand `first`: with the path gone, `second` sees no live listener and
+        // binds its own socket at the same name.
+        unlink(shared)
         let second = ControlSocketServer(router: ControlRouter(dataSource: FakeDS()), path: shared)
         second.start()
         Thread.sleep(forTimeInterval: 0.1)
@@ -135,6 +142,99 @@ final class ControlSocketServerTests: XCTestCase {
         second.stop()
         XCTAssertFalse(FileManager.default.fileExists(atPath: shared),
                        "stop() left a stale socket behind")
+    }
+
+    // MARK: - ownership + self-healing
+
+    /// Layer 1. `start()` used to unlink the path unconditionally, so a second
+    /// instance silently took the live app's socket and stranded it. Now it
+    /// probes first: something is listening, so it stands down instead.
+    func testSecondInstanceStandsByRatherThanStealLiveSocket() {
+        let shared = "/tmp/sh-\(UUID().uuidString.prefix(8)).sock"
+        let first = ControlSocketServer(router: ControlRouter(dataSource: FakeDS()), path: shared)
+        first.start()
+        Thread.sleep(forTimeInterval: 0.1)
+        var st = stat()
+        XCTAssertEqual(stat(shared, &st), 0)
+        let firstInode = st.st_ino
+
+        let second = ControlSocketServer(router: ControlRouter(dataSource: FakeDS()), path: shared)
+        second.start()
+        Thread.sleep(forTimeInterval: 0.1)
+        defer { second.stop(); first.stop() }
+
+        XCTAssertEqual(second.state, .standby, "second instance stole a live socket")
+        XCTAssertEqual(first.state, .listening)
+
+        // The file on disk must still be the first instance's socket...
+        var after = stat()
+        XCTAssertEqual(stat(shared, &after), 0)
+        XCTAssertEqual(after.st_ino, firstInode, "the path was rebound under a live listener")
+
+        // ...and the first instance must still answer on it.
+        let fd = connect(shared); defer { close(fd) }
+        send(fd, #"{"id":"10","method":"ping"}"#)
+        XCTAssertEqual((json(readLine(fd))?["result"] as? [String: Any])?["pong"] as? Bool, true)
+    }
+
+    /// Layer 2. The exact production failure: the socket file vanishes while the
+    /// listener is still bound to it. Nothing in-process notices on its own —
+    /// accept() keeps waiting on an fd no client can name — so the health check
+    /// has to spot it and rebind.
+    func testHealthCheckRebindsAfterSocketFileVanishes() {
+        let shared = "/tmp/sh-\(UUID().uuidString.prefix(8)).sock"
+        let server = ControlSocketServer(router: ControlRouter(dataSource: FakeDS()),
+                                         path: shared, healthCheckInterval: 0.2)
+        server.start()
+        Thread.sleep(forTimeInterval: 0.1)
+        defer { server.stop() }
+
+        unlink(shared)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: shared))
+
+        XCTAssertTrue(waitUntil(2) { FileManager.default.fileExists(atPath: shared) },
+                      "health check never rebound the vanished socket path")
+        XCTAssertEqual(server.state, .listening)
+
+        // Reachable again — a rebind that no client can use is not a recovery.
+        let fd = connect(shared); defer { close(fd) }
+        send(fd, #"{"id":"11","method":"ping"}"#)
+        XCTAssertEqual((json(readLine(fd))?["result"] as? [String: Any])?["pong"] as? Bool, true)
+    }
+
+    /// Layer 2, the other direction: a stood-down instance is not dead. When the
+    /// owner exits it takes the path with it, and the survivor claims it.
+    func testStandbyInstanceTakesOverWhenOwnerStops() {
+        let shared = "/tmp/sh-\(UUID().uuidString.prefix(8)).sock"
+        let owner = ControlSocketServer(router: ControlRouter(dataSource: FakeDS()), path: shared)
+        owner.start()
+        Thread.sleep(forTimeInterval: 0.1)
+
+        let waiter = ControlSocketServer(router: ControlRouter(dataSource: FakeDS()),
+                                         path: shared, healthCheckInterval: 0.2)
+        waiter.start()
+        Thread.sleep(forTimeInterval: 0.1)
+        defer { waiter.stop() }
+        XCTAssertEqual(waiter.state, .standby)
+
+        owner.stop()
+        XCTAssertTrue(waitUntil(2) { waiter.state == .listening },
+                      "standby instance never claimed the freed socket path")
+
+        let fd = connect(shared); defer { close(fd) }
+        send(fd, #"{"id":"12","method":"ping"}"#)
+        XCTAssertEqual((json(readLine(fd))?["result"] as? [String: Any])?["pong"] as? Bool, true)
+    }
+
+    /// Poll a condition rather than sleeping a fixed slice — the health check
+    /// fires on its own timer and a fixed sleep is either flaky or slow.
+    private func waitUntil(_ timeout: TimeInterval, _ cond: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if cond() { return true }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        return cond()
     }
 
     func testEventsSubscribeReplaysAfterSeq() {

--- a/Tests/OpenCodePluginInstallerTests.swift
+++ b/Tests/OpenCodePluginInstallerTests.swift
@@ -81,4 +81,26 @@ final class OpenCodePluginInstallerTests: XCTestCase {
         // whole call must be skipped, not a filtered subset forwarded.
         XCTAssertTrue(js.contains("q.multiple"))
     }
+
+    /// A resume ref built from the seahelm pane name is useless to opencode
+    /// (`opencode resume` only recognizes opencode's own ids), so the plugin must
+    /// learn and forward the real `sessionID` — via the session lifecycle event,
+    /// not just whenever the question tool happens to fire.
+    func testTracksOpencodesOwnSessionIdViaLifecycleEvents() {
+        let js = OpenCodePluginInstaller.pluginContents()
+        XCTAssertTrue(js.contains("event: async ({ event }) =>"))
+        XCTAssertTrue(js.contains("\"session.created\""))
+        XCTAssertTrue(js.contains("\"session.idle\""))
+        XCTAssertTrue(js.contains("event.properties?.sessionID"))
+        // Question-tool events must carry the real id too, not PANE.
+        XCTAssertTrue(js.contains("input.sessionID"))
+    }
+
+    /// A Task-tool subagent's session going idle must never read as the main
+    /// pane's agent finishing — herdr's own history is the cautionary tale here.
+    func testExcludesSubagentSessionsFromIdleReporting() {
+        let js = OpenCodePluginInstaller.pluginContents()
+        XCTAssertTrue(js.contains("parentID"))
+        XCTAssertTrue(js.contains("subagentSessions"))
+    }
 }

--- a/Tests/PiExtensionInstallerTests.swift
+++ b/Tests/PiExtensionInstallerTests.swift
@@ -59,6 +59,18 @@ final class PiExtensionInstallerTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: PiExtensionInstaller.settingsURL(agentDir: dir), encoding: .utf8), raw)
     }
 
+    /// A resume ref built from the seahelm pane name is useless to Pi (`pi --session`
+    /// only recognizes Pi's own ids) — the extension must forward Pi's real session
+    /// handle, not fall back to PANE whenever a session context is available.
+    func testReportsPisOwnSessionIdAndPathNotThePaneId() {
+        let js = PiExtensionInstaller.extensionContents()
+        XCTAssertTrue(js.contains("ctx.sessionManager.getSessionId"))
+        XCTAssertTrue(js.contains("ctx.sessionManager.getSessionFile"))
+        XCTAssertTrue(js.contains("session_path"))
+        // Handlers must receive ctx to have anything to read.
+        XCTAssertTrue(js.contains("(e, ctx) =>"))
+    }
+
     func testLeavesForeignExtensionFileAlone() throws {
         let dir = try makeTempDir()
         let ext = PiExtensionInstaller.extensionFileURL(agentDir: dir)

--- a/Tests/SessionLaunchCommandTests.swift
+++ b/Tests/SessionLaunchCommandTests.swift
@@ -8,23 +8,55 @@ final class SessionLaunchCommandTests: XCTestCase {
             name: "seahelm-repo-feat",
             cwd: "/work/repo/feat",
             agentCommandLine: "claude 'fix bug'",
-            shell: "/bin/zsh"
+            shell: "/bin/zsh",
+            terminfoPath: "/Apps/Seahelm.app/Contents/Resources/terminfo"
         )
         XCTAssertEqual(cmds.count, 1)
         let socket = ControlSocketServer.defaultSocketPath()
         let inner = "export SEAHELM_ENV=1 SEAHELM_SOCKET_PATH=\(ShellEscape.singleQuote(socket))"
             + " SEAHELM_PANE_ID='seahelm-repo-feat'"
-            + " && cd '/work/repo/feat' && clear && claude 'fix bug'"
+            + " && cd '/work/repo/feat'"
+            + " && printf '\\033[2J\\033[3J\\033[H' && claude 'fix bug'"
         XCTAssertEqual(
             cmds[0],
-            [ZmxLocator.executable(), "run", "seahelm-repo-feat", "/bin/zsh", "-lic", inner]
+            ["TERM=xterm-ghostty", "TERMINFO=/Apps/Seahelm.app/Contents/Resources/terminfo",
+             ZmxLocator.executable(), "run", "seahelm-repo-feat", "/bin/zsh", "-lic", inner]
         )
+    }
+
+    /// Regression: a Finder-launched build inherits launchd's environment, which
+    /// carries no TERM. `clear` then exited 1 and short-circuited the `&&` chain
+    /// before the agent was ever exec'd — the worktree came up with a bare shell.
+    /// The launch line must both carry a TERM of its own and clear the screen
+    /// without consulting terminfo.
+    func testZmxLaunchCarriesTerminalEnvironmentAndTerminfoFreeClear() {
+        let cmds = SessionManager.detachedLaunchCommands(
+            backend: "zmx", name: "n", cwd: "/c", agentCommandLine: "claude",
+            shell: "/bin/zsh", terminfoPath: "/res/terminfo"
+        )
+        XCTAssertEqual(Array(cmds[0].prefix(2)),
+                       ["TERM=xterm-ghostty", "TERMINFO=/res/terminfo"])
+        let inner = cmds[0].last ?? ""
+        XCTAssertFalse(inner.contains(" clear "))
+        XCTAssertTrue(inner.contains(TerminalEnvironment.clearScreenCommand))
+    }
+
+    /// Without the bundled database `xterm-ghostty` is unresolvable, so fall
+    /// back to a TERM that /usr/share/terminfo always has.
+    func testZmxLaunchFallsBackWhenBundledTerminfoMissing() {
+        let cmds = SessionManager.detachedLaunchCommands(
+            backend: "zmx", name: "n", cwd: "/c", agentCommandLine: "claude",
+            shell: "/bin/zsh", terminfoPath: nil
+        )
+        XCTAssertEqual(cmds[0].first, "TERM=xterm-256color")
+        XCTAssertFalse(cmds[0].contains { $0.hasPrefix("TERMINFO=") })
     }
 
     func testUnknownBackendReturnsEmpty() {
         XCTAssertTrue(SessionManager.detachedLaunchCommands(
             backend: "local",
-            name: "n", cwd: "/c", agentCommandLine: "claude", shell: "/bin/zsh"
+            name: "n", cwd: "/c", agentCommandLine: "claude", shell: "/bin/zsh",
+            terminfoPath: nil
         ).isEmpty)
     }
 

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		8F88CCC86880979546321D70 /* IMessageSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0129F6EBD2E1650EFE04DC4A /* IMessageSender.swift */; };
 		8FE5D1705C06DDB664FF7C94 /* Manifests in Resources */ = {isa = PBXBuildFile; fileRef = A94DAD757D9F452B11283244 /* Manifests */; };
 		90650F907FCC7FB24383A44D /* HooksChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A7E8E322E5A353D4457DBC /* HooksChannel.swift */; };
+		913DBD2B1D15867351B0DEE0 /* TerminalEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D90518E8BFCA59E2D344513 /* TerminalEnvironment.swift */; };
 		91AD0153C909A0DF726EE6A1 /* ManifestEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304981CB302BEC6B00289258 /* ManifestEngineTests.swift */; };
 		91AE9A595CB36E54847C8274 /* GlobalKeymapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F339357674536CA6736266 /* GlobalKeymapTests.swift */; };
 		926281EDB1D02F36BD5782DE /* LayoutNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85D2312DE47C6FDA0B8652EE /* LayoutNodeTests.swift */; };
@@ -552,6 +553,7 @@
 		3C63D5B14013E417D6AC3E33 /* ChromeLayoutState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeLayoutState.swift; sourceTree = "<group>"; };
 		3CD049D511655E149E38EA48 /* PairingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingWindowController.swift; sourceTree = "<group>"; };
 		3D002748AEBEA4297919DC48 /* FocusPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPanelView.swift; sourceTree = "<group>"; };
+		3D90518E8BFCA59E2D344513 /* TerminalEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalEnvironment.swift; sourceTree = "<group>"; };
 		3F4CB69B94BFFAB30A5D430C /* ChromeHeaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeHeaderDelegate.swift; sourceTree = "<group>"; };
 		3F67CBC84404085C3483C910 /* TestViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewHelpers.swift; sourceTree = "<group>"; };
 		3FA6E78D00BFAF395356B892 /* IMessageRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMessageRuleTests.swift; sourceTree = "<group>"; };
@@ -1018,6 +1020,7 @@
 				30F9565C3156144526A74B08 /* StationManager.swift */,
 				532D40CAB3DC6BC206BB94C4 /* StationRegistry.swift */,
 				22B1A2AE485F12ED562023B0 /* StopHookResponder.swift */,
+				3D90518E8BFCA59E2D344513 /* TerminalEnvironment.swift */,
 				77ABED3BE7AAC378B4E6B068 /* TodoStore.swift */,
 				F0982B809334A31181947736 /* WatchFeed.swift */,
 				B07FF7C768D8C4871A88AA48 /* WorkspaceManager.swift */,
@@ -2192,6 +2195,7 @@
 				D167E1E554F3BA094107F39D /* TabCoordinator.swift in Sources */,
 				859DBEFE2BAE0BA0C975FD3E /* TaskProgressParser.swift in Sources */,
 				0658FAE09BDFAD7932B01617 /* TerminalCoordinator.swift in Sources */,
+				913DBD2B1D15867351B0DEE0 /* TerminalEnvironment.swift in Sources */,
 				AD608FF60D293BA96BCB01B8 /* TerminalHeaderView.swift in Sources */,
 				CBB8B4ECA774CBFE1EF1A070 /* Theme.swift in Sources */,
 				964D05E6C8C5D093CB6633E2 /* ThemedBackgroundView.swift in Sources */,
@@ -2272,7 +2276,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.49;
+				MARKETING_VERSION = 2.0.50;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",
@@ -2510,7 +2514,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.49;
+				MARKETING_VERSION = 2.0.50;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",


### PR DESCRIPTION
## Summary
- Keep the control socket alive across instance handoff (control socket self-heal)
- Carry TERM/TERMINFO into detached zmx launches so a Finder/launchd-launched build doesn't silently drop into a bare shell (missing TERM broke the terminfo-dependent `clear` mid-launch-chain)
- Report pi's and opencode's own native session id (not seahelm's pane id) so an agent resume ref actually targets a session those agents recognize; opencode also now learns its session id from a lifecycle event instead of only when its `question` tool fires
- Stop `MainWindowController`'s stale config snapshot from clobbering `agentSessions` on every worktree-activity save — this was silently wiping every agent's resume ref within moments of it being recorded, on every build, for every agent (claude included)

## Test plan
- [x] `seahelmTests` unit suite passes (one `ChromeCollapseAnimationTests` flake, confirmed unrelated + passes in isolation)
- [x] Rebuilt and relaunched locally; sent synthetic hook events over the live control socket and confirmed `agent_sessions` in `config.json` now persists a resume ref and survives a follow-up save, instead of reverting to `{}` within seconds
- [x] Confirmed via `zmx list` that real, currently-running claude panes' session ids get recorded correctly post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)