### PR TITLE
fix: count untracked lines in the dashboard's +/- badge

### DIFF
--- a/Sources/Git/WorktreeGitStats.swift
+++ b/Sources/Git/WorktreeGitStats.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 /// Lightweight per-worktree git summary for the dashboard cards: working-tree
-/// diff size (added/removed lines vs HEAD) plus ahead/behind vs the branch's
-/// upstream. Deliberately cheap — no hunk parsing, just `--numstat` and a
-/// `rev-list` count — so it can be polled behind a short-TTL cache.
+/// diff size (added/removed lines vs HEAD, including files git does not track
+/// yet) plus ahead/behind vs the branch's upstream. Deliberately cheap — no hunk
+/// parsing, just `--numstat`, an `ls-files` walk and a `rev-list` count — so it
+/// can be polled behind a short-TTL cache.
 struct WorktreeGitStats: Equatable {
     var added: Int = 0
     var removed: Int = 0
@@ -20,6 +21,22 @@ struct WorktreeGitStats: Equatable {
 enum WorktreeGitStatsProvider {
     private static let gitTimeout: TimeInterval = 5
 
+    /// Wider deadline for the one call that walks the working tree rather than
+    /// reading the index. Matches `WorktreeFileIndex`, which pays the same cost.
+    private static let listTimeout: TimeInterval = 30
+
+    /// Caps on the untracked pass, so one stray multi-gigabyte file an agent
+    /// left behind cannot stall a poll that runs every few seconds. A file over
+    /// the per-file ceiling is skipped outright rather than counted in part —
+    /// at that size it is a log or an asset, not the work the card is reporting.
+    private static let maxUntrackedFiles = 500
+    private static let maxUntrackedBytes = 8 << 20
+    private static let maxUntrackedFileBytes = 4 << 20
+
+    /// How far git looks for a NUL before calling a blob binary. Mirrored here
+    /// so our counts agree with the `-` numstat prints for binary files.
+    private static let binarySniffWindow = 8000
+
     static func stats(worktreePath: String) -> WorktreeGitStats {
         var result = WorktreeGitStats()
 
@@ -34,6 +51,12 @@ enum WorktreeGitStatsProvider {
             }
         }
 
+        // `diff HEAD` sees staged additions but is blind to files git does not
+        // track at all — which is the most common shape of agent work, since an
+        // agent writes new files and leaves staging to the user. Without this
+        // the card reports +0 for a worktree the agent just filled with code.
+        result.added += untrackedAddedLines(worktreePath: worktreePath)
+
         // Ahead/behind vs upstream. `left-right` prints "<behind>\t<ahead>".
         // Exits non-zero when no upstream is configured — leave both nil.
         if let counts = runGit(["rev-list", "--count", "--left-right", "@{upstream}...HEAD"], at: worktreePath) {
@@ -47,8 +70,73 @@ enum WorktreeGitStatsProvider {
         return result
     }
 
-    private static func runGit(_ arguments: [String], at path: String) -> String? {
-        GitProcess.run(arguments, in: path, timeout: gitTimeout)
+    /// Lines in files git does not track yet, counted the way `--numstat` would
+    /// have if they were staged: newlines, plus one for a trailing partial line,
+    /// and nothing at all for binary files. `--exclude-standard` keeps ignored
+    /// build output from being mistaken for the agent's work.
+    static func untrackedAddedLines(worktreePath: String) -> Int {
+        guard let output = runGit(
+            ["ls-files", "--others", "--exclude-standard", "-z"],
+            at: worktreePath,
+            timeout: listTimeout
+        ) else { return 0 }
+
+        let root = URL(fileURLWithPath: worktreePath)
+        var total = 0
+        var budget = maxUntrackedBytes
+        for path in output.split(separator: "\0", omittingEmptySubsequences: true).prefix(maxUntrackedFiles) {
+            guard budget > 0 else { break }
+            guard let data = readForCounting(root.appendingPathComponent(String(path))) else { continue }
+            budget -= data.count
+            total += lineCount(of: data)
+        }
+        return total
+    }
+
+    /// Reads a whole untracked file, or nothing if it is empty or outsized.
+    ///
+    /// Deliberately a bounded `FileHandle` read and not a memory map: these are
+    /// files an agent is actively writing, and a mapped file truncated out from
+    /// under us faults the process rather than failing the read.
+    private static func readForCounting(_ url: URL) -> Data? {
+        guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize,
+              size > 0, size <= maxUntrackedFileBytes,
+              let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        return try? handle.read(upToCount: size)
+    }
+
+    /// Lines in one blob, with git's binary rule applied first.
+    private static func lineCount(of data: Data) -> Int {
+        guard !data.isEmpty else { return 0 }
+        return data.withUnsafeBytes { raw -> Int in
+            guard let base = raw.baseAddress else { return 0 }
+            let newline = UInt8(ascii: "\n")
+            // Binary files are the ones numstat prints "-" for; they contribute
+            // no line counts, so neither should we.
+            if memchr(base, Int32(0), min(raw.count, binarySniffWindow)) != nil { return 0 }
+
+            var lines = 0
+            var cursor = base
+            var remaining = raw.count
+            while remaining > 0, let hit = memchr(cursor, Int32(newline), remaining) {
+                lines += 1
+                let consumed = UnsafeRawPointer(hit) - cursor + 1
+                cursor = UnsafeRawPointer(hit) + 1
+                remaining -= consumed
+            }
+            // A last line with no terminator still counts as a line.
+            if remaining > 0 { lines += 1 }
+            return lines
+        }
+    }
+
+    private static func runGit(
+        _ arguments: [String],
+        at path: String,
+        timeout: TimeInterval = gitTimeout
+    ) -> String? {
+        GitProcess.run(arguments, in: path, timeout: timeout)
     }
 }
 

--- a/Tests/WorktreeGitStatsTests.swift
+++ b/Tests/WorktreeGitStatsTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import seahelm
+
+/// Covers the +/- badge on the dashboard card. The case that matters most is
+/// the untracked one: an agent writes new files and leaves staging to the user,
+/// so a card driven by `git diff HEAD` alone reports nothing for a worktree the
+/// agent just filled with code.
+final class WorktreeGitStatsTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        super.tearDown()
+    }
+
+    func testUntrackedFileCountsTowardAdded() throws {
+        let repo = try makeRepo()
+        try "a\nb\nc\nd\n".write(toFile: repo + "/tracked.txt", atomically: true, encoding: .utf8)
+        try "p\nq\n".write(toFile: repo + "/staged-new.txt", atomically: true, encoding: .utf8)
+        runGit(["add", "staged-new.txt"], in: repo)
+        try "x\ny\nz\n".write(toFile: repo + "/brand-new.txt", atomically: true, encoding: .utf8)
+
+        // 1 tracked edit + 2 staged + 3 untracked.
+        XCTAssertEqual(WorktreeGitStatsProvider.stats(worktreePath: repo).added, 6)
+    }
+
+    func testLastLineWithoutNewlineStillCounts() throws {
+        let repo = try makeRepo()
+        try "one\ntwo".write(toFile: repo + "/partial.txt", atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(WorktreeGitStatsProvider.untrackedAddedLines(worktreePath: repo), 2)
+    }
+
+    /// numstat prints "-" for binary blobs rather than a count, so the untracked
+    /// pass must not invent one either.
+    func testUntrackedBinaryFileContributesNothing() throws {
+        let repo = try makeRepo()
+        var bytes = Data([0x00, 0x01, 0x02])
+        bytes.append(contentsOf: [UInt8](repeating: UInt8(ascii: "\n"), count: 40))
+        try bytes.write(to: URL(fileURLWithPath: repo + "/blob.bin"))
+
+        XCTAssertEqual(WorktreeGitStatsProvider.untrackedAddedLines(worktreePath: repo), 0)
+    }
+
+    /// `--exclude-standard`: build output is not the agent's work.
+    func testIgnoredFilesAreNotCounted() throws {
+        let repo = try makeRepo()
+        try "build/\n".write(toFile: repo + "/.gitignore", atomically: true, encoding: .utf8)
+        runGit(["add", ".gitignore"], in: repo)
+        runGit(["-c", "user.name=Test", "-c", "user.email=test@example.com",
+                "commit", "-m", "ignore build"], in: repo)
+        try FileManager.default.createDirectory(atPath: repo + "/build", withIntermediateDirectories: true)
+        try "junk\njunk\njunk\n".write(toFile: repo + "/build/out.txt", atomically: true, encoding: .utf8)
+
+        XCTAssertEqual(WorktreeGitStatsProvider.untrackedAddedLines(worktreePath: repo), 0)
+    }
+
+    func testEmptyUntrackedFileCountsNoLines() throws {
+        let repo = try makeRepo()
+        FileManager.default.createFile(atPath: repo + "/empty.txt", contents: Data())
+
+        XCTAssertEqual(WorktreeGitStatsProvider.untrackedAddedLines(worktreePath: repo), 0)
+    }
+
+    func testCleanWorktreeReportsNothing() throws {
+        let repo = try makeRepo()
+        let stats = WorktreeGitStatsProvider.stats(worktreePath: repo)
+        XCTAssertEqual(stats.added, 0)
+        XCTAssertEqual(stats.removed, 0)
+        // No upstream configured — ahead/behind stay unknown rather than zero.
+        XCTAssertNil(stats.ahead)
+        XCTAssertNil(stats.behind)
+        XCTAssertTrue(stats.isEmpty)
+    }
+
+    // MARK: - helpers
+
+    private func makeRepo() throws -> String {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-gitstats-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let repo = tempDir.appendingPathComponent("repo").path
+        runGit(["init", "-b", "main", repo], in: tempDir.path)
+        try "a\nb\nc\n".write(toFile: repo + "/tracked.txt", atomically: true, encoding: .utf8)
+        runGit(["add", "."], in: repo)
+        runGit(["-c", "user.name=Test", "-c", "user.email=test@example.com",
+                "commit", "-m", "init"], in: repo)
+        return repo
+    }
+
+    private func runGit(_ args: [String], in directory: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = URL(fileURLWithPath: directory)
+        let err = Pipe()
+        process.standardOutput = Pipe()
+        process.standardError = err
+        try? process.run()
+        let errData = err.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, String(data: errData, encoding: .utf8) ?? "")
+    }
+}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		539E3AA254683CFEB1515713 /* ZmxSessionRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B767FA4381095CD7B0F537CF /* ZmxSessionRecovery.swift */; };
 		53CB2A1C620681FD4477E378 /* UpdateBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A07652F0DCD0488FA748B2 /* UpdateBanner.swift */; };
 		53D46BF1B3E00A35B53A86C4 /* AgentTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D445453693B8D5A3D088F1 /* AgentTypeTests.swift */; };
