### PR TITLE
fix: diff a stacked worktree against the branch it sits on

### DIFF
--- a/Sources/Core/PersistedStringMap.swift
+++ b/Sources/Core/PersistedStringMap.swift
@@ -32,6 +32,16 @@ final class PersistedStringMap {
         persist(snapshot)
     }
 
+    /// Drop a key. Worktree paths get reused — a stale entry left behind by a
+    /// deleted worktree would answer for whatever is created at that path next.
+    func remove(forKey key: String) {
+        lock.lock()
+        guard map.removeValue(forKey: key) != nil else { lock.unlock(); return }
+        let snapshot = map
+        lock.unlock()
+        persist(snapshot)
+    }
+
     private func persist(_ snapshot: [String: String]) {
         DispatchQueue.global(qos: .utility).async {
             try? FileManager.default.createDirectory(at: Config.configDir, withIntermediateDirectories: true)

--- a/Sources/Core/WorktreeBaseBranchStore.swift
+++ b/Sources/Core/WorktreeBaseBranchStore.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Persists the branch a worktree was created from, keyed by worktree path.
+///
+/// git does not record this: `git worktree add -b B <path> A` leaves no trace
+/// that `A` was the base, and `-b` off a local branch sets no upstream either.
+/// So a worktree stacked on another agent's branch is indistinguishable from
+/// one cut off main — which is why the diff base used to be guessed from a
+/// fixed list of trunk names, and why a stacked worktree showed the branch
+/// below it as its own work.
+///
+/// seahelm does know: the user picked the base in the new-branch dialog. This
+/// just remembers it. Stored as JSON alongside config.json
+/// (`~/.config/seahelm/worktree-bases.json`).
+final class WorktreeBaseBranchStore {
+    static let shared = WorktreeBaseBranchStore()
+
+    private let store = PersistedStringMap(fileName: "worktree-bases.json")
+
+    private init() {}
+
+    /// The branch this worktree was cut from, if seahelm created it.
+    func baseBranch(forWorktree path: String) -> String? {
+        guard let value = store[path]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else { return nil }
+        return value
+    }
+
+    /// Record the base at creation time.
+    func set(_ baseBranch: String, forWorktree path: String) {
+        let trimmed = baseBranch.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        store.set(trimmed, forKey: path)
+    }
+
+    /// Forget a deleted worktree, so a later worktree at the same path does not
+    /// inherit its base.
+    func forget(worktreePath path: String) {
+        store.remove(forKey: path)
+    }
+}

--- a/Sources/Git/GitDiff.swift
+++ b/Sources/Git/GitDiff.swift
@@ -233,9 +233,22 @@ enum GitDiff {
         worktreePath: String,
         limit: Int = maxListedChangedFiles
     ) -> GitBranchChanges {
+        branchChangedFiles(
+            worktreePath: worktreePath,
+            limit: limit,
+            recordedBase: WorktreeBaseBranchStore.shared.baseBranch(forWorktree: worktreePath)
+        )
+    }
+
+    /// Seam for tests — see `resolveBaseRef(worktreePath:recordedBase:)`.
+    static func branchChangedFiles(
+        worktreePath: String,
+        limit: Int = maxListedChangedFiles,
+        recordedBase: String?
+    ) -> GitBranchChanges {
         let uncapped: [GitChangedFile]
         let baseRef: String?
-        if let resolved = resolveBaseRef(worktreePath: worktreePath),
+        if let resolved = resolveBaseRef(worktreePath: worktreePath, recordedBase: recordedBase),
            let mergeBase = mergeBase(with: resolved, worktreePath: worktreePath) {
             baseRef = resolved
             let nameStatus = runGit(
@@ -293,12 +306,33 @@ enum GitDiff {
     }
 
     static func resolveBaseRef(worktreePath: String) -> String? {
-        for ref in preferredBaseRefs {
-            if runGit(args: ["rev-parse", "--verify", "--quiet", ref], in: worktreePath) != nil {
-                return ref
-            }
+        resolveBaseRef(
+            worktreePath: worktreePath,
+            recordedBase: WorktreeBaseBranchStore.shared.baseBranch(forWorktree: worktreePath)
+        )
+    }
+
+    /// Seam for tests, so they can supply a recorded base without writing to
+    /// the user's real store.
+    ///
+    /// What seahelm recorded when it created the worktree beats guessing at a
+    /// trunk name: a worktree stacked on another agent's branch has a base no
+    /// entry in `preferredBaseRefs` can name, and comparing it against trunk
+    /// reports the branch below it as its own work. A recorded base that no
+    /// longer resolves — merged and pruned, or renamed — falls through to the
+    /// trunk guess rather than leaving the panel with no base at all.
+    static func resolveBaseRef(worktreePath: String, recordedBase: String?) -> String? {
+        if let recordedBase, refExists(recordedBase, worktreePath: worktreePath) {
+            return recordedBase
+        }
+        for ref in preferredBaseRefs where refExists(ref, worktreePath: worktreePath) {
+            return ref
         }
         return nil
+    }
+
+    private static func refExists(_ ref: String, worktreePath: String) -> Bool {
+        runGit(args: ["rev-parse", "--verify", "--quiet", ref], in: worktreePath) != nil
     }
 
     private static func mergeBase(with baseRef: String?, worktreePath: String) -> String? {

--- a/Sources/Git/WorktreeCreator.swift
+++ b/Sources/Git/WorktreeCreator.swift
@@ -100,6 +100,11 @@ enum WorktreeCreator {
         let hash = runGit(args: ["rev-parse", "--short", "HEAD"], in: worktreePath)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
+        // Remember what this was cut from. git keeps no record of it, and
+        // without it a worktree stacked on another agent's branch reports that
+        // branch's commits as its own changes.
+        WorktreeBaseBranchStore.shared.set(baseBranch, forWorktree: worktreePath)
+
         // Write seahelm-suggest guidance to worktree
         SuggestGuidanceWriter.writeForWorktree(worktreePath)
 

--- a/Sources/Git/WorktreeDeleter.swift
+++ b/Sources/Git/WorktreeDeleter.swift
@@ -82,6 +82,8 @@ enum WorktreeDeleter {
             throw WorktreeDeleterError.gitFailed(classifyWorktreeRemoveError(stderr, path: worktreePath))
         }
 
+        WorktreeBaseBranchStore.shared.forget(worktreePath: worktreePath)
+
         // Optionally delete the branch
         var branchWarning: String?
         if deleteBranch {

--- a/Tests/StackedWorktreeBaseTests.swift
+++ b/Tests/StackedWorktreeBaseTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import seahelm
+
+/// Covers the diff base for a worktree cut from another worktree's branch.
+///
+/// git records nothing about what a branch was created from, so the base used
+/// to be guessed from a fixed list of trunk names. For a stacked worktree that
+/// guess is wrong in a way that shows: the branch below it appears as its own
+/// work. seahelm does know the base — the user picked it — so these lock in
+/// that it is used, and that a stale record degrades rather than breaks.
+final class StackedWorktreeBaseTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func tearDown() {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        super.tearDown()
+    }
+
+    /// The defect, end to end: `feat/ui` sits on `feat/api`, so `api.py` is not
+    /// its work. Against trunk it was reported as such.
+    func testStackedWorktreeExcludesTheBranchItSitsOn() throws {
+        let repo = try makeStackedRepo()
+
+        let stacked = GitDiff.branchChangedFiles(worktreePath: repo.uiWorktree, recordedBase: "feat/api")
+        XCTAssertEqual(stacked.baseRef, "feat/api")
+        XCTAssertEqual(Set(stacked.files.map(\.path)), ["ui.html"])
+
+        // Without the record, the old trunk guess still reports both files —
+        // this is the behaviour being fixed, kept here so the difference is
+        // visible rather than asserted only in the negative.
+        let guessed = GitDiff.branchChangedFiles(worktreePath: repo.uiWorktree, recordedBase: nil)
+        XCTAssertEqual(guessed.baseRef, "main")
+        XCTAssertEqual(Set(guessed.files.map(\.path)), ["api.py", "ui.html"])
+    }
+
+    func testRecordedBaseWins() throws {
+        let repo = try makeStackedRepo()
+        XCTAssertEqual(
+            GitDiff.resolveBaseRef(worktreePath: repo.uiWorktree, recordedBase: "feat/api"),
+            "feat/api"
+        )
+    }
+
+    /// A base merged upstream and pruned must not leave the panel baseless.
+    func testDeletedBaseFallsBackToTrunk() throws {
+        let repo = try makeStackedRepo()
+        XCTAssertEqual(
+            GitDiff.resolveBaseRef(worktreePath: repo.uiWorktree, recordedBase: "feat/long-gone"),
+            "main"
+        )
+    }
+
+    func testNoRecordKeepsTheTrunkGuess() throws {
+        let repo = try makeStackedRepo()
+        XCTAssertEqual(
+            GitDiff.resolveBaseRef(worktreePath: repo.uiWorktree, recordedBase: nil),
+            "main"
+        )
+    }
+
+    /// An empty or blank record is treated as no record, not as a ref named "".
+    func testBlankRecordIsIgnored() throws {
+        let repo = try makeStackedRepo()
+        XCTAssertEqual(
+            GitDiff.resolveBaseRef(worktreePath: repo.uiWorktree, recordedBase: "   "),
+            "main"
+        )
+    }
+
+    /// Uncommitted work in a stacked worktree still belongs to it.
+    func testUncommittedWorkInAStackedWorktreeIsStillItsOwn() throws {
+        let repo = try makeStackedRepo()
+        try "draft\n".write(toFile: repo.uiWorktree + "/draft.txt", atomically: true, encoding: .utf8)
+
+        let stacked = GitDiff.branchChangedFiles(worktreePath: repo.uiWorktree, recordedBase: "feat/api")
+        XCTAssertEqual(Set(stacked.files.map(\.path)), ["ui.html", "draft.txt"])
+    }
+
+    // MARK: - helpers
+
+    private struct StackedRepo {
+        let root: String
+        let uiWorktree: String
+    }
+
+    /// main ← feat/api (agent A) ← feat/ui (agent B), B in its own worktree.
+    private func makeStackedRepo() throws -> StackedRepo {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-stacked-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let repo = tempDir.appendingPathComponent("repo").path
+        runGit(["init", "-b", "main", repo], in: tempDir.path)
+        try "base\n".write(toFile: repo + "/base.txt", atomically: true, encoding: .utf8)
+        commitAll(in: repo, message: "main: base")
+
+        runGit(["checkout", "-b", "feat/api"], in: repo)
+        try "def endpoint(): pass\n".write(toFile: repo + "/api.py", atomically: true, encoding: .utf8)
+        commitAll(in: repo, message: "A: add endpoint")
+        runGit(["checkout", "main"], in: repo)
+
+        let ui = tempDir.appendingPathComponent("ui").path
+        runGit(["worktree", "add", ui, "-b", "feat/ui", "feat/api"], in: repo)
+        try "<div/>\n".write(toFile: ui + "/ui.html", atomically: true, encoding: .utf8)
+        commitAll(in: ui, message: "B: build the UI")
+
+        return StackedRepo(root: repo, uiWorktree: ui)
+    }
+
+    private func commitAll(in directory: String, message: String) {
+        runGit(["add", "-A"], in: directory)
+        runGit(["-c", "user.name=Test", "-c", "user.email=test@example.com",
+                "commit", "-m", message], in: directory)
+    }
+
+    private func runGit(_ args: [String], in directory: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = URL(fileURLWithPath: directory)
+        let err = Pipe()
+        process.standardOutput = Pipe()
+        process.standardError = err
+        try? process.run()
+        let errData = err.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, String(data: errData, encoding: .utf8) ?? "")
+    }
+}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		0DA6D2D48F320DFB8671C67C /* ClaudeStatuslineBridgeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EFCABEFB8EEA92A8B6FA13 /* ClaudeStatuslineBridgeInstaller.swift */; };
 		0E3AA9FF166CC516F1B7264B /* ZmxChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F98DB046516F2EB312E63F /* ZmxChannel.swift */; };
 		0F1F7BA79FAD1F778C22E92B /* WorktreeTaskStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EEEE2451A4C40006552810 /* WorktreeTaskStore.swift */; };
+		0F42CE97488379120CBB967A /* StackedWorktreeBaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F52B822BB29970B0615304 /* StackedWorktreeBaseTests.swift */; };
 		0F486115B10D4353770B261C /* SessionRestoreConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFAE60D0EF11A5DC22B2B73 /* SessionRestoreConfigTests.swift */; };
 		0FDF118A34CA87216F2FD70D /* GitProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BAEF3139798D53AE355496 /* GitProcess.swift */; };
 		1063EE7F5505310F9DEE6E07 /* SuggestGuidanceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159B10196D13B333CFC76E1D /* SuggestGuidanceWriter.swift */; };
