### PR TITLE
fix: stop the fleet list mis-highlighting rows and jumping worktrees

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -615,7 +615,7 @@ class MainWindowController: NSWindowController, MailCommandContext {
 
     private func refreshChromeWorktreeContextEnabled() {
         let hasSelection = tabCoordinator.selectedPane != nil
-            || !(dashboardVC?.selectedPaneId.isEmpty ?? true)
+            || !(dashboardVC?.selectedWorktreeId.isEmpty ?? true)
         windowChrome?.setWorktreeContextEnabled(hasSelection)
     }
 

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -429,7 +429,6 @@ class TabCoordinator {
             }
 
             result.append(WorktreeRowInfo(
-                id: agent.id,
                 name: worktreeName,
                 project: agent.project,
                 thread: worktreeName,

--- a/Sources/Core/AgentRegistry.swift
+++ b/Sources/Core/AgentRegistry.swift
@@ -933,13 +933,17 @@ class AgentRegistry {
         lock.lock()
         defer { lock.unlock() }
 
-        orderedIDs.sort { a, b in
-            let pathA = agents[a]?.worktreePath ?? ""
-            let pathB = agents[b]?.worktreePath ?? ""
-            let ai = paths.firstIndex(of: pathA) ?? Int.max
-            let bi = paths.firstIndex(of: pathB) ?? Int.max
-            return ai < bi
-        }
+        // Stable by construction: `sort` is not a stable sort, and this
+        // comparator calls every pane of the same worktree equal — so a plain
+        // sort was free to permute panes *within* a worktree on each call,
+        // silently changing which pane the fleet treats as that worktree's
+        // representative. Falling back to the current position keeps registration
+        // order intact inside each worktree.
+        orderedIDs = orderedIDs.enumerated().sorted { a, b in
+            let ai = paths.firstIndex(of: agents[a.element]?.worktreePath ?? "") ?? Int.max
+            let bi = paths.firstIndex(of: agents[b.element]?.worktreePath ?? "") ?? Int.max
+            return ai != bi ? ai < bi : a.offset < b.offset
+        }.map(\.element)
     }
 
     // MARK: - Queries

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -29,7 +29,6 @@ struct PaneDisplayInfo {
 // MARK: - WorktreeRowInfo
 
 struct WorktreeRowInfo {
-    let id: String          // terminal ID (from Station.id)
     let name: String        // display name like "Agent-Alpha"
     let project: String     // repo display name
     let thread: String      // branch name
@@ -43,6 +42,17 @@ struct WorktreeRowInfo {
     let roundDuration: String   // "HH:MM:SS" format
     let station: Station
     let worktreePath: String    // needed to lazily create the terminal
+
+    /// Row identity. Deliberately the worktree path and nothing else.
+    ///
+    /// This used to be a pane's `Station.id` — whichever of the worktree's panes
+    /// happened to be registered first. Closing that pane changed the row's
+    /// identity, `selectedWorktreeId` stopped matching any row, and the "validate
+    /// the selection" fallback then landed on the *first row of the whole fleet*:
+    /// close a split pane in one worktree and the terminal jumped to another one.
+    /// A worktree outlives every pane inside it, so its path is the only identity
+    /// that can't die underneath the selection.
+    var id: String { worktreePath }
     let paneCount: Int          // number of split panes (1 = no badge)
     let paneStations: [Station]  // all pane stations in leaf order
     let isMainWorktree: Bool    // true = base repo, false = git worktree
@@ -107,7 +117,11 @@ class DashboardViewController: NSViewController {
     /// Set by MainWindowController — forwards split events to TerminalCoordinator
     weak var splitContainerDelegate: SplitContainerDelegate?
 
-    var selectedPaneId: String = ""
+    /// The selected fleet row's id — i.e. the selected worktree's path.
+    ///
+    /// Named for the worktree, not the pane, on purpose: it survives every pane
+    /// inside that worktree being split, slept, or closed. See `WorktreeRowInfo.id`.
+    var selectedWorktreeId: String = ""
 
     /// Deprecated layout alias for chrome collapse (SSOT is `ChromeLayoutState`):
     /// - `.split` == sidebar expanded (`!chrome.isCollapsed`)
@@ -147,7 +161,7 @@ class DashboardViewController: NSViewController {
     var idleWorktreePaths: Set<String> = []
 
     var selectedPaneIndex: Int {
-        agents.firstIndex(where: { $0.id == selectedPaneId }) ?? 0
+        agents.firstIndex(where: { $0.id == selectedWorktreeId }) ?? 0
     }
 
     /// Cached SplitContainerView per worktree path
@@ -238,7 +252,7 @@ class DashboardViewController: NSViewController {
     }
 
     private var currentWorktreePath: String? {
-        (agents.first(where: { $0.id == selectedPaneId }) ?? agents.first)?.worktreePath
+        (agents.first(where: { $0.id == selectedWorktreeId }) ?? agents.first)?.worktreePath
     }
 
     /// True when the selected worktree is showing the split edit layout.
@@ -428,9 +442,12 @@ class DashboardViewController: NSViewController {
             leftRightContainer.isHidden = false
         }
 
-        // Validate selectedPaneId
-        if !agents.contains(where: { $0.id == selectedPaneId }) {
-            selectedPaneId = agents.first?.id ?? ""
+        // Validate the selection. Now that a row is keyed by its worktree path,
+        // this only fires when the selected worktree itself is gone (deleted, or
+        // its last pane closed) — not when a pane inside it comes and goes, which
+        // is what used to bounce the selection onto an unrelated worktree.
+        if !agents.contains(where: { $0.id == selectedWorktreeId }) {
+            selectedWorktreeId = agents.first?.id ?? ""
         }
 
         if structureChanged {
@@ -444,7 +461,7 @@ class DashboardViewController: NSViewController {
     }
 
     private func syncSidePanelToSelection() {
-        let path = agents.first(where: { $0.id == selectedPaneId })?.worktreePath
+        let path = agents.first(where: { $0.id == selectedWorktreeId })?.worktreePath
         sidePanelVC.setWorktree(path)
     }
 
@@ -474,7 +491,7 @@ class DashboardViewController: NSViewController {
         lastCommittedWorktreePath = path
         guard agents.contains(where: { $0.worktreePath == path }) else { return }
         selectPane(byWorktreePath: path, focusTerminal: focusTerminal)
-        overviewSelectedId = selectedPaneId
+        overviewSelectedId = selectedWorktreeId
         // Push the highlight onto the overview so a programmatic commit (e.g. launch
         // restore, chat steering) moves the selected row just like a click does.
         if !overviewView.isHidden {
@@ -485,11 +502,11 @@ class DashboardViewController: NSViewController {
 
     func selectPane(byWorktreePath path: String, focusTerminal: Bool = true) {
         guard let agent = agents.first(where: { $0.worktreePath == path }) else { return }
-        let changed = agent.id != selectedPaneId
+        let changed = agent.id != selectedWorktreeId
         if changed {
             dismissCenterOverlay()
         }
-        selectedPaneId = agent.id
+        selectedWorktreeId = agent.id
         detachTerminals()
         embedSplitContainerForSelectedPane(focusTerminal: focusTerminal)
         syncSidePanelToSelection()
@@ -520,7 +537,7 @@ class DashboardViewController: NSViewController {
 
         if collapsed {
             if firstMateSideOpen { flushPendingPreview() }
-            lastCommittedWorktreePath = agents.first(where: { $0.id == selectedPaneId })?.worktreePath
+            lastCommittedWorktreePath = agents.first(where: { $0.id == selectedWorktreeId })?.worktreePath
                 ?? lastCommittedWorktreePath
             DispatchQueue.main.asyncAfter(deadline: .now() + settleDelay) { [weak self] in
                 guard let self, self.viewMode == .terminal else { return }
@@ -538,7 +555,7 @@ class DashboardViewController: NSViewController {
                 openFirstMateColumn()
                 currentSide = .firstMate
             }
-            lastCommittedWorktreePath = agents.first(where: { $0.id == selectedPaneId })?.worktreePath
+            lastCommittedWorktreePath = agents.first(where: { $0.id == selectedWorktreeId })?.worktreePath
                 ?? lastCommittedWorktreePath
             // Same reasoning as the collapse branch — the first embed after a
             // cold start is the most expensive one there is.
@@ -655,7 +672,7 @@ class DashboardViewController: NSViewController {
     /// needs is here: the row id, the focus ring's index, and the animation.
     func cycleToWorktree(path: String) {
         selectPane(byWorktreePath: path)
-        overviewSelectedId = selectedPaneId
+        overviewSelectedId = selectedWorktreeId
         if let index = overviewView.orderedRows.firstIndex(where: { $0.path == path }) {
             _ = overviewFocus.jumpToWorktree(index)
         }
@@ -671,7 +688,7 @@ class DashboardViewController: NSViewController {
 
     func enterWorktree(byWorktreePath path: String) {
         selectPane(byWorktreePath: path)
-        overviewSelectedId = selectedPaneId
+        overviewSelectedId = selectedWorktreeId
         // If the overview is on screen (fleet full-screen, or docked as the First
         // Mate side panel), move its selection highlight to the clicked row.
         if !overviewView.isHidden {
@@ -736,8 +753,8 @@ class DashboardViewController: NSViewController {
     // MARK: - Layout
 
     private func rebuildFocusLayout() {
-        if let selected = agents.first(where: { $0.id == selectedPaneId }) ?? agents.first {
-            selectedPaneId = selected.id
+        if let selected = agents.first(where: { $0.id == selectedWorktreeId }) ?? agents.first {
+            selectedWorktreeId = selected.id
             // Only embed when the dashboard is visible to avoid stealing
             // surfaces from the active repo tab's split container.
             if view.window != nil {
@@ -953,7 +970,7 @@ class DashboardViewController: NSViewController {
     /// `focusTerminal: false` is used for live nav preview — it keeps the dashboard
     /// VC as first responder so arrow keys keep driving the nav ring.
     func embedSplitContainerForSelectedPane(focusTerminal: Bool = true) {
-        guard let agent = agents.first(where: { $0.id == selectedPaneId }) ?? agents.first else { return }
+        guard let agent = agents.first(where: { $0.id == selectedWorktreeId }) ?? agents.first else { return }
         let worktreePath = agent.worktreePath
 
         // Attach/detach the edit container for THIS worktree's mode before we pick
@@ -1113,14 +1130,14 @@ class DashboardViewController: NSViewController {
 
         let snapshot = DashboardFocusController.Snapshot(
             firstResponder: view.window?.firstResponder,
-            focusedWorktreePath: agents.first(where: { $0.id == selectedPaneId })?.worktreePath
+            focusedWorktreePath: agents.first(where: { $0.id == selectedWorktreeId })?.worktreePath
         )
         focusController.captureSnapshot(snapshot)
 
         let cardIds = cruiseOrder.map(\.id)
         let initial = snapshot.focusedWorktreePath
             .flatMap { path in agents.first(where: { $0.worktreePath == path })?.id }
-            ?? (selectedPaneId.isEmpty ? nil : selectedPaneId)
+            ?? (selectedWorktreeId.isEmpty ? nil : selectedWorktreeId)
         focusController.enterFocusLayout(cardIds: cardIds, initialId: initial)
 
         view.window?.makeFirstResponder(self)
@@ -1139,7 +1156,7 @@ class DashboardViewController: NSViewController {
         if restoreSnapshot,
            let path = snapshot?.focusedWorktreePath,
            let original = agents.first(where: { $0.worktreePath == path }),
-           original.id != selectedPaneId {
+           original.id != selectedWorktreeId {
             selectPane(byWorktreePath: path)
         }
 
@@ -1284,8 +1301,8 @@ class DashboardViewController: NSViewController {
             overviewView.update(agents)
             // Persist the highlighted row immediately so a quit during the
             // preview debounce still restores this worktree, not the previous one.
-            if selectionChanged || selectedPaneId != row.id {
-                selectedPaneId = row.id
+            if selectionChanged || selectedWorktreeId != row.id {
+                selectedWorktreeId = row.id
                 notifySelectionChanged()
             }
             if viewMode == .split { schedulePreview(path: row.path) }
@@ -1397,7 +1414,7 @@ class DashboardViewController: NSViewController {
     /// updated (and persisted) by `applyOverviewEffect`; this only embeds.
     private func previewWorktree(path: String) {
         guard let agent = agents.first(where: { $0.worktreePath == path }) else { return }
-        selectedPaneId = agent.id
+        selectedWorktreeId = agent.id
         guard activeSplitWorktreePath != path else { return }
         detachTerminals()
         embedSplitContainerForSelectedPane(focusTerminal: false)
@@ -1898,7 +1915,7 @@ extension DashboardViewController: WorktreeSidePanelDelegate {
     }
 
     func sidePanel(_ vc: WorktreeSidePanelViewController, didSelectChange path: String) {
-        let worktreePath = agents.first(where: { $0.id == selectedPaneId })?.worktreePath ?? ""
+        let worktreePath = agents.first(where: { $0.id == selectedWorktreeId })?.worktreePath ?? ""
         let fileName = URL(fileURLWithPath: path).lastPathComponent
         let title = fileName.isEmpty ? "Changes" : fileName
         showCenterOverlay(
@@ -1926,6 +1943,18 @@ private final class NonFirstResponderScrollView: NSScrollView {
 /// pending orders live in the island, not here.
 extension Array {
     subscript(safeIndex index: Int) -> Element? { indices.contains(index) ? self[index] : nil }
+}
+
+/// A fleet row that paints a pointer-hover tint.
+///
+/// Hover is owned by the list, not by the row's own tracking area. AppKit pairs
+/// `mouseEntered` / `mouseExited` off pointer *movement*: scrolling the fleet
+/// under a stationary cursor delivers an enter for every row that slides beneath
+/// the pointer and no matching exit, so each one it passed stayed tinted and the
+/// list read as a dozen rows selected at once. Routing both edges through the
+/// list keeps at most one row lit no matter which events AppKit drops.
+private protocol FleetHoverRow: NSView {
+    func setHovered(_ hovered: Bool)
 }
 
 final class DashboardOverviewView: NSView {
@@ -1987,6 +2016,8 @@ final class DashboardOverviewView: NSView {
     private var addWorktreeProjects: [String] = []
     private static let addWorktreeButtonIdentifier = NSUserInterfaceItemIdentifier("seahelm.addWorktree")
     private var revealedRowID: String?
+    /// The one row currently painting the hover tint, if any.
+    private weak var hoveredRow: FleetHoverRow?
     private var paneRowViewsByStationID: [String: PaneRowView] = [:]
     private var lastStructureSignature: String?
     private var fullRenderCount = 0
@@ -2066,6 +2097,10 @@ final class DashboardOverviewView: NSView {
         scroll.borderType = .noBorder
         scroll.translatesAutoresizingMaskIntoConstraints = false
         scroll.documentView = stack
+        scroll.contentView.postsBoundsChangedNotifications = true
+        NotificationCenter.default.addObserver(self, selector: #selector(fleetDidScroll),
+                                               name: NSView.boundsDidChangeNotification,
+                                               object: scroll.contentView)
         addSubview(scroll)
 
         // --- Bottom shortcut strip ---
@@ -2195,6 +2230,44 @@ final class DashboardOverviewView: NSView {
         refreshChromeColors()
     }
 
+    deinit { NotificationCenter.default.removeObserver(self) }
+
+    // MARK: - Hover
+
+    @objc private func fleetDidScroll() { refreshHoverForPointer() }
+
+    /// A row reported a tracking-area edge. Enters win outright; an exit only
+    /// counts for the row the list still believes is lit, so a stale exit
+    /// arriving after the pointer already moved on can't blank the new row.
+    private func rowHoverChanged(_ row: FleetHoverRow, entered: Bool) {
+        if entered {
+            setHoveredRow(row)
+        } else if hoveredRow === row {
+            setHoveredRow(nil)
+        }
+    }
+
+    private func setHoveredRow(_ row: FleetHoverRow?) {
+        guard hoveredRow !== row else { return }
+        hoveredRow?.setHovered(false)
+        hoveredRow = row
+        row?.setHovered(true)
+    }
+
+    /// Re-resolve the hovered row from where the pointer actually is.
+    ///
+    /// Scrolling moves rows under a still cursor, which AppKit reports as a run
+    /// of enters with no exits — so the fleet asks the pointer instead of
+    /// trusting the events every time the content offset changes.
+    private func refreshHoverForPointer() {
+        guard let window, window.isKeyWindow else { setHoveredRow(nil); return }
+        let point = scroll.contentView.convert(window.mouseLocationOutsideOfEventStream, from: nil)
+        guard scroll.contentView.bounds.contains(point) else { setHoveredRow(nil); return }
+        var hit = stack.hitTest(point)
+        while let view = hit, !(view is FleetHoverRow) { hit = view.superview }
+        setHoveredRow(hit as? FleetHoverRow)
+    }
+
     /// Layer `CGColor`s don't auto-track dynamic `NSColor`s — re-resolve on appearance flips.
     private func refreshChromeColors() {
         layer?.backgroundColor = NSColor.clear.cgColor
@@ -2264,6 +2337,7 @@ final class DashboardOverviewView: NSView {
         #endif
         fullRenderCount += 1
         lastStructureSignature = structureSignature
+        setHoveredRow(nil)
         stack.arrangedSubviews.forEach { $0.removeFromSuperview() }
         orderedRows = []
         rowViewsByID = [:]
@@ -2291,6 +2365,9 @@ final class DashboardOverviewView: NSView {
                 row.onTap = { [weak self] path in self?.onSelectWorktree?(path) }
                 row.onDelete = { [weak self] path in self?.onDeleteWorktree?(path) }
                 row.onDeleteWithBranch = { [weak self] path in self?.onDeleteWorktreeWithBranch?(path) }
+                row.onHoverChanged = { [weak self] row, entered in
+                    self?.rowHoverChanged(row, entered: entered)
+                }
                 rowsBox.addArrangedSubview(row)
                 row.widthAnchor.constraint(equalTo: rowsBox.widthAnchor).isActive = true
                 orderedRows.append((groupedItem.id, groupedItem.path))
@@ -2307,6 +2384,9 @@ final class DashboardOverviewView: NSView {
                         let paneRow = PaneRowView(pane: paneInfo, worktreePath: pane.worktreePath)
                         paneRow.onTap = { [weak self] worktreePath, stationId in
                             self?.onSelectPane?(worktreePath, stationId)
+                        }
+                        paneRow.onHoverChanged = { [weak self] row, entered in
+                            self?.rowHoverChanged(row, entered: entered)
                         }
                         rowsBox.addArrangedSubview(paneRow)
                         paneRow.widthAnchor.constraint(equalTo: rowsBox.widthAnchor).isActive = true
@@ -2459,6 +2539,15 @@ final class DashboardOverviewView: NSView {
             .compactMap { addWorktreeProjects[safeIndex: $0.tag] }
     }
     var renderedSelectedRowIDForTesting: String? { rowViewsByID[selectedId] == nil ? nil : selectedId }
+    /// Ids of every row currently painting the hover tint — more than one means
+    /// the scroll-leaves-a-trail bug is back.
+    var hoveredRowIDsForTesting: [String] {
+        rowViewsByID.filter { $0.value.isHoveredForTesting }.keys.sorted()
+    }
+    func simulateRowHoverForTesting(id: String, entered: Bool) {
+        guard let row = rowViewsByID[id] else { return }
+        rowHoverChanged(row, entered: entered)
+    }
     var revealedRowIDForTesting: String? { revealedRowID }
     func rowRuntimeTextForTesting(id: String) -> String? { rowViewsByID[id]?.runtimeTextForTesting }
     func rowTitleTextForTesting(id: String) -> String? { rowViewsByID[id]?.titleTextForTesting }
@@ -2572,8 +2661,11 @@ final class DashboardOverviewView: NSView {
     ///    branch  git info                           N panes
     /// ```
     /// Title and branch share a text column so their leading edges align.
-    private final class RowView: NSView {
+    private final class RowView: NSView, FleetHoverRow {
         var onTap: ((String) -> Void)?
+        /// Pointer entered (`true`) or left (`false`) this row. The list, not the
+        /// row, decides what that means — see `FleetHoverRow`.
+        var onHoverChanged: ((FleetHoverRow, Bool) -> Void)?
         var onDelete: ((String) -> Void)?
         var onDeleteWithBranch: ((String) -> Void)?
         /// Refreshed by `update` rather than fixed at init: a row is keyed by its
@@ -2863,11 +2955,12 @@ final class DashboardOverviewView: NSView {
             let t = NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect], owner: self)
             addTrackingArea(t); tracking = t
         }
-        override func mouseEntered(with event: NSEvent) {
-            applyBackground(hovered: true)
-        }
-        override func mouseExited(with event: NSEvent) {
-            applyBackground(hovered: false)
+        override func mouseEntered(with event: NSEvent) { onHoverChanged?(self, true) }
+        override func mouseExited(with event: NSEvent) { onHoverChanged?(self, false) }
+
+        func setHovered(_ hovered: Bool) {
+            guard self.hovered != hovered else { return }
+            applyBackground(hovered: hovered)
         }
 
         /// Move the selection highlight on or off this row.
@@ -2902,22 +2995,27 @@ final class DashboardOverviewView: NSView {
 
         override func viewDidChangeEffectiveAppearance() {
             super.viewDidChangeEffectiveAppearance()
-            applyBackground(hovered: false)
+            applyBackground(hovered: hovered)
         }
+
+        var isHoveredForTesting: Bool { hovered }
     }
 
     // MARK: - Pane row (Group by Pane)
 
     /// Third-level row under a worktree in the expanded "Group by Pane" mode:
     /// an indented, clickable pane. `● pane title`, dimmed unless focused.
-    private final class PaneRowView: NSView {
+    private final class PaneRowView: NSView, FleetHoverRow {
         var onTap: ((String, String) -> Void)?
+        /// See `RowView.onHoverChanged`.
+        var onHoverChanged: ((FleetHoverRow, Bool) -> Void)?
         private let stationId: String
         /// Carried on the view, not captured in `onTap`: rows outlive a single
         /// render now, and a transferred worktree keeps its station ids.
         private var worktreePath: String
         private let dotLabel: NSTextField
         private let titleLabel: NSTextField
+        private var hovered = false
 
         private static let cornerRadius: CGFloat = 6
         private static let hoverFill = NSColor(name: nil) { appearance in
@@ -2981,12 +3079,16 @@ final class DashboardOverviewView: NSView {
             let t = NSTrackingArea(rect: bounds, options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect], owner: self)
             addTrackingArea(t); tracking = t
         }
-        override func mouseEntered(with event: NSEvent) {
-            layer?.backgroundColor = resolvedCGColor(Self.hoverFill)
+        override func mouseEntered(with event: NSEvent) { onHoverChanged?(self, true) }
+        override func mouseExited(with event: NSEvent) { onHoverChanged?(self, false) }
+
+        func setHovered(_ hovered: Bool) {
+            guard self.hovered != hovered else { return }
+            self.hovered = hovered
+            layer?.backgroundColor = hovered ? resolvedCGColor(Self.hoverFill) : NSColor.clear.cgColor
         }
-        override func mouseExited(with event: NSEvent) {
-            layer?.backgroundColor = NSColor.clear.cgColor
-        }
+
+        var isHoveredForTesting: Bool { hovered }
     }
 
 }

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -9,7 +9,7 @@ final class DashboardOverviewGroupingTests: XCTestCase {
         let lastActivityAt = Date(timeIntervalSince1970: 1_721_234_567)
         let creationDate = Date(timeIntervalSince1970: 1_700_000_000)
         let pane = makePane(
-            id: "station-42",
+            name: "station-42",
             project: "seahelm",
             worktreePath: "/tmp/seahelm-feature",
             paneStatuses: [.running, .error],
@@ -19,7 +19,7 @@ final class DashboardOverviewGroupingTests: XCTestCase {
 
         let item = pane.groupingItem(creationDate: creationDate)
 
-        XCTAssertEqual(item.id, "station-42")
+        XCTAssertEqual(item.id, "/tmp/seahelm-feature", "row identity is the worktree path")
         XCTAssertEqual(item.path, "/tmp/seahelm-feature")
         XCTAssertEqual(item.repository, "seahelm")
         XCTAssertEqual(item.status, .error)
@@ -69,15 +69,15 @@ final class DashboardOverviewGroupingTests: XCTestCase {
             let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
                                              defaults: defaults,
                                              now: { self.now })
-            view.selectedId = "run"
+            view.selectedId = "/run"
             view.update([
-                makePane(id: "idle", project: "charlie", worktreePath: "/idle",
+                makePane(name: "idle", project: "charlie", worktreePath: "/idle",
                            paneStatuses: [.idle], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-300)),
-                makePane(id: "wait", project: "alpha", worktreePath: "/wait",
+                makePane(name: "wait", project: "alpha", worktreePath: "/wait",
                            paneStatuses: [.waiting], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-100)),
-                makePane(id: "run", project: "bravo", worktreePath: "/run",
+                makePane(name: "run", project: "bravo", worktreePath: "/run",
                            paneStatuses: [.running], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-200)),
             ])
@@ -88,10 +88,10 @@ final class DashboardOverviewGroupingTests: XCTestCase {
 
             XCTAssertEqual(defaults.string(forKey: WorktreeGroupingPreference.key), "status")
             XCTAssertEqual(view.renderedGroupTitlesForTesting, ["Needs input", "Running", "Idle"])
-            XCTAssertEqual(view.orderedRows.map(\.id), ["wait", "run", "idle"])
-            XCTAssertEqual(view.selectedId, "run")
-            XCTAssertEqual(view.renderedSelectedRowIDForTesting, "run")
-            XCTAssertEqual(view.revealedRowIDForTesting, "run")
+            XCTAssertEqual(view.orderedRows.map(\.id), ["/wait", "/run", "/idle"])
+            XCTAssertEqual(view.selectedId, "/run")
+            XCTAssertEqual(view.renderedSelectedRowIDForTesting, "/run")
+            XCTAssertEqual(view.revealedRowIDForTesting, "/run")
             XCTAssertEqual(callbackCount, 1)
         }
     }
@@ -101,25 +101,25 @@ final class DashboardOverviewGroupingTests: XCTestCase {
             let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
                                              defaults: defaults,
                                              now: { self.now })
-            view.selectedId = "removed"
+            view.selectedId = "/removed"
             view.update([
-                makePane(id: "idle", project: "charlie", worktreePath: "/idle",
+                makePane(name: "idle", project: "charlie", worktreePath: "/idle",
                            paneStatuses: [.idle], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-300)),
-                makePane(id: "wait", project: "alpha", worktreePath: "/wait",
+                makePane(name: "wait", project: "alpha", worktreePath: "/wait",
                            paneStatuses: [.waiting], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-100)),
-                makePane(id: "run", project: "bravo", worktreePath: "/run",
+                makePane(name: "run", project: "bravo", worktreePath: "/run",
                            paneStatuses: [.running], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-200)),
             ])
 
             view.selectGroupingModeForTesting(.status)
 
-            XCTAssertEqual(view.orderedRows.map(\.id), ["wait", "run", "idle"])
-            XCTAssertEqual(view.selectedId, "wait")
-            XCTAssertEqual(view.renderedSelectedRowIDForTesting, "wait")
-            XCTAssertEqual(view.revealedRowIDForTesting, "wait")
+            XCTAssertEqual(view.orderedRows.map(\.id), ["/wait", "/run", "/idle"])
+            XCTAssertEqual(view.selectedId, "/wait")
+            XCTAssertEqual(view.renderedSelectedRowIDForTesting, "/wait")
+            XCTAssertEqual(view.revealedRowIDForTesting, "/wait")
         }
     }
 
@@ -145,10 +145,10 @@ final class DashboardOverviewGroupingTests: XCTestCase {
                                              defaults: defaults,
                                              now: { self.now })
             view.update([
-                makePane(id: "wait", project: "alpha", worktreePath: "/wait",
+                makePane(name: "wait", project: "alpha", worktreePath: "/wait",
                            paneStatuses: [.waiting], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-100)),
-                makePane(id: "run", project: "bravo", worktreePath: "/run",
+                makePane(name: "run", project: "bravo", worktreePath: "/run",
                            paneStatuses: [.running], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-200)),
             ])
@@ -169,7 +169,7 @@ final class DashboardOverviewGroupingTests: XCTestCase {
                                              defaults: defaults,
                                              now: { self.now })
             view.update([
-                makePane(id: "wait", project: "alpha", worktreePath: "/wait",
+                makePane(name: "wait", project: "alpha", worktreePath: "/wait",
                            paneStatuses: [.waiting], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-100)),
             ])
@@ -178,17 +178,17 @@ final class DashboardOverviewGroupingTests: XCTestCase {
             // rebuild them out from under it.
             view.isRenderPaused = true
             view.update([
-                makePane(id: "wait", project: "alpha", worktreePath: "/wait",
+                makePane(name: "wait", project: "alpha", worktreePath: "/wait",
                            paneStatuses: [.waiting], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-100)),
-                makePane(id: "run", project: "bravo", worktreePath: "/run",
+                makePane(name: "run", project: "bravo", worktreePath: "/run",
                            paneStatuses: [.running], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-200)),
             ])
-            XCTAssertEqual(view.orderedRows.map(\.id), ["wait"])
+            XCTAssertEqual(view.orderedRows.map(\.id), ["/wait"])
 
             view.isRenderPaused = false
-            XCTAssertEqual(view.orderedRows.map(\.id), ["wait", "run"])
+            XCTAssertEqual(view.orderedRows.map(\.id), ["/wait", "/run"])
         }
     }
 
@@ -198,24 +198,24 @@ final class DashboardOverviewGroupingTests: XCTestCase {
                                              defaults: defaults,
                                              now: { self.now })
             view.update([
-                makePane(id: "run", project: "alpha", worktreePath: "/run",
+                makePane(name: "run", project: "alpha", worktreePath: "/run",
                            paneStatuses: [.running], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-20),
                            currentPaneRunTime: "10s"),
             ])
 
             XCTAssertEqual(view.fullRenderCountForTesting, 1)
-            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "run"), "10s")
+            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "/run"), "10s")
 
             view.update([
-                makePane(id: "run", project: "alpha", worktreePath: "/run",
+                makePane(name: "run", project: "alpha", worktreePath: "/run",
                            paneStatuses: [.running], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-10),
                            currentPaneRunTime: "20s"),
             ])
 
             XCTAssertEqual(view.fullRenderCountForTesting, 1)
-            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "run"), "20s")
+            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "/run"), "20s")
         }
     }
 
@@ -225,20 +225,20 @@ final class DashboardOverviewGroupingTests: XCTestCase {
                                              defaults: defaults,
                                              now: { self.now })
             view.update([
-                makePane(id: "run", project: "alpha", worktreePath: "/run",
+                makePane(name: "run", project: "alpha", worktreePath: "/run",
                            paneStatuses: [.running], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-20),
                            currentPaneTitle: "Initial title"),
             ])
-            XCTAssertEqual(view.rowTitleTextForTesting(id: "run"), "Initial title")
+            XCTAssertEqual(view.rowTitleTextForTesting(id: "/run"), "Initial title")
 
             view.update([
-                makePane(id: "run", project: "alpha", worktreePath: "/run",
+                makePane(name: "run", project: "alpha", worktreePath: "/run",
                            paneStatuses: [.running], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-10),
                            currentPaneTitle: "   "),
             ])
-            XCTAssertEqual(view.rowTitleTextForTesting(id: "run"), "Initial title")
+            XCTAssertEqual(view.rowTitleTextForTesting(id: "/run"), "Initial title")
         }
     }
 
@@ -252,7 +252,7 @@ final class DashboardOverviewGroupingTests: XCTestCase {
                                              now: { self.now })
             func push(_ status: AgentStatus, runtime: String) {
                 view.update([
-                    makePane(id: "run", project: "alpha", worktreePath: "/run",
+                    makePane(name: "run", project: "alpha", worktreePath: "/run",
                                paneStatuses: [status], isMainWorktree: false,
                                lastActivityAt: now.addingTimeInterval(-10),
                                currentPaneRunTime: runtime),
@@ -260,15 +260,15 @@ final class DashboardOverviewGroupingTests: XCTestCase {
             }
 
             push(.running, runtime: "12s")
-            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "run"), "12s")
+            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "/run"), "12s")
 
             // Still running, value momentarily unavailable — hold the last figure.
             push(.running, runtime: "")
-            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "run"), "12s")
+            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "/run"), "12s")
 
             // Stopped with no known activity age — the counter must go away.
             push(.idle, runtime: "")
-            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "run"), "")
+            XCTAssertEqual(view.rowRuntimeTextForTesting(id: "/run"), "")
 
             XCTAssertEqual(view.fullRenderCountForTesting, 1, "these should all be incremental")
         }
@@ -278,20 +278,58 @@ final class DashboardOverviewGroupingTests: XCTestCase {
     /// out of autoresizing constraints by hand. Without that, the frame-derived
     /// constraints win and the whole text column lays out at zero height — every
     /// row paints as a bare dot with no title, branch, or timings.
+    /// Scrolling the fleet under a stationary pointer used to deliver an enter
+    /// for every row that slid past and no matching exit, leaving a column of
+    /// rows tinted as if they were all selected.
+    func testHoverTintNeverLandsOnMoreThanOneRow() {
+        withDefaults { defaults in
+            let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
+                                             defaults: defaults,
+                                             now: { self.now })
+            view.update([
+                makePane(name: "one", project: "alpha", worktreePath: "/one",
+                         paneStatuses: [.running], isMainWorktree: false,
+                         lastActivityAt: now.addingTimeInterval(-10)),
+                makePane(name: "two", project: "alpha", worktreePath: "/two",
+                         paneStatuses: [.waiting], isMainWorktree: false,
+                         lastActivityAt: now.addingTimeInterval(-20)),
+                makePane(name: "three", project: "alpha", worktreePath: "/three",
+                         paneStatuses: [.idle], isMainWorktree: false,
+                         lastActivityAt: now.addingTimeInterval(-30)),
+            ])
+
+            view.simulateRowHoverForTesting(id: "/one", entered: true)
+            XCTAssertEqual(view.hoveredRowIDsForTesting, ["/one"])
+
+            // Rows sliding past the pointer: enters with no exits.
+            view.simulateRowHoverForTesting(id: "/two", entered: true)
+            view.simulateRowHoverForTesting(id: "/three", entered: true)
+            XCTAssertEqual(view.hoveredRowIDsForTesting, ["/three"])
+
+            // A stale exit for a row the pointer already left must not blank the
+            // row that is actually under it.
+            view.simulateRowHoverForTesting(id: "/one", entered: false)
+            XCTAssertEqual(view.hoveredRowIDsForTesting, ["/three"])
+
+            view.simulateRowHoverForTesting(id: "/three", entered: false)
+            XCTAssertEqual(view.hoveredRowIDsForTesting, [])
+        }
+    }
+
     func testWorktreeRowLaysOutTitleWithRealSize() {
         withDefaults { defaults in
             let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
                                              defaults: defaults,
                                              now: { self.now })
             view.update([
-                makePane(id: "run", project: "alpha", worktreePath: "/run",
+                makePane(name: "run", project: "alpha", worktreePath: "/run",
                            paneStatuses: [.idle], isMainWorktree: false,
                            lastActivityAt: now.addingTimeInterval(-20),
                            currentPaneTitle: "claude — building"),
             ])
             view.layoutSubtreeIfNeeded()
 
-            let frame = view.rowTitleFrameForTesting(id: "run")
+            let frame = view.rowTitleFrameForTesting(id: "/run")
             XCTAssertNotNil(frame)
             XCTAssertGreaterThan(frame?.height ?? 0, 0, "row title collapsed to zero height")
             XCTAssertGreaterThan(frame?.width ?? 0, 0, "row title collapsed to zero width")
@@ -308,7 +346,7 @@ final class DashboardOverviewGroupingTests: XCTestCase {
 }
 
 private func makePane(
-    id: String,
+    name: String,
     project: String,
     worktreePath: String,
     paneStatuses: [AgentStatus],
@@ -319,8 +357,7 @@ private func makePane(
 ) -> WorktreeRowInfo {
     let surface = Station()
     return WorktreeRowInfo(
-        id: id,
-        name: id,
+        name: name,
         project: project,
         thread: "feature",
         paneStatuses: paneStatuses,
@@ -340,7 +377,7 @@ private func makePane(
         lastActivityAge: "1m",
         lastActivityAt: lastActivityAt,
         gitStats: nil,
-        currentPaneTitle: currentPaneTitle ?? id,
+        currentPaneTitle: currentPaneTitle ?? name,
         currentPaneRunTime: currentPaneRunTime
     )
 }

--- a/Tests/DashboardViewControllerClickTests.swift
+++ b/Tests/DashboardViewControllerClickTests.swift
@@ -8,7 +8,7 @@ final class DashboardViewControllerClickTests: XCTestCase {
     func testEnteringWorktreeKeepsExpandedSidebarExpanded() {
         let vc = DashboardViewController()
         vc.loadViewIfNeeded()
-        vc.updatePanes([makePane(id: "agent-a", worktreePath: "/repo/a")])
+        vc.updatePanes([makePane(name: "agent-a", worktreePath: "/repo/a")])
         vc.adoptChromeCollapse(false, activePane: .firstMate)
         var requestedCollapse: Bool?
         vc.onRequestSetChromeCollapsed = { requestedCollapse = $0 }
@@ -23,7 +23,7 @@ final class DashboardViewControllerClickTests: XCTestCase {
     func testEnteringWorktreeKeepsCollapsedSidebarCollapsed() {
         let vc = DashboardViewController()
         vc.loadViewIfNeeded()
-        vc.updatePanes([makePane(id: "agent-a", worktreePath: "/repo/a")])
+        vc.updatePanes([makePane(name: "agent-a", worktreePath: "/repo/a")])
         vc.adoptChromeCollapse(true, activePane: .firstMate)
         var requestedCollapse: Bool?
         vc.onRequestSetChromeCollapsed = { requestedCollapse = $0 }
@@ -52,11 +52,11 @@ final class DashboardViewControllerClickTests: XCTestCase {
         vc.dashboardDelegate = DashboardDelegateSpy()
         vc.loadViewIfNeeded()
         vc.updatePanes([
-            makePane(id: "agent-a", worktreePath: "/repo/a"),
-            makePane(id: "agent-b", worktreePath: "/repo/b"),
+            makePane(name: "agent-a", worktreePath: "/repo/a"),
+            makePane(name: "agent-b", worktreePath: "/repo/b"),
         ])
         vc.handleWorktreeRowClickForTesting(path: "/repo/b")
-        XCTAssertEqual(vc.selectedPaneId, "agent-b")
+        XCTAssertEqual(vc.selectedWorktreeId, "/repo/b")
     }
 
     func testRowClickClosesEditorOverlayWhenSwitchingWorktrees() {
@@ -64,16 +64,58 @@ final class DashboardViewControllerClickTests: XCTestCase {
         vc.dashboardDelegate = DashboardDelegateSpy()
         vc.loadViewIfNeeded()
         vc.updatePanes([
-            makePane(id: "agent-a", worktreePath: "/repo/a"),
-            makePane(id: "agent-b", worktreePath: "/repo/b"),
+            makePane(name: "agent-a", worktreePath: "/repo/a"),
+            makePane(name: "agent-b", worktreePath: "/repo/b"),
         ])
         vc.showCenterOverlay(NSView(), title: "file.env")
         XCTAssertTrue(vc.hasCenterOverlayForTesting)
 
         vc.handleWorktreeRowClickForTesting(path: "/repo/b")
 
-        XCTAssertEqual(vc.selectedPaneId, "agent-b")
+        XCTAssertEqual(vc.selectedWorktreeId, "/repo/b")
         XCTAssertFalse(vc.hasCenterOverlayForTesting)
+    }
+
+    // MARK: - Selection survives pane churn
+
+    /// Closing a split pane in the selected worktree used to move the selection
+    /// to an unrelated worktree: a row was identified by whichever of its panes
+    /// registered first, so closing that pane changed the row's id, the stored
+    /// selection matched nothing, and the "validate" fallback landed on the first
+    /// row of the whole fleet. A rebuild that replaces every Station must leave
+    /// the selection exactly where it was.
+    func testClosingAPaneKeepsTheSelectionOnTheSameWorktree() {
+        let vc = DashboardViewController()
+        vc.dashboardDelegate = DashboardDelegateSpy()
+        vc.loadViewIfNeeded()
+        vc.updatePanes([
+            makePane(name: "agent-a", worktreePath: "/repo/a"),
+            makePane(name: "agent-b", worktreePath: "/repo/b"),
+        ])
+        vc.handleWorktreeRowClickForTesting(path: "/repo/b")
+        XCTAssertEqual(vc.selectedWorktreeId, "/repo/b")
+
+        // Same worktrees, freshly built rows carrying brand-new Stations — what a
+        // pane close followed by the next status poll produces.
+        vc.updatePanes([
+            makePane(name: "agent-a", worktreePath: "/repo/a"),
+            makePane(name: "agent-b", worktreePath: "/repo/b"),
+        ])
+
+        XCTAssertEqual(vc.selectedWorktreeId, "/repo/b",
+                       "pane churn inside a worktree must not move the selection")
+    }
+
+    /// The identity a row is keyed by cannot depend on its panes.
+    func testRowIdentityIsTheWorktreePathNotAPane() {
+        let first = makePane(name: "agent-a", worktreePath: "/repo/a")
+        let second = makePane(name: "renamed", worktreePath: "/repo/a")
+
+        XCTAssertEqual(first.id, "/repo/a")
+        XCTAssertEqual(first.id, second.id,
+                       "two builds of the same worktree carry the same row id")
+        XCTAssertNotEqual(first.station.id, second.station.id,
+                          "…even though their Stations differ")
     }
 
     func testCodeEditorKeepsHorizontalScrollerVisible() {
@@ -92,14 +134,14 @@ final class DashboardViewControllerClickTests: XCTestCase {
         vc.dashboardDelegate = spy
         vc.loadViewIfNeeded()
         vc.updatePanes([
-            makePane(id: "agent-a", worktreePath: "/repo/a"),
-            makePane(id: "agent-b", worktreePath: "/repo/b"),
+            makePane(name: "agent-a", worktreePath: "/repo/a"),
+            makePane(name: "agent-b", worktreePath: "/repo/b"),
         ])
         vc.adoptChromeCollapse(false, activePane: .firstMate)
         vc.handleWorktreeRowClickForTesting(path: "/repo/b")
         XCTAssertTrue(spy.didChangeSelectionCalled,
                       "First Mate row selection must notify so the path can be persisted")
-        XCTAssertEqual(vc.selectedPaneId, "agent-b")
+        XCTAssertEqual(vc.selectedWorktreeId, "/repo/b")
     }
 
     /// Regression: split-mode row clicks used to live-preview with
@@ -111,16 +153,16 @@ final class DashboardViewControllerClickTests: XCTestCase {
         vc.dashboardDelegate = DashboardDelegateSpy()
         vc.loadViewIfNeeded()
         vc.updatePanes([
-            makePane(id: "agent-a", worktreePath: "/repo/a"),
-            makePane(id: "agent-b", worktreePath: "/repo/b"),
+            makePane(name: "agent-a", worktreePath: "/repo/a"),
+            makePane(name: "agent-b", worktreePath: "/repo/b"),
         ])
         vc.adoptChromeCollapse(false, activePane: .firstMate)
         XCTAssertEqual(vc.viewMode, .split)
 
         vc.handleWorktreeRowClickForTesting(path: "/repo/b")
 
-        XCTAssertEqual(vc.selectedPaneId, "agent-b")
-        XCTAssertEqual(vc.overviewSelectedIdForTesting, "agent-b")
+        XCTAssertEqual(vc.selectedWorktreeId, "/repo/b")
+        XCTAssertEqual(vc.overviewSelectedIdForTesting, "/repo/b")
     }
 
     // MARK: - ⌃⇥ worktree cycle
@@ -132,16 +174,16 @@ final class DashboardViewControllerClickTests: XCTestCase {
         let vc = DashboardViewController()
         vc.loadViewIfNeeded()
         vc.updatePanes([
-            makePane(id: "agent-a", worktreePath: "/repo/a"),
-            makePane(id: "agent-b", worktreePath: "/repo/b"),
+            makePane(name: "agent-a", worktreePath: "/repo/a"),
+            makePane(name: "agent-b", worktreePath: "/repo/b"),
         ])
         vc.adoptChromeCollapse(false, activePane: .firstMate)
         vc.cycleToWorktree(path: "/repo/a")
 
         vc.cycleToWorktree(path: "/repo/b")
 
-        XCTAssertEqual(vc.selectedPaneId, "agent-b")
-        XCTAssertEqual(vc.overviewSelectedIdForTesting, "agent-b",
+        XCTAssertEqual(vc.selectedWorktreeId, "/repo/b")
+        XCTAssertEqual(vc.overviewSelectedIdForTesting, "/repo/b",
                        "the fleet list is still highlighting the previous worktree")
     }
 
@@ -150,33 +192,32 @@ final class DashboardViewControllerClickTests: XCTestCase {
     func testCycleToWorktreeTracksSelectionWithoutARenderedRow() {
         let vc = DashboardViewController()
         vc.loadViewIfNeeded()
-        vc.updatePanes([makePane(id: "agent-a", worktreePath: "/repo/a")])
+        vc.updatePanes([makePane(name: "agent-a", worktreePath: "/repo/a")])
 
         vc.cycleToWorktree(path: "/repo/a")
 
-        XCTAssertEqual(vc.overviewSelectedIdForTesting, "agent-a")
+        XCTAssertEqual(vc.overviewSelectedIdForTesting, "/repo/a")
     }
 
     func testCommitWorktreeSelectionRestoresOverviewHighlight() {
         let vc = DashboardViewController()
         vc.loadViewIfNeeded()
         vc.updatePanes([
-            makePane(id: "agent-a", worktreePath: "/repo/a"),
-            makePane(id: "agent-b", worktreePath: "/repo/b"),
+            makePane(name: "agent-a", worktreePath: "/repo/a"),
+            makePane(name: "agent-b", worktreePath: "/repo/b"),
         ])
         vc.adoptChromeCollapse(false, activePane: .firstMate)
         vc.commitWorktreeSelection(path: "/repo/b")
-        XCTAssertEqual(vc.selectedPaneId, "agent-b")
+        XCTAssertEqual(vc.selectedWorktreeId, "/repo/b")
     }
 }
 
 // MARK: - Test helpers
 
-private func makePane(id: String, worktreePath: String) -> WorktreeRowInfo {
+private func makePane(name: String, worktreePath: String) -> WorktreeRowInfo {
     let surface = Station()
     return WorktreeRowInfo(
-        id: id,
-        name: id,
+        name: name,
         project: "proj",
         thread: "main",
         paneStatuses: [.idle],
@@ -196,7 +237,7 @@ private func makePane(id: String, worktreePath: String) -> WorktreeRowInfo {
         lastActivityAge: "",
         lastActivityAt: nil,
         gitStats: nil,
-        currentPaneTitle: id,
+        currentPaneTitle: name,
         currentPaneRunTime: ""
     )
 }


### PR DESCRIPTION
Two independent First Mate fleet-list bugs, both reported from live use.

## 1. Scrolling left a trail of "selected" rows

Each `RowView` painted its own hover tint from its own tracking area. AppKit pairs `mouseEntered`/`mouseExited` off pointer **movement**, so scrolling the list under a stationary cursor delivers an enter for every row that slides beneath it and no matching exit — every row the pointer passed stayed tinted, and the list read as a dozen rows selected at once.

The list now owns hover instead of the rows:

- enters preempt (the previously lit row is forced off), stale exits only count for the row the list still believes is lit — at most one row can be tinted no matter which events AppKit drops
- a `boundsDidChangeNotification` observer on the scroll's content view re-resolves the hovered row from the pointer's actual position, so scrolling can't desync it
- clears on full rebuild, when the pointer leaves the visible rect, and when the window isn't key

## 2. Closing a split pane jumped to another worktree

A worktree row was identified by whichever of its panes registered first (`WorktreeRowInfo.id = agent.id` in `buildWorktreeRowInfos`). So:

1. close that pane → `AgentRegistry.unregister` drops it from `orderedIDs`
2. next rebuild → the row comes back with a **different** id (the next surviving pane)
3. `updatePanes`' validate step finds the stored selection matches no row and falls back to `agents.first` — **the first row of the whole fleet**
4. `structureChanged` is true, so `rebuildFocusLayout()` re-embeds that other worktree's split container

Splitting in worktree A and closing the *original* pane moved the terminal to an unrelated worktree; closing the *new* pane didn't — which is why it read as intermittent.

A worktree outlives every pane inside it, so its path is now the row identity — as a **computed** property, so a pane id can't be passed in again:

```swift
var id: String { worktreePath }
```

`selectedPaneId` is renamed `selectedWorktreeId` to match what it has always actually held; that name is precisely what made the bug invisible. The validate step is unchanged but now only fires when the selected worktree is genuinely gone.

Also makes `AgentRegistry.reorder` stable: its comparator calls every pane of the same worktree equal and `sort` is not a stable sort, so it could permute panes within a worktree and change the representative on its own — same symptom, reachable without closing anything.

## Tests

- `testHoverTintNeverLandsOnMoreThanOneRow` — three enters with no exits, plus a stale exit; only the last row stays lit
- `testClosingAPaneKeepsTheSelectionOnTheSameWorktree` — rebuild every row with brand-new `Station`s (what a pane close + the next status poll produces); the selection must not move. Fails before this change
- `testRowIdentityIsTheWorktreePathNotAPane` — two builds of the same worktree share a row id despite different `Station`s
- both test helpers changed from `makePane(id:)` to `makePane(name:)` with path-based assertions, so they exercise the real invariant rather than an id they invented

1660 unit tests pass.

## Note for remote clients

`worktreeGroups` ships each item's `"id"` over the control socket; that value changes from a pane's station id to the worktree path (`"worktree_path"` is unchanged and was already present). Fine for any client treating it as an opaque row key — a client using it to address a *pane* was already broken by pane closes, which is the bug being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)