+		54A772E67F151CB1257995CD /* WorktreeGitStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17E46AFD48BFAA312D7D627 /* WorktreeGitStatsTests.swift */; };
 		5565D8E023C238A5639D04C4 /* ControlProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42D823B95AEE78F60FE2DFB1 /* ControlProtocol.swift */; };
 		55837BD097FC8B76C4C8E3DB /* ActivityFeedRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A43BFEA80D85BEB85CE0125 /* ActivityFeedRendererTests.swift */; };
 		55C5B0B646137831DCA9D1E9 /* PairingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD049D511655E149E38EA48 /* PairingWindowController.swift */; };
@@ -728,6 +729,7 @@
 		9F66DA28CC57BFA18891872D /* WebhookEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebhookEvent.swift; sourceTree = "<group>"; };
 		A07E3B53FF30705F3C18D603 /* PaneHistoryBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneHistoryBuffer.swift; sourceTree = "<group>"; };
 		A0FFC00EE90A3DAECD6396FC /* HostGatewayFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayFrame.swift; sourceTree = "<group>"; };
+		A17E46AFD48BFAA312D7D627 /* WorktreeGitStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeGitStatsTests.swift; sourceTree = "<group>"; };
 		A51B009382FE3586E735355D /* CodexHooksSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHooksSetup.swift; sourceTree = "<group>"; };
 		A5943C79014C5FE35819487C /* ScanDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDecoder.swift; sourceTree = "<group>"; };
 		A657EAE120C252D650A7961B /* FileTreeOutlineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeOutlineController.swift; sourceTree = "<group>"; };
@@ -1454,6 +1456,7 @@
 				810968D6A752BC9C5B9C5F27 /* WorktreeDeleterTests.swift */,
 				22DBAC51DE05D73135AD2889 /* WorktreeDiscoveryTests.swift */,
 				75619FAA0B399E6EFEFD58ED /* WorktreeFileIndexTests.swift */,