@@ -229,6 +230,7 @@
 		89A6025BEEB8CC143CD40664 /* AgentManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8C0AA934FBBE1D3F9E6831 /* AgentManifest.swift */; };
 		89C41D7167472A785EA66D4F /* JetBrainsMono-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 669FC11510A48A9E8656C26A /* JetBrainsMono-Bold.ttf */; };
 		8AB6456ED364F85D037EBE00 /* RegionFocusControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C1E60B8144F4FB489FADD2 /* RegionFocusControllerTests.swift */; };
+		8ACCD2515815938984A017D8 /* WorktreeBaseBranchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9F931F9258E63CD7AD87773 /* WorktreeBaseBranchStore.swift */; };
 		8B392DCF5756B7062714ED20 /* WorktreeTitleCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A141F8A22DEE7A3DDC6768A /* WorktreeTitleCache.swift */; };
 		8BB5F6D554A6F5BE68613FBA /* ProcessRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DEB2B3541ED551726C6C96 /* ProcessRunnerTests.swift */; };
 		8BBCB395DA0D4E99A6407A59 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56E02C4A6D726C18E655451 /* main.swift */; };
@@ -710,6 +712,7 @@
 		911314F4B91E512511E3FC21 /* EventHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHubTests.swift; sourceTree = "<group>"; };
 		93F4FC4D61D58DD56DB8E9FE /* MailPaneRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailPaneRouter.swift; sourceTree = "<group>"; };
 		95C6B4297D134649B185BC65 /* DividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerView.swift; sourceTree = "<group>"; };
+		95F52B822BB29970B0615304 /* StackedWorktreeBaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedWorktreeBaseTests.swift; sourceTree = "<group>"; };
 		9626FD6C7EE99EAEC76D6443 /* PRURLParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRURLParsingTests.swift; sourceTree = "<group>"; };
 		968213FDE4B08CF2A98DB961 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		975413D32056A4CFFA39C32C /* HostGatewayVTFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayVTFrame.swift; sourceTree = "<group>"; };
@@ -862,6 +865,7 @@
 		E960699EF752C67ED06FF552 /* SplitContainerLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitContainerLayoutTests.swift; sourceTree = "<group>"; };
 		E96EE302F1479073676DB584 /* FirstMateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateTests.swift; sourceTree = "<group>"; };
 		E97FC10F15109A2EF528DD87 /* SeahelmSuggestInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmSuggestInstaller.swift; sourceTree = "<group>"; };
+		E9F931F9258E63CD7AD87773 /* WorktreeBaseBranchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeBaseBranchStore.swift; sourceTree = "<group>"; };
 		EB82719AC58E2E0289564007 /* HookDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookDecoderTests.swift; sourceTree = "<group>"; };
 		EB9C0192916DE1D56E68048E /* StationReparentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationReparentTests.swift; sourceTree = "<group>"; };
 		EBE28FEA6DE230823C9078B5 /* ManifestEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManifestEngine.swift; sourceTree = "<group>"; };
@@ -1039,6 +1043,7 @@
 				F0982B809334A31181947736 /* WatchFeed.swift */,
 				B07FF7C768D8C4871A88AA48 /* WorkspaceManager.swift */,
 				999DBD13511B3A8C4F4D4B8E /* WorktreeAgentTypeStore.swift */,
