### PR TITLE
fix: stop naming every detached worktree "(detached)"

### DIFF
--- a/Sources/Git/WorktreeDiscovery.swift
+++ b/Sources/Git/WorktreeDiscovery.swift
@@ -2,9 +2,27 @@ import Foundation
 
 struct WorktreeInfo {
     let path: String
+    /// Empty when the worktree is checked out at a bare commit — see `isDetached`.
     let branch: String
     let commitHash: String
     let isMainWorktree: Bool
+    /// A worktree sitting on a commit rather than a branch. Rare by hand, but
+    /// the normal state for a jj workspace, which is anonymous by design.
+    let isDetached: Bool
+
+    init(
+        path: String,
+        branch: String,
+        commitHash: String,
+        isMainWorktree: Bool,
+        isDetached: Bool = false
+    ) {
+        self.path = path
+        self.branch = branch
+        self.commitHash = commitHash
+        self.isMainWorktree = isMainWorktree
+        self.isDetached = isDetached
+    }
 
     var displayName: String {
         return branch.isEmpty ? URL(fileURLWithPath: path).lastPathComponent : branch
@@ -126,6 +144,7 @@ enum WorktreeDiscovery {
         var currentBranch = ""
         var currentCommit = ""
         var isMainWorktree = false
+        var isDetached = false
 
         for line in output.components(separatedBy: "\n") {
             if line.isEmpty {
@@ -135,13 +154,15 @@ enum WorktreeDiscovery {
                         path: path,
                         branch: currentBranch,
                         commitHash: currentCommit,
-                        isMainWorktree: isMainWorktree
+                        isMainWorktree: isMainWorktree,
+                        isDetached: isDetached
                     ))
                 }
                 currentPath = nil
                 currentBranch = ""
                 currentCommit = ""
                 isMainWorktree = false
+                isDetached = false
             } else if line.hasPrefix("worktree ") {
                 currentPath = String(line.dropFirst("worktree ".count))
                     .trimmingCharacters(in: .whitespaces)
@@ -162,7 +183,11 @@ enum WorktreeDiscovery {
             } else if line == "bare" {
                 // bare worktree, skip
             } else if line == "detached" {
-                currentBranch = "(detached)"
+                // Leave `branch` empty rather than naming it "(detached)": that
+                // string is not a branch, it defeats the directory-name fallback
+                // in `displayName`, and it makes every detached worktree look
+                // like the same one to anything matching on branch name.
+                isDetached = true
             }
         }
 
@@ -172,7 +197,8 @@ enum WorktreeDiscovery {
                 path: path,
                 branch: currentBranch,
                 commitHash: currentCommit,
-                isMainWorktree: isMainWorktree
+                isMainWorktree: isMainWorktree,
+                isDetached: isDetached
             ))
         }
 