+				A17E46AFD48BFAA312D7D627 /* WorktreeGitStatsTests.swift */,
 				448BBAB293764647E8FDB894 /* WorktreeGroupingTests.swift */,
 				6C1E76E23951B9F8DB873E3C /* WorktreePathIndexTests.swift */,
 				4C97F6C22C29552377720F4D /* WorktreePathNavigationTests.swift */,
@@ -1990,6 +1993,7 @@
 				BAC8750B961A40953BC4841F /* WorktreeDeleterTests.swift in Sources */,
 				02D9F0D1B7092AAE247A22A1 /* WorktreeDiscoveryTests.swift in Sources */,
 				AEA66E4248E88862ECCF3D07 /* WorktreeFileIndexTests.swift in Sources */,
+				54A772E67F151CB1257995CD /* WorktreeGitStatsTests.swift in Sources */,
 				2D473084E59DC7776E010F78 /* WorktreeGroupingTests.swift in Sources */,
 				831980CBE1E33D059A978E82 /* WorktreePathIndexTests.swift in Sources */,
 				80C1779FA957EF77BB2331A1 /* WorktreePathNavigationTests.swift in Sources */,


### PR DESCRIPTION
## The bug

`WorktreeGitStatsProvider` computed the card's `+N/-M` from `git diff --numstat HEAD`. That command sees staged additions but is **blind to files git does not track at all** — so a worktree an agent had just filled with new code reported `+0`.