+				E9F931F9258E63CD7AD87773 /* WorktreeBaseBranchStore.swift */,
 				B18B71C7A49633D6D41985CC /* WorktreeFileIndex.swift */,
 				E1FA2EB699654E9A701124D1 /* WorktreeShellActions.swift */,
 				60EEEE2451A4C40006552810 /* WorktreeTaskStore.swift */,
@@ -1423,6 +1428,7 @@
 				E960699EF752C67ED06FF552 /* SplitContainerLayoutTests.swift */,
 				27B42EEB25FF49236DBABA03 /* SplitContainerRecoveryTests.swift */,
 				B64B6D9AE47DFBCFCF626885 /* SplitNodeTests.swift */,
+				95F52B822BB29970B0615304 /* StackedWorktreeBaseTests.swift */,
 				1C0F7D7F30A3F031DC191AFF /* StationHealthCheckTests.swift */,
 				6D9670C14DA62CDEE9828F5C /* StationRegistryConcurrencyTests.swift */,
 				EB9C0192916DE1D56E68048E /* StationReparentTests.swift */,
@@ -1960,6 +1966,7 @@
 				E2066652132155948F7F9B1F /* SplitContainerLayoutTests.swift in Sources */,
 				01BC534B1823141012EAAAE3 /* SplitContainerRecoveryTests.swift in Sources */,
 				BE5BDE49F57C10D9024D8379 /* SplitNodeTests.swift in Sources */,