--- a/Tests/WorktreeDiscoveryTests.swift
+++ b/Tests/WorktreeDiscoveryTests.swift
@@ -58,7 +58,48 @@ final class WorktreeDiscoveryTests: XCTestCase {
         """
         let worktrees = WorktreeDiscovery.parsePorcelain(output)
         XCTAssertEqual(worktrees.count, 1)
-        XCTAssertEqual(worktrees[0].branch, "(detached)")
+        XCTAssertTrue(worktrees[0].isDetached)
+        // Not "(detached)": that is not a branch name, and leaving it empty is
+        // what lets `displayName` fall back to the directory.
+        XCTAssertEqual(worktrees[0].branch, "")
+        XCTAssertEqual(worktrees[0].displayName, "project")
+    }
+
+    /// Detachment is per entry, so a detached worktree must not mark the branched
+    /// one that follows it.
+    func testParseDetachedDoesNotLeakIntoNextEntry() {
+        let output = """
+        worktree /Users/dev/project
+        HEAD abc1234567890
+        detached
+
+        worktree /Users/dev/project-feature
+        HEAD def4567890123
+        branch refs/heads/feature-x
+
+        """
+        let worktrees = WorktreeDiscovery.parsePorcelain(output)
+        XCTAssertEqual(worktrees.count, 2)
+        XCTAssertTrue(worktrees[0].isDetached)
+        XCTAssertFalse(worktrees[1].isDetached)
+        XCTAssertEqual(worktrees[1].branch, "feature-x")
+    }
+
+    /// Two anonymous worktrees have to stay tellable apart — under "(detached)"
+    /// they shared a name, which is how a jj-style fleet would collide.
+    func testDetachedWorktreesGetDistinctDisplayNames() {
+        let output = """
+        worktree /Users/dev/.worktrees/agent1
+        HEAD abc1234567890
+        detached
+
+        worktree /Users/dev/.worktrees/agent2
+        HEAD def4567890123
+        detached
+
+        """
+        let worktrees = WorktreeDiscovery.parsePorcelain(output)
+        XCTAssertEqual(worktrees.map(\.displayName), ["agent1", "agent2"])
     }
 
     func testParseEmptyOutput() {
@@ -137,7 +178,8 @@ final class WorktreeDiscoveryTests: XCTestCase {
     }
 
     func testDisplayName_FallsBackToDirectoryWhenDetached() {
-        let info = WorktreeInfo(path: "/Users/dev/project", branch: "", commitHash: "abc", isMainWorktree: true)
+        let info = WorktreeInfo(path: "/Users/dev/project", branch: "", commitHash: "abc",
+                                isMainWorktree: true, isDetached: true)
         XCTAssertEqual(info.displayName, "project")
     }
 


### PR DESCRIPTION
## The bug

`parsePorcelain` turned git's `detached` marker into a branch *name*:

```swift
} else if line == "detached" {
    currentBranch = "(detached)"
}
```

`"(detached)"` is not a branch, and being non-empty it defeats the fallback in `displayName`:

```swift
return branch.isEmpty ? URL(fileURLWithPath: path).lastPathComponent : branch
```

So every detached worktree is labelled `(detached)` — several of them share one name — and the directory-name fallback can never fire.

The intent was already recorded in the suite. `testDisplayName_FallsBackToDirectoryWhenDetached` constructs `branch: ""` and expects the directory name, but the real pipeline never produces that state: the test passed while covering an unreachable case. Its neighbouring comment says it outright — "the directory name is only the fallback for a detached checkout".

Downstream, anything keyed on branch name saw those worktrees as one:

- `QuickSwitcherViewController.swift:201` — `info.branch.isEmpty ? info.displayName : info.branch` was waiting for an empty string that never arrived.
- `BridgeCommand.swift:120` — `worktrees.first(where: { $0.branch.lowercased() == name.lowercased() })` could not tell them apart.

## The fix

Detachment becomes its own field instead of a fake branch name. `branch` stays empty — which is what lets the fallback fire — and `isDetached` keeps the signal for callers that want it. The new explicit init defaults `isDetached` to `false`, so the existing construction sites (6 in `Sources/`, plus the tests) are untouched.

## Why it matters now

It is a latent bug today: any hand-made detached worktree hits it. It becomes structural for anonymous checkouts, where *every* worktree is detached — a throwaway integration worktree created with `git worktree add --detach`, for instance, would show up on the card as `(detached)` rather than by name.

## Tests

`WorktreeDiscoveryTests` 13/13.

`testParseDetachedHead` asserted `branch == "(detached)"`; it now asserts `isDetached`, an empty `branch`, and the resolved `displayName`. Two added:

- `testParseDetachedDoesNotLeakIntoNextEntry` — detachment is per entry, so a detached worktree must not mark the branched one after it. This is the bug you get by forgetting to reset the flag.
- `testDetachedWorktreesGetDistinctDisplayNames` — `.worktrees/agent1` and `agent2` must resolve to two different names, i.e. the original defect in its natural habitat.

App builds; the 54 neighbouring tests around `WorktreeInfo` consumers (`PaneTransferTests`, `TabCoordinatorTests`, `WorktreeCreatorTests`, `WorktreeGitStatsTests`, `WorktreeGroupingTests`, `WorktreePathIndexTests`) show no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