That is the most common shape of agent work: an agent writes new files and leaves staging to the user. `GitDiff` already passed `--untracked-files=all` for the Changes list, so the dashboard card and the side panel disagreed about the same worktree.

This PR is its own repro. Before / after, on the diff it contains:

```
tracked:    93  5  Sources/Git/WorktreeGitStats.swift
             4  0  seahelm.xcodeproj/project.pbxproj
untracked:            Tests/WorktreeGitStatsTests.swift   ← 107 lines, invisible
```

Old: `+97`. Actual: `+204`. The 107 invisible lines are a new test file — exactly what an agent produces.

## The fix

A second pass over `git ls-files --others --exclude-standard -z`, counting lines in Swift.

**Why not stage into a temp index.** The more git-native option was `GIT_INDEX_FILE=<tmp> git add -A -N` and let git count. Rejected: agents run git concurrently in these worktrees, and this is a read path polled every few seconds — writing an index or blobs is risk for nothing.

**Why not mmap.** The first draft used `Data(contentsOf:options:.mappedIfSafe)`. A mapped file truncated out from under us raises SIGBUS and takes the process down, and these are files an agent is actively writing. Replaced with a bounded `FileHandle.read(upToCount:)`.

**Bounds.** 500 files / 8 MiB total / 4 MiB per file. Outsized files are skipped outright rather than counted in part — at that size it is a log or an asset, not the work the card reports.

**git-compatible counting.** A NUL in the first 8000 bytes means binary and contributes nothing (matching the `-` numstat prints); a last line with no terminator still counts as a line.

## Performance

Cheaper than feared. On this repo the `ls-files` walk measures **14ms**, against **25ms** for the `diff` call it joins — `--exclude-standard` prunes ignored directories and never enters the `ghostty` submodule.

## Tests

`Tests/WorktreeGitStatsTests.swift` — the first tests for this file. 6 cases: untracked counted, last line without newline, binary contributes nothing, `.gitignore` respected, empty file, clean worktree (including `ahead`/`behind` staying `nil` with no upstream).

All 6 pass; the neighbouring 46 git tests (`GitDiffTests`, `WorktreeDiscoveryTests`, `WorktreeCreatorTests`, `WorktreeDeleterTests`) show no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