+				0F42CE97488379120CBB967A /* StackedWorktreeBaseTests.swift in Sources */,
 				FB6A28074D9ADC1B5DB97F53 /* StationHealthCheckTests.swift in Sources */,
 				6C822061BD36C74213F5D43B /* StationRegistryConcurrencyTests.swift in Sources */,
 				004A9A98C4F160DD44D877A1 /* StationReparentTests.swift in Sources */,
@@ -2252,6 +2259,7 @@
 				7D09CC05B794C0D59CA4146B /* WindowChromeController.swift in Sources */,
 				4BBA37E55963FD4DBDC549E4 /* WorkspaceManager.swift in Sources */,
 				71937D0C72752C62DFBB63C1 /* WorktreeAgentTypeStore.swift in Sources */,
+				8ACCD2515815938984A017D8 /* WorktreeBaseBranchStore.swift in Sources */,
 				B0AF97B3F50FA1567DBD5CD9 /* WorktreeCreator.swift in Sources */,
 				D27F424356DE8B506B1C7C05 /* WorktreeDeleter.swift in Sources */,
 				56D7FA05EEF91495A4DCED81 /* WorktreeDiscovery.swift in Sources */,
@@ -2316,7 +2324,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.51;
+				MARKETING_VERSION = 2.0.52;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",
@@ -2554,7 +2562,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.51;
+				MARKETING_VERSION = 2.0.52;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",


### PR DESCRIPTION
## The bug

The Changes list picked its base by walking a fixed list of trunk names (`GitDiff.swift:115`):

```swift
preferredBaseRefs = ["origin/main", "origin/master", "main", "master"]
```

There was no notion of the base a worktree actually has. For a worktree cut from another worktree's branch — `feat/ui` created on top of `feat/api`, which is what the base picker in `NewBranchDialog` offers and `WorktreeCreator.swift:83` passes to `git worktree add` — the base resolved to main, the merge-base reached below `feat/api`, and every commit from the branch underneath was listed as this worktree's own work:

```
agent B's worktree (feat/ui stacked on feat/api)
  Changes panel showed:   A  api.py     ← agent A's work
                          A  ui.html
  B actually touched:     A  ui.html
```

It is not only a dirty list. `capToRecentFiles` keeps the 100 most recently modified entries, so a deep enough stack pushes a worktree's own files out of the list entirely. FirstMate's review and inspection read the same scope.

## Why it could not be inferred

git records nothing to recover this from. `git worktree add -b B <path> A` leaves no trace that `A` was the base, and `-b` off a local branch sets no upstream either — a stacked worktree is indistinguishable from one cut off main.

But seahelm knows: the user picks the base in the new-branch dialog and it is handed straight to `WorktreeCreator`. It just threw the answer away.

## The fix

`WorktreeBaseBranchStore` records the base at creation, keyed by worktree path — mirroring `WorktreeAgentTypeStore`, which persists the other thing that same dialog collects, and reusing `PersistedStringMap`.

`resolveBaseRef` prefers the recorded base and falls back to the trunk guess when:

- there is no record — worktrees predating this, or created outside seahelm
- the record no longer resolves — a base merged upstream and pruned degrades to the old behaviour rather than leaving the panel with no base at all

`PersistedStringMap` gains `remove`, and `WorktreeDeleter` forgets a worktree on removal: worktree paths get reused, and a stale entry would otherwise answer for whatever is created at that path next.

Both public entry points keep their existing signatures. The recorded base is threaded through overloads so tests can supply one without writing to the user's real `~/.config/seahelm/` store.

## Tests

`StackedWorktreeBaseTests` — 6 cases against a real `main ← feat/api ← feat/ui` repo with `feat/ui` in its own worktree:

- the defect end to end: with the base recorded, only `ui.html`; the same call with no record still reports both files, so the difference is asserted rather than only the fix
- recorded base wins
- deleted base falls back to trunk
- no record keeps the trunk guess
- a blank record is ignored rather than treated as a ref named `""`
- uncommitted work in a stacked worktree is still its own

App builds; 62 neighbouring tests (`GitDiffTests`, `WorktreeCreatorTests`, `WorktreeDeleterTests`, `WorktreeDiscoveryTests`, `WorktreeGitStatsTests`, `WorktreeFileIndexTests`) show no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
