### PR TITLE
feat: a self-maintaining integration checkout for the fleet

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -1290,7 +1290,7 @@ dashboard.stationManager = terminalCoordinator.stationManager
                     )
                     DispatchQueue.main.async {
                         IntegrationWorktreeStore.shared.set(report.integrationWorktreePath, forRepo: repoPath)
-                        IntegrationStatusStore.shared.set(report.cardLine, forWorktree: report.integrationWorktreePath)
+                        IntegrationStatusStore.shared.set(report.panelState, forWorktree: report.integrationWorktreePath)
                     }
                     reply(report.summary)
                 } catch {
@@ -1444,7 +1444,7 @@ dashboard.stationManager = terminalCoordinator.stationManager
                     // checkout, so a failed first run does not leave the store
                     // pointing at a directory that was never created.
                     IntegrationWorktreeStore.shared.set(report.integrationWorktreePath, forRepo: repoPath)
-                    IntegrationStatusStore.shared.set(report.cardLine, forWorktree: report.integrationWorktreePath)
+                    IntegrationStatusStore.shared.set(report.panelState, forWorktree: report.integrationWorktreePath)
                     // A round that published cleanly is meant to be invisible —
                     // the integration worktree is simply current. Only speak up
                     // when something was dropped or held back.

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -849,6 +849,7 @@ class MainWindowController: NSWindowController, MailCommandContext {
 
         // Create dashboard — single permanent LeftRight layout
         let dashboard = DashboardViewController()
+        dashboard.integrationEnabled = config.integrationEnabled
         dashboard.dashboardDelegate = self
         dashboard.hasWorkspaces = { [weak self] in
             !(self?.tabCoordinator.config.workspacePaths.isEmpty ?? true)
@@ -1269,6 +1270,10 @@ dashboard.stationManager = terminalCoordinator.stationManager
         case .integrate(let mode, let force):
             // Nothing here can disturb a worktree until the final checkout, so
             // this is safe to run straight from a message rather than carded.
+            guard config.integrationEnabled else {
+                reply("Integration is turned off in Settings.")
+                return
+            }
             guard let selected = tabCoordinator.config.selectedWorktreePath,
                   let repoPath = WorktreeDiscovery.findRepoRoot(from: selected) else {
                 reply("No repo selected.")
@@ -1418,6 +1423,13 @@ dashboard.stationManager = terminalCoordinator.stationManager
     }
 
     private func runIntegration(repoPath: String, mode: IntegrationConflictMode, force: Bool) {
+        guard config.integrationEnabled else {
+            enqueueIntegrationReport(
+                "Integration is turned off in Settings ▸ General ▸ Integration",
+                repoPath: repoPath
+            )
+            return
+        }
         let worktrees = tabCoordinator.allWorktrees
             .map(\.info)
             .filter { WorktreeDiscovery.findRepoRoot(from: $0.path) == repoPath }
@@ -2835,6 +2847,7 @@ extension MainWindowController: SettingsDelegate {
         tabCoordinator.config = merged
         terminalCoordinator.config = merged
         updateCoordinator.config = merged
+        dashboardVC?.integrationEnabled = merged.integrationEnabled
         normalizeBackendAvailabilityIfNeeded()
 
         let newPaths = Set(config.workspacePaths)

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -1259,7 +1259,7 @@ dashboard.stationManager = terminalCoordinator.stationManager
             openGitHubIssue(title: title)
             reply("Opening GitHub issue for **seahelm**…")
 
-        case .integrate(let mode):
+        case .integrate(let mode, let force):
             // Nothing here can disturb a worktree until the final checkout, so
             // this is safe to run straight from a message rather than carded.
             guard let selected = tabCoordinator.config.selectedWorktreePath,
@@ -1278,10 +1278,12 @@ dashboard.stationManager = terminalCoordinator.stationManager
                         repoPath: repoPath,
                         integrationPath: integrationPath,
                         worktrees: worktrees,
-                        mode: mode
+                        mode: mode,
+                        force: force
                     )
                     DispatchQueue.main.async {
                         IntegrationWorktreeStore.shared.set(report.integrationWorktreePath, forRepo: repoPath)
+                        IntegrationStatusStore.shared.set(report.cardLine, forWorktree: report.integrationWorktreePath)
                     }
                     reply(report.summary)
                 } catch {
@@ -1384,8 +1386,8 @@ dashboard.stationManager = terminalCoordinator.stationManager
             flagIssue: { [weak self] title in
                 self?.openGitHubIssue(title: title)
             },
-            integrate: { [weak self] mode in
-                self?.runIntegration(mode: mode)
+            integrate: { [weak self] mode, force in
+                self?.runIntegration(mode: mode, force: force)
             },
             activePaneCount: { AgentRegistry.shared.allPanes().count },
             branchForPath: { path in AgentRegistry.shared.pane(forWorktree: path)?.branch ?? "" },
@@ -1399,7 +1401,7 @@ dashboard.stationManager = terminalCoordinator.stationManager
     /// the main thread; only the report comes back. Nothing it does before the
     /// final checkout can disturb a worktree, so an interrupted or failed round
     /// simply leaves everything as it was.
-    private func runIntegration(mode: IntegrationConflictMode) {
+    private func runIntegration(mode: IntegrationConflictMode, force: Bool) {
         guard let selected = tabCoordinator.config.selectedWorktreePath,
               let repoPath = WorktreeDiscovery.findRepoRoot(from: selected) else {
             NSSound.beep()
@@ -1418,7 +1420,8 @@ dashboard.stationManager = terminalCoordinator.stationManager
                     repoPath: repoPath,
                     integrationPath: integrationPath,
                     worktrees: worktrees,
-                    mode: mode
+                    mode: mode,
+                    force: force
                 ))
             } catch {
                 outcome = .failure(error)
@@ -1430,6 +1433,7 @@ dashboard.stationManager = terminalCoordinator.stationManager
                     // checkout, so a failed first run does not leave the store
                     // pointing at a directory that was never created.
                     IntegrationWorktreeStore.shared.set(report.integrationWorktreePath, forRepo: repoPath)
+                    IntegrationStatusStore.shared.set(report.cardLine, forWorktree: report.integrationWorktreePath)
                     // A round that published cleanly is meant to be invisible —
                     // the integration worktree is simply current. Only speak up
                     // when something was dropped or held back.

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -1259,6 +1259,36 @@ dashboard.stationManager = terminalCoordinator.stationManager
             openGitHubIssue(title: title)
             reply("Opening GitHub issue for **seahelm**…")
 
+        case .integrate(let mode):
+            // Nothing here can disturb a worktree until the final checkout, so
+            // this is safe to run straight from a message rather than carded.
+            guard let selected = tabCoordinator.config.selectedWorktreePath,
+                  let repoPath = WorktreeDiscovery.findRepoRoot(from: selected) else {
+                reply("No repo selected.")
+                return
+            }
+            let worktrees = tabCoordinator.allWorktrees
+                .map(\.info)
+                .filter { WorktreeDiscovery.findRepoRoot(from: $0.path) == repoPath }
+            let integrationPath = IntegrationWorktreeStore.shared.worktreePath(forRepo: repoPath)
+                ?? IntegrationWorktree.defaultPath(forRepo: repoPath)
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    let report = try IntegrationRunner.run(
+                        repoPath: repoPath,
+                        integrationPath: integrationPath,
+                        worktrees: worktrees,
+                        mode: mode
+                    )
+                    DispatchQueue.main.async {
+                        IntegrationWorktreeStore.shared.set(report.integrationWorktreePath, forRepo: repoPath)
+                    }
+                    reply(report.summary)
+                } catch {
+                    reply("Integration failed: \(error.localizedDescription)")
+                }
+            }
+
         case .removeAll:
             // Cards, exactly as on the desktop. A blind sweep is the one place
             // direct execution could delete several worktrees from one stray line.
@@ -1354,9 +1384,79 @@ dashboard.stationManager = terminalCoordinator.stationManager
             flagIssue: { [weak self] title in
                 self?.openGitHubIssue(title: title)
             },
+            integrate: { [weak self] mode in
+                self?.runIntegration(mode: mode)
+            },
             activePaneCount: { AgentRegistry.shared.allPanes().count },
             branchForPath: { path in AgentRegistry.shared.pane(forWorktree: path)?.branch ?? "" },
             projectForPath: { path in AgentRegistry.shared.pane(forWorktree: path)?.project ?? "" }
+        )
+    }
+
+    /// One `/integrate` round for the current repo.
+    ///
+    /// Snapshotting and merging shell out several times over, so it runs off
+    /// the main thread; only the report comes back. Nothing it does before the
+    /// final checkout can disturb a worktree, so an interrupted or failed round
+    /// simply leaves everything as it was.
+    private func runIntegration(mode: IntegrationConflictMode) {
+        guard let selected = tabCoordinator.config.selectedWorktreePath,
+              let repoPath = WorktreeDiscovery.findRepoRoot(from: selected) else {
+            NSSound.beep()
+            return
+        }
+        let worktrees = tabCoordinator.allWorktrees
+            .map(\.info)
+            .filter { WorktreeDiscovery.findRepoRoot(from: $0.path) == repoPath }
+        let integrationPath = IntegrationWorktreeStore.shared.worktreePath(forRepo: repoPath)
+            ?? IntegrationWorktree.defaultPath(forRepo: repoPath)
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let outcome: Result<IntegrationRunReport, Error>
+            do {
+                outcome = .success(try IntegrationRunner.run(
+                    repoPath: repoPath,
+                    integrationPath: integrationPath,
+                    worktrees: worktrees,
+                    mode: mode
+                ))
+            } catch {
+                outcome = .failure(error)
+            }
+            DispatchQueue.main.async { [weak self] in
+                switch outcome {
+                case .success(let report):
+                    // Record only once the round got far enough to have a
+                    // checkout, so a failed first run does not leave the store
+                    // pointing at a directory that was never created.
+                    IntegrationWorktreeStore.shared.set(report.integrationWorktreePath, forRepo: repoPath)
+                    // A round that published cleanly is meant to be invisible —
+                    // the integration worktree is simply current. Only speak up
+                    // when something was dropped or held back.
+                    if report.needsAttention {
+                        self?.enqueueIntegrationReport(report.summary, repoPath: repoPath)
+                    }
+                case .failure(let error):
+                    self?.enqueueIntegrationReport(
+                        "Integration failed: \(error.localizedDescription)",
+                        repoPath: repoPath
+                    )
+                }
+            }
+        }
+    }
+
+    private func enqueueIntegrationReport(_ message: String, repoPath: String) {
+        tabCoordinator.pendingOrders.enqueue(
+            FirstMateAction(
+                kind: .integrationReport,
+                zone: .red,
+                worktreePath: repoPath,
+                branch: "",
+                project: tabCoordinator.repoName(forWorktree: repoPath),
+                terminalID: "",
+                message: message
+            )
         )
     }
 

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -924,6 +924,13 @@ dashboard.stationManager = terminalCoordinator.stationManager
             // its createForm keyboard substate were removed).
             self?.tabCoordinator.dashboardVC?.focusInlineCreate()
         }
+        dashboard.onIntegrateProject = { [weak self] project in
+            guard let self, let repoPath = self.tabCoordinator.repoPath(forProject: project) else {
+                NSSound.beep()
+                return
+            }
+            self.runIntegration(repoPath: repoPath, mode: .excludeConflicting, force: false)
+        }
         dashboard.onAddWorktreeToProject = { [weak self] project, rect, anchor in
             self?.presentAddWorktreePopover(project: project, rect: rect, anchor: anchor)
         }
@@ -1407,6 +1414,10 @@ dashboard.stationManager = terminalCoordinator.stationManager
             NSSound.beep()
             return
         }
+        runIntegration(repoPath: repoPath, mode: mode, force: force)
+    }
+
+    private func runIntegration(repoPath: String, mode: IntegrationConflictMode, force: Bool) {
         let worktrees = tabCoordinator.allWorktrees
             .map(\.info)
             .filter { WorktreeDiscovery.findRepoRoot(from: $0.path) == repoPath }

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -126,7 +126,7 @@ class TabCoordinator {
             integrationPath: { IntegrationWorktreeStore.shared.worktreePath(forRepo: $0) },
             isCheckoutBusy: { AgentRegistry.shared.pane(forWorktree: $0)?.status == .running },
             onReport: { [weak self] report, _ in
-                IntegrationStatusStore.shared.set(report.cardLine, forWorktree: report.integrationWorktreePath)
+                IntegrationStatusStore.shared.set(report.panelState, forWorktree: report.integrationWorktreePath)
                 guard report.needsAttention else { return }
                 self?.pendingOrders.enqueue(
                     FirstMateAction(

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -128,6 +128,7 @@ class TabCoordinator {
             },
             integrationPath: { IntegrationWorktreeStore.shared.worktreePath(forRepo: $0) },
             isCheckoutBusy: { AgentRegistry.shared.pane(forWorktree: $0)?.status == .running },
+            isWorktreeBusy: { AgentRegistry.shared.pane(forWorktree: $0)?.status == .running },
             onReport: { [weak self] report, _ in
                 IntegrationStatusStore.shared.set(report.panelState, forWorktree: report.integrationWorktreePath)
                 guard report.needsAttention else { return }

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -1718,7 +1718,10 @@ extension TabCoordinator {
     /// the far side is what would let the browser and the desktop disagree.
     func worktreeGroups(mode: String) -> [[String: Any]] {
         let items = buildWorktreeRowInfos().map {
-            $0.groupingItem(creationDate: DashboardOverviewView.creationDate($0.worktreePath))
+            $0.groupingItem(
+                creationDate: DashboardOverviewView.creationDate($0.worktreePath),
+                isIntegration: IntegrationWorktreeStore.shared.isIntegrationWorktree($0.worktreePath)
+            )
         }
         return WorktreeGrouping
             .groups(items, mode: WorktreeGroupingMode(wire: mode), now: Date())

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -116,7 +116,10 @@ class TabCoordinator {
             }
         )
         integration = IntegrationCoordinator(
-            isEnabled: { [weak self] in self?.config.autoIntegrate ?? false },
+            isEnabled: { [weak self] in
+                guard let self else { return false }
+                return self.config.integrationEnabled && self.config.autoIntegrate
+            },
             repoRoot: { WorktreeDiscovery.findRepoRoot(from: $0) },
             worktrees: { [weak self] repo in
                 self?.allWorktrees

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -29,6 +29,9 @@ class TabCoordinator {
 
     var activeTabIndex: Int = 0
     var allWorktrees: [(info: WorktreeInfo, tree: SplitTree)] = []
+    /// Keeps each repo's integration checkout current as agents finish turns.
+    /// Nil until `init` builds it; only acts on repos that already have one.
+    private var integration: IntegrationCoordinator?
     var worktreeRepoCache: [String: String] = [:]
 
     /// Display name of the repo owning a given worktree path.
@@ -112,6 +115,32 @@ class TabCoordinator {
                 self?.runFirstMateInspection(action)
             }
         )
+        integration = IntegrationCoordinator(
+            isEnabled: { [weak self] in self?.config.autoIntegrate ?? false },
+            repoRoot: { WorktreeDiscovery.findRepoRoot(from: $0) },
+            worktrees: { [weak self] repo in
+                self?.allWorktrees
+                    .map(\.info)
+                    .filter { WorktreeDiscovery.findRepoRoot(from: $0.path) == repo } ?? []
+            },
+            integrationPath: { IntegrationWorktreeStore.shared.worktreePath(forRepo: $0) },
+            isCheckoutBusy: { AgentRegistry.shared.pane(forWorktree: $0)?.status == .running },
+            onReport: { [weak self] report, _ in
+                IntegrationStatusStore.shared.set(report.cardLine, forWorktree: report.integrationWorktreePath)
+                guard report.needsAttention else { return }
+                self?.pendingOrders.enqueue(
+                    FirstMateAction(
+                        kind: .integrationReport,
+                        zone: .red,
+                        worktreePath: report.integrationWorktreePath,
+                        branch: "",
+                        project: self?.repoName(forWorktree: report.integrationWorktreePath) ?? "",
+                        terminalID: "",
+                        message: report.summary
+                    )
+                )
+            }
+        )
         AgentRegistry.shared.onOutcome = { [weak self] outcome in
             guard let self else { return }
             switch outcome.event.source {
@@ -121,6 +150,7 @@ class TabCoordinator {
                 self.statusPublisher.invalidateScanCache(terminalID: outcome.info.id)
             }
             self.firstMate?.handle(outcome)
+            self.integration?.handle(outcome)
             self.mailPaneObserver.ingest(outcome)
             // Feed the worktree aggregator from AgentRegistry's arbitrated status
             // (scan + hook + OSC), so the dashboard reflects hook/OSC-driven

--- a/Sources/Core/BridgeCommand.swift
+++ b/Sources/Core/BridgeCommand.swift
@@ -70,10 +70,12 @@ enum BridgeCommand: Equatable {
     case removeWorktree(worktreePath: String)
     /// `/feedback <description>` — open a GitHub issue pre-filled with the description.
     case flagIssue(title: String)
-    /// `/integrate [full]` — fold every worktree in the current repo onto trunk
-    /// and check the result out in the integration worktree. `full` keeps
-    /// conflicting worktrees with markers instead of dropping them.
-    case integrate(mode: IntegrationConflictMode)
+    /// `/integrate [full] [force]` — fold every worktree in the current repo
+    /// onto trunk and check the result out in the integration worktree. `full`
+    /// keeps conflicting worktrees with markers instead of dropping them;
+    /// `force` discards local edits in the checkout, which is otherwise the one
+    /// thing that holds a round back.
+    case integrate(mode: IntegrationConflictMode, force: Bool)
 }
 
 enum BridgeCommandError: Error, Equatable {
@@ -212,14 +214,19 @@ enum BridgeCommandParser {
             return rest.isEmpty ? .failure(.emptyTask) : .success(.flagIssue(title: rest))
 
         case "integrate":
-            switch rest.lowercased() {
-            case "", "clean":
-                return .success(.integrate(mode: .excludeConflicting))
-            case "full":
-                return .success(.integrate(mode: .includeWithMarkers))
-            default:
-                return .failure(.unknownTarget(rest))
+            var mode = IntegrationConflictMode.excludeConflicting
+            var force = false
+            for token in rest.lowercased().split(separator: " ", omittingEmptySubsequences: true) {
+                switch token {
+                case "clean": mode = .excludeConflicting
+                case "full": mode = .includeWithMarkers
+                case "force": force = true
+                // An unrecognised word is a typo, not a shrug: `/integrate ful`
+                // must not quietly drop someone's conflicting work.
+                default: return .failure(.unknownTarget(String(token)))
+                }
             }
+            return .success(.integrate(mode: mode, force: force))
 
         default:
             return .failure(.unknownCommand(verb))

--- a/Sources/Core/BridgeCommand.swift
+++ b/Sources/Core/BridgeCommand.swift
@@ -70,6 +70,10 @@ enum BridgeCommand: Equatable {
     case removeWorktree(worktreePath: String)
     /// `/feedback <description>` — open a GitHub issue pre-filled with the description.
     case flagIssue(title: String)
+    /// `/integrate [full]` — fold every worktree in the current repo onto trunk
+    /// and check the result out in the integration worktree. `full` keeps
+    /// conflicting worktrees with markers instead of dropping them.
+    case integrate(mode: IntegrationConflictMode)
 }
 
 enum BridgeCommandError: Error, Equatable {
@@ -206,6 +210,16 @@ enum BridgeCommandParser {
 
         case "feedback":
             return rest.isEmpty ? .failure(.emptyTask) : .success(.flagIssue(title: rest))
+
+        case "integrate":
+            switch rest.lowercased() {
+            case "", "clean":
+                return .success(.integrate(mode: .excludeConflicting))
+            case "full":
+                return .success(.integrate(mode: .includeWithMarkers))
+            default:
+                return .failure(.unknownTarget(rest))
+            }
 
         default:
             return .failure(.unknownCommand(verb))

--- a/Sources/Core/BridgeCommandRouter.swift
+++ b/Sources/Core/BridgeCommandRouter.swift
@@ -22,7 +22,7 @@ struct BridgeCommandRouter {
     /// Open a pre-filled GitHub issue in the browser.
     let flagIssue: (String) -> Void
     /// Run one integration round for the current repo and report what happened.
-    let integrate: (IntegrationConflictMode) -> Void
+    let integrate: (IntegrationConflictMode, Bool) -> Void
     let activePaneCount: () -> Int
     let branchForPath: (String) -> String
     let projectForPath: (String) -> String
@@ -49,8 +49,8 @@ struct BridgeCommandRouter {
             removeWorktree(path)
         case .flagIssue(let title):
             flagIssue(title)
-        case .integrate(let mode):
-            integrate(mode)
+        case .integrate(let mode, let force):
+            integrate(mode, force)
         case .broadcast(let task):
             queue.enqueue(FirstMateAction(kind: .broadcastOrder, zone: .red, worktreePath: "",
                                           branch: "", project: "", terminalID: "",

--- a/Sources/Core/BridgeCommandRouter.swift
+++ b/Sources/Core/BridgeCommandRouter.swift
@@ -21,6 +21,8 @@ struct BridgeCommandRouter {
     let removeWorktree: (String) -> Void
     /// Open a pre-filled GitHub issue in the browser.
     let flagIssue: (String) -> Void
+    /// Run one integration round for the current repo and report what happened.
+    let integrate: (IntegrationConflictMode) -> Void
     let activePaneCount: () -> Int
     let branchForPath: (String) -> String
     let projectForPath: (String) -> String
@@ -47,6 +49,8 @@ struct BridgeCommandRouter {
             removeWorktree(path)
         case .flagIssue(let title):
             flagIssue(title)
+        case .integrate(let mode):
+            integrate(mode)
         case .broadcast(let task):
             queue.enqueue(FirstMateAction(kind: .broadcastOrder, zone: .red, worktreePath: "",
                                           branch: "", project: "", terminalID: "",

--- a/Sources/Core/Config.swift
+++ b/Sources/Core/Config.swift
@@ -34,6 +34,10 @@ struct Config: Codable {
     var gmailMail: GmailMailConfig?
     var hostGateway: HostGatewayConfig?
     var firstMate: FirstMateConfig
+    /// Keep the integration checkout current as agents finish turns. Only ever
+    /// acts on a repo that already has one — running `/integrate` once is what
+    /// opts a repo in, so this is the off switch, not the on switch.
+    var autoIntegrate: Bool
     var notifications: NotificationConfig
     /// Vibe-island style notch overlay showing notifications + suggestions.
     var islandEnabled: Bool
@@ -95,6 +99,7 @@ struct Config: Codable {
         case enabledHookAgents = "enabled_hook_agents"
         case notificationSound = "notification_sound"
         case confirmBeforeQuit = "confirm_before_quit"
+        case autoIntegrate = "auto_integrate"
         case agentMemoryGuard = "agent_memory_guard"
         case autoSleep = "auto_sleep"
     }
@@ -133,6 +138,7 @@ struct Config: Codable {
         enabledHookAgents = []
         notificationSound = "default"
         confirmBeforeQuit = true
+        autoIntegrate = true
         agentMemoryGuard = .default
         autoSleep = .default
     }
@@ -181,6 +187,7 @@ struct Config: Codable {
         enabledHookAgents = try container.decodeIfPresent([String].self, forKey: .enabledHookAgents) ?? []
         notificationSound = try container.decodeIfPresent(String.self, forKey: .notificationSound) ?? "default"
         confirmBeforeQuit = try container.decodeIfPresent(Bool.self, forKey: .confirmBeforeQuit) ?? true
+        autoIntegrate = try container.decodeIfPresent(Bool.self, forKey: .autoIntegrate) ?? true
         agentMemoryGuard = try container.decodeIfPresent(AgentMemoryGuardConfig.self, forKey: .agentMemoryGuard) ?? .default
         autoSleep = try container.decodeIfPresent(AutoSleepConfig.self, forKey: .autoSleep) ?? .default
     }

--- a/Sources/Core/Config.swift
+++ b/Sources/Core/Config.swift
@@ -34,6 +34,10 @@ struct Config: Codable {
     var gmailMail: GmailMailConfig?
     var hostGateway: HostGatewayConfig?
     var firstMate: FirstMateConfig
+    /// Whether the integration checkout exists as a concept at all: its button,
+    /// its banner, its panel, `/integrate`, and the automatic rounds. Off hides
+    /// the feature entirely without deleting any checkout already on disk.
+    var integrationEnabled: Bool
     /// Keep the integration checkout current as agents finish turns. Only ever
     /// acts on a repo that already has one — running `/integrate` once is what
     /// opts a repo in, so this is the off switch, not the on switch.
@@ -99,6 +103,7 @@ struct Config: Codable {
         case enabledHookAgents = "enabled_hook_agents"
         case notificationSound = "notification_sound"
         case confirmBeforeQuit = "confirm_before_quit"
+        case integrationEnabled = "integration_enabled"
         case autoIntegrate = "auto_integrate"
         case agentMemoryGuard = "agent_memory_guard"
         case autoSleep = "auto_sleep"
@@ -138,6 +143,7 @@ struct Config: Codable {
         enabledHookAgents = []
         notificationSound = "default"
         confirmBeforeQuit = true
+        integrationEnabled = true
         autoIntegrate = true
         agentMemoryGuard = .default
         autoSleep = .default
@@ -187,6 +193,7 @@ struct Config: Codable {
         enabledHookAgents = try container.decodeIfPresent([String].self, forKey: .enabledHookAgents) ?? []
         notificationSound = try container.decodeIfPresent(String.self, forKey: .notificationSound) ?? "default"
         confirmBeforeQuit = try container.decodeIfPresent(Bool.self, forKey: .confirmBeforeQuit) ?? true
+        integrationEnabled = try container.decodeIfPresent(Bool.self, forKey: .integrationEnabled) ?? true
         autoIntegrate = try container.decodeIfPresent(Bool.self, forKey: .autoIntegrate) ?? true
         agentMemoryGuard = try container.decodeIfPresent(AgentMemoryGuardConfig.self, forKey: .agentMemoryGuard) ?? .default
         autoSleep = try container.decodeIfPresent(AutoSleepConfig.self, forKey: .autoSleep) ?? .default

--- a/Sources/Core/FirstMate.swift
+++ b/Sources/Core/FirstMate.swift
@@ -10,6 +10,9 @@ enum FirstMateActionKind: Equatable {
     case suggestNextOrder
     case returnToPort
     case broadcastOrder
+    /// An integration round that needs looking at — conflicts, or a checkout
+    /// held back. A round that published cleanly says nothing.
+    case integrationReport
 }
 
 struct FirstMateAction: Equatable {

--- a/Sources/Core/FirstMateCoordinator.swift
+++ b/Sources/Core/FirstMateCoordinator.swift
@@ -67,7 +67,9 @@ final class FirstMateCoordinator {
                     notify(action)
                 case .inspect, .autoCommit:
                     runInspection(action)
-                case .suggestNextOrder, .returnToPort, .broadcastOrder:
+                case .suggestNextOrder, .returnToPort, .broadcastOrder, .integrationReport:
+                    // Never adjudicated green: reports are raised directly by
+                    // `/integrate`, and the rest are red-zone by construction.
                     break
                 }
             case .red:

--- a/Sources/Core/IntegrationCoordinator.swift
+++ b/Sources/Core/IntegrationCoordinator.swift
@@ -29,6 +29,9 @@ final class IntegrationCoordinator {
     private let worktrees: (String) -> [WorktreeInfo]
     private let integrationPath: (String) -> String?
     private let isCheckoutBusy: (String) -> Bool
+    /// Whether a worktree has an agent mid-turn. Such a worktree contributes its
+    /// HEAD rather than a live snapshot — see `IntegrationRunner.run`.
+    private let isWorktreeBusy: (String) -> Bool
     private let onReport: (IntegrationRunReport, String) -> Void
     private let runRound: (String, String, [WorktreeInfo]) throws -> IntegrationRunReport
 
@@ -42,10 +45,9 @@ final class IntegrationCoordinator {
         worktrees: @escaping (String) -> [WorktreeInfo],
         integrationPath: @escaping (String) -> String?,
         isCheckoutBusy: @escaping (String) -> Bool,
+        isWorktreeBusy: @escaping (String) -> Bool = { _ in false },
         onReport: @escaping (IntegrationRunReport, String) -> Void,
-        runRound: @escaping (String, String, [WorktreeInfo]) throws -> IntegrationRunReport = { repo, path, trees in
-            try IntegrationRunner.run(repoPath: repo, integrationPath: path, worktrees: trees)
-        }
+        runRound: ((String, String, [WorktreeInfo]) throws -> IntegrationRunReport)? = nil
     ) {
         self.coalesceWindow = coalesceWindow
         self.isEnabled = isEnabled
@@ -53,8 +55,12 @@ final class IntegrationCoordinator {
         self.worktrees = worktrees
         self.integrationPath = integrationPath
         self.isCheckoutBusy = isCheckoutBusy
+        self.isWorktreeBusy = isWorktreeBusy
         self.onReport = onReport
-        self.runRound = runRound
+        self.runRound = runRound ?? { repo, path, trees in
+            try IntegrationRunner.run(repoPath: repo, integrationPath: path,
+                                      worktrees: trees, isBusy: isWorktreeBusy)
+        }
     }
 
     /// An agent status outcome. Only the edge out of `.running` schedules work.

--- a/Sources/Core/IntegrationCoordinator.swift
+++ b/Sources/Core/IntegrationCoordinator.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Keeps each repo's integration checkout current as agents finish turns.
+///
+/// The trigger is the edge seahelm already computes: an agent leaving
+/// `.running` is a stage of work reaching a resting point. Several agents
+/// finishing together coalesce into one round rather than one round each.
+///
+/// Only repos that already have an integration checkout are touched. Running
+/// `/integrate` once is what opts a repo in — nothing here creates a directory
+/// on its own, so turning this on cannot surprise anyone with new state on
+/// disk.
+///
+/// This is only safe to run unattended because of what `IntegrationRunner`
+/// does: every merge happens in the object database, and the checkout is moved
+/// by a single `reset --hard` onto an already-merged commit. There is no
+/// partial state to wake up to. The one destructive moment — discarding local
+/// edits in the checkout — is never taken automatically; those rounds report a
+/// hold instead.
+final class IntegrationCoordinator {
+    /// Several agents finishing within a turn of each other are one round.
+    static let defaultCoalesceWindow: TimeInterval = 2.0
+
+    /// Injectable so tests do not have to spend the real window on every case.
+    let coalesceWindow: TimeInterval
+
+    private let isEnabled: () -> Bool
+    private let repoRoot: (String) -> String?
+    private let worktrees: (String) -> [WorktreeInfo]
+    private let integrationPath: (String) -> String?
+    private let isCheckoutBusy: (String) -> Bool
+    private let onReport: (IntegrationRunReport, String) -> Void
+    private let runRound: (String, String, [WorktreeInfo]) throws -> IntegrationRunReport
+
+    private var pending: [String: DispatchWorkItem] = [:]
+    private var inFlight: Set<String> = []
+
+    init(
+        coalesceWindow: TimeInterval = IntegrationCoordinator.defaultCoalesceWindow,
+        isEnabled: @escaping () -> Bool,
+        repoRoot: @escaping (String) -> String?,
+        worktrees: @escaping (String) -> [WorktreeInfo],
+        integrationPath: @escaping (String) -> String?,
+        isCheckoutBusy: @escaping (String) -> Bool,
+        onReport: @escaping (IntegrationRunReport, String) -> Void,
+        runRound: @escaping (String, String, [WorktreeInfo]) throws -> IntegrationRunReport = { repo, path, trees in
+            try IntegrationRunner.run(repoPath: repo, integrationPath: path, worktrees: trees)
+        }
+    ) {
+        self.coalesceWindow = coalesceWindow
+        self.isEnabled = isEnabled
+        self.repoRoot = repoRoot
+        self.worktrees = worktrees
+        self.integrationPath = integrationPath
+        self.isCheckoutBusy = isCheckoutBusy
+        self.onReport = onReport
+        self.runRound = runRound
+    }
+
+    /// An agent status outcome. Only the edge out of `.running` schedules work.
+    func handle(_ outcome: IngestOutcome) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard outcome.statusChanged,
+              outcome.oldStatus == .running,
+              outcome.newStatus != .running else { return }
+        schedule(worktreePath: outcome.info.worktreePath)
+    }
+
+    /// Exposed for the same edge arriving as a plain transition.
+    func handle(_ transition: StatusTransition) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard transition.oldStatus == .running, transition.newStatus != .running else { return }
+        schedule(worktreePath: transition.worktreePath)
+    }
+
+    private func schedule(worktreePath: String) {
+        guard isEnabled(),
+              !worktreePath.isEmpty,
+              let repo = repoRoot(worktreePath),
+              let path = integrationPath(repo),
+              FileManager.default.fileExists(atPath: path) else { return }
+
+        // Replace any round already waiting for this repo: the newer edge
+        // supersedes it, and the coalesce window restarts so a burst of agents
+        // finishing produces one round after the burst, not one per agent.
+        pending[repo]?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            self?.pending[repo] = nil
+            self?.run(repo: repo, integrationPath: path)
+        }
+        pending[repo] = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + coalesceWindow, execute: work)
+    }
+
+    private func run(repo: String, integrationPath path: String) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        // One round per repo at a time. A round that lands while another is
+        // running would race on the same checkout, and its result would be
+        // stale anyway — the edge that triggered it will come round again.
+        guard !inFlight.contains(repo) else { return }
+        // Someone is using the checkout: publishing would pull files out from
+        // under them. Skip rather than build a result that can only be held.
+        guard !isCheckoutBusy(path) else { return }
+
+        inFlight.insert(repo)
+        let trees = worktrees(repo)
+        let round = runRound
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let report = try? round(repo, path, trees)
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.inFlight.remove(repo)
+                guard let report else { return }
+                self.onReport(report, repo)
+            }
+        }
+    }
+}

--- a/Sources/Core/IntegrationRunner.swift
+++ b/Sources/Core/IntegrationRunner.swift
@@ -19,6 +19,21 @@ struct IntegrationRunReport: Equatable {
         }
     }
 
+    /// The ambient line on the checkout's card. Says what is in it, not what
+    /// went wrong — the report card covers that.
+    var cardLine: String {
+        var line = result.included.isEmpty
+            ? "integration · empty"
+            : "integration · \(result.included.count) worktree\(result.included.count == 1 ? "" : "s")"
+        if !result.excluded.isEmpty {
+            line += " · excluded \(result.excluded.map(\.label).joined(separator: ", "))"
+        }
+        if case .held = outcome {
+            line += " · pending"
+        }
+        return line
+    }
+
     /// One line for a notification or the helm.
     var summary: String {
         var parts: [String] = []
@@ -41,7 +56,8 @@ struct IntegrationRunReport: Equatable {
         switch outcome {
         case .published: break
         case .unchanged: parts.append("already current")
-        case .held(.dirtyWorktree, _): parts.append("not checked out — local edits in the integration worktree")
+        case .held(.dirtyWorktree, _):
+            parts.append("not checked out — local edits in the integration worktree; `/integrate force` to discard them")
         case .failed(let message): parts.append("checkout failed: \(message)")
         }
         return parts.joined(separator: " · ")

--- a/Sources/Core/IntegrationRunner.swift
+++ b/Sources/Core/IntegrationRunner.swift
@@ -34,6 +34,22 @@ struct IntegrationRunReport: Equatable {
         return line
     }
 
+    /// Everything the card, the banner and the Changes panel show, from one
+    /// round, so they cannot disagree about it.
+    var panelState: IntegrationPanelState {
+        var held = false
+        if case .held = outcome { held = true }
+        return IntegrationPanelState(
+            line: cardLine,
+            included: result.included,
+            excluded: result.excluded.map {
+                IntegrationPanelState.Excluded(label: $0.label, paths: $0.conflictingPaths)
+            },
+            conflictedPaths: result.conflictedPaths,
+            isHeld: held
+        )
+    }
+
     /// One line for a notification or the helm.
     var summary: String {
         var parts: [String] = []

--- a/Sources/Core/IntegrationRunner.swift
+++ b/Sources/Core/IntegrationRunner.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// What one integration round did.
+struct IntegrationRunReport: Equatable {
+    let integrationWorktreePath: String
+    let result: IntegrationResult
+    let outcome: IntegrationPublishOutcome
+    /// Worktrees that offered nothing — no HEAD to snapshot, usually an unborn
+    /// branch. Reported rather than silently skipped.
+    let unsnapshotable: [String]
+
+    /// Whether this round is worth telling the user about. A clean publish is
+    /// meant to be invisible; anything dropped, marked or held is not.
+    var needsAttention: Bool {
+        if result.hasConflicts || !unsnapshotable.isEmpty { return true }
+        switch outcome {
+        case .published, .unchanged: return false
+        case .held, .failed: return true
+        }
+    }
+
+    /// One line for a notification or the helm.
+    var summary: String {
+        var parts: [String] = []
+        if result.included.isEmpty {
+            parts.append("nothing to integrate")
+        } else {
+            parts.append("integrated \(result.included.joined(separator: ", "))")
+        }
+        if !result.excluded.isEmpty {
+            let details = result.excluded.map { exclusion -> String in
+                exclusion.conflictingPaths.isEmpty
+                    ? exclusion.label
+                    : "\(exclusion.label) (\(exclusion.conflictingPaths.joined(separator: ", ")))"
+            }
+            parts.append("excluded \(details.joined(separator: "; "))")
+        }
+        if !result.conflictedPaths.isEmpty {
+            parts.append("conflict markers in \(result.conflictedPaths.joined(separator: ", "))")
+        }
+        switch outcome {
+        case .published: break
+        case .unchanged: parts.append("already current")
+        case .held(.dirtyWorktree, _): parts.append("not checked out — local edits in the integration worktree")
+        case .failed(let message): parts.append("checkout failed: \(message)")
+        }
+        return parts.joined(separator: " · ")
+    }
+}
+
+enum IntegrationRunError: LocalizedError {
+    case noBaseRef
+    case worktreeUnavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .noBaseRef:
+            return "Could not find a trunk to integrate onto"
+        case .worktreeUnavailable(let message):
+            return "Integration worktree unavailable: \(message)"
+        }
+    }
+}
+
+/// One integration round, start to finish: snapshot every fleet worktree, fold
+/// them onto trunk, and move the integration checkout to the result.
+///
+/// Everything before the last step happens in the object database, so a round
+/// that ends up held — or that fails outright — leaves the checkout exactly as
+/// it was.
+enum IntegrationRunner {
+    /// Sources are taken in a stable order, because merge order decides which
+    /// of two colliding worktrees gets reported. Path order is arbitrary but
+    /// repeatable, which is the property that matters: the same fleet produces
+    /// the same report twice running.
+    static func sources(from worktrees: [WorktreeInfo], excluding excludedPaths: Set<String>) -> [WorktreeInfo] {
+        worktrees
+            .filter { !$0.isMainWorktree }
+            .filter { !excludedPaths.contains(WorktreeDiscovery.canonicalPath($0.path)) }
+            .sorted { $0.path < $1.path }
+    }
+
+    /// - Parameters:
+    ///   - integrationPath: the checkout to publish into. Created if absent.
+    ///   - worktrees: the repo's worktrees, main and integration included; both
+    ///     are filtered out here.
+    static func run(
+        repoPath: String,
+        integrationPath: String,
+        worktrees: [WorktreeInfo],
+        mode: IntegrationConflictMode = .excludeConflicting,
+        force: Bool = false
+    ) throws -> IntegrationRunReport {
+        guard let base = GitDiff.resolveBaseRef(worktreePath: repoPath) else {
+            throw IntegrationRunError.noBaseRef
+        }
+
+        if !FileManager.default.fileExists(atPath: integrationPath) {
+            do {
+                try IntegrationWorktree.create(repoPath: repoPath, at: integrationPath, base: base)
+            } catch {
+                throw IntegrationRunError.worktreeUnavailable(error.localizedDescription)
+            }
+        }
+
+        let candidates = sources(
+            from: worktrees,
+            excluding: [WorktreeDiscovery.canonicalPath(integrationPath)]
+        )
+
+        var integrationSources: [IntegrationSource] = []
+        var unsnapshotable: [String] = []
+        for worktree in candidates {
+            guard let snapshot = WorktreeSnapshotter.snapshot(worktreePath: worktree.path) else {
+                unsnapshotable.append(worktree.displayName)
+                continue
+            }
+            integrationSources.append(
+                IntegrationSource(label: worktree.displayName, commit: snapshot.commit)
+            )
+        }
+
+        guard let result = IntegrationBuilder.build(
+            repoPath: repoPath,
+            base: base,
+            sources: integrationSources,
+            mode: mode
+        ) else {
+            throw IntegrationRunError.noBaseRef
+        }
+
+        let outcome = IntegrationWorktree.publish(commit: result.commit, to: integrationPath, force: force)
+        return IntegrationRunReport(
+            integrationWorktreePath: integrationPath,
+            result: result,
+            outcome: outcome,
+            unsnapshotable: unsnapshotable
+        )
+    }
+}

--- a/Sources/Core/IntegrationRunner.swift
+++ b/Sources/Core/IntegrationRunner.swift
@@ -8,6 +8,9 @@ struct IntegrationRunReport: Equatable {
     /// Worktrees that offered nothing — no HEAD to snapshot, usually an unborn
     /// branch. Reported rather than silently skipped.
     let unsnapshotable: [String]
+    /// Worktrees taken at HEAD because their agent was mid-turn, so their
+    /// uncommitted work is not in this round.
+    let committedOnly: [String]
 
     /// Whether this round is worth telling the user about. A clean publish is
     /// meant to be invisible; anything dropped, marked or held is not.
@@ -27,6 +30,11 @@ struct IntegrationRunReport: Equatable {
             : "integration · \(result.included.count) worktree\(result.included.count == 1 ? "" : "s")"
         if !result.excluded.isEmpty {
             line += " · excluded \(result.excluded.map(\.label).joined(separator: ", "))"
+        }
+        if !committedOnly.isEmpty {
+            // Ambient, not a card: an agent still working is the normal case,
+            // and raising one every round would be pure noise.
+            line += " · \(committedOnly.count) still working"
         }
         if case .held = outcome {
             line += " · pending"
@@ -68,6 +76,9 @@ struct IntegrationRunReport: Equatable {
         }
         if !result.conflictedPaths.isEmpty {
             parts.append("conflict markers in \(result.conflictedPaths.joined(separator: ", "))")
+        }
+        if !committedOnly.isEmpty {
+            parts.append("committed work only from \(committedOnly.joined(separator: ", ")) — still working")
         }
         switch outcome {
         case .published: break
@@ -116,12 +127,20 @@ enum IntegrationRunner {
     ///   - integrationPath: the checkout to publish into. Created if absent.
     ///   - worktrees: the repo's worktrees, main and integration included; both
     ///     are filtered out here.
+    ///   - isBusy: whether a worktree has an agent mid-turn. A round is
+    ///     triggered by *one* agent finishing, but it folds in every worktree,
+    ///     and the others may be mid-write — half a file, half a rename. Those
+    ///     contribute their HEAD instead: their last self-consistent state,
+    ///     rather than a torn one that could fail the integration in a way that
+    ///     looks like a real conflict. They come in whole on the round their own
+    ///     turn ends.
     static func run(
         repoPath: String,
         integrationPath: String,
         worktrees: [WorktreeInfo],
         mode: IntegrationConflictMode = .excludeConflicting,
-        force: Bool = false
+        force: Bool = false,
+        isBusy: (String) -> Bool = { _ in false }
     ) throws -> IntegrationRunReport {
         guard let base = GitDiff.resolveBaseRef(worktreePath: repoPath) else {
             throw IntegrationRunError.noBaseRef
@@ -142,7 +161,19 @@ enum IntegrationRunner {
 
         var integrationSources: [IntegrationSource] = []
         var unsnapshotable: [String] = []
+        var partial: [String] = []
         for worktree in candidates {
+            if isBusy(worktree.path) {
+                guard let head = WorktreeSnapshotter.head(worktreePath: worktree.path) else {
+                    unsnapshotable.append(worktree.displayName)
+                    continue
+                }
+                partial.append(worktree.displayName)
+                integrationSources.append(
+                    IntegrationSource(label: worktree.displayName, commit: head)
+                )
+                continue
+            }
             guard let snapshot = WorktreeSnapshotter.snapshot(worktreePath: worktree.path) else {
                 unsnapshotable.append(worktree.displayName)
                 continue
@@ -166,7 +197,8 @@ enum IntegrationRunner {
             integrationWorktreePath: integrationPath,
             result: result,
             outcome: outcome,
-            unsnapshotable: unsnapshotable
+            unsnapshotable: unsnapshotable,
+            committedOnly: partial
         )
     }
 }

--- a/Sources/Core/IntegrationStatusStore.swift
+++ b/Sources/Core/IntegrationStatusStore.swift
@@ -1,9 +1,32 @@
 import Foundation
 
-/// The one-line state of each integration checkout, keyed by its path.
+/// What the last integration round produced for one checkout.
+///
+/// The card and the banner want one line; the Changes panel wants to say what
+/// actually went in and what did not. Both come from here so they can never
+/// disagree about the same round.
+struct IntegrationPanelState: Codable, Equatable {
+    /// The ambient one-liner for the card and the banner.
+    var line: String
+    /// Labels that merged, in the order applied.
+    var included: [String]
+    /// Labels dropped, each with the paths it collided on.
+    var excluded: [Excluded]
+    /// Paths carrying conflict markers, when the round kept conflicting sources.
+    var conflictedPaths: [String]
+    /// The result was built but not checked out — local edits in the checkout.
+    var isHeld: Bool
+
+    struct Excluded: Codable, Equatable {
+        var label: String
+        var paths: [String]
+    }
+}
+
+/// Per-checkout state, keyed by worktree path.
 ///
 /// Persisted so the card still reads correctly after a relaunch, before any
-/// round has run. It is display text only — nothing decides anything from it.
+/// round has run. Display only — nothing decides anything from it.
 final class IntegrationStatusStore {
     static let shared = IntegrationStatusStore()
 
@@ -11,21 +34,37 @@ final class IntegrationStatusStore {
 
     private init() {}
 
+    /// The one-liner. Falls back to the raw value for entries written before
+    /// this held structured state, so an upgrade does not blank the card.
     func status(forWorktree path: String) -> String? {
-        store[WorktreeDiscovery.canonicalPath(path)]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .nilIfEmpty
+        guard let raw = store[WorktreeDiscovery.canonicalPath(path)] else { return nil }
+        if let state = Self.decode(raw) { return state.line.nilIfBlank }
+        return raw.nilIfBlank
     }
 
-    func set(_ status: String, forWorktree path: String) {
-        store.set(status, forKey: WorktreeDiscovery.canonicalPath(path))
+    func state(forWorktree path: String) -> IntegrationPanelState? {
+        store[WorktreeDiscovery.canonicalPath(path)].flatMap(Self.decode)
+    }
+
+    func set(_ state: IntegrationPanelState, forWorktree path: String) {
+        guard let data = try? JSONEncoder().encode(state),
+              let encoded = String(data: data, encoding: .utf8) else { return }
+        store.set(encoded, forKey: WorktreeDiscovery.canonicalPath(path))
     }
 
     func forget(worktreePath path: String) {
         store.remove(forKey: WorktreeDiscovery.canonicalPath(path))
     }
+
+    static func decode(_ raw: String) -> IntegrationPanelState? {
+        guard let data = raw.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(IntegrationPanelState.self, from: data)
+    }
 }
 
 private extension String {
-    var nilIfEmpty: String? { isEmpty ? nil : self }
+    var nilIfBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
 }

--- a/Sources/Core/IntegrationStatusStore.swift
+++ b/Sources/Core/IntegrationStatusStore.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// The one-line state of each integration checkout, keyed by its path.
+///
+/// Persisted so the card still reads correctly after a relaunch, before any
+/// round has run. It is display text only — nothing decides anything from it.
+final class IntegrationStatusStore {
+    static let shared = IntegrationStatusStore()
+
+    private let store = PersistedStringMap(fileName: "integration-status.json")
+
+    private init() {}
+
+    func status(forWorktree path: String) -> String? {
+        store[WorktreeDiscovery.canonicalPath(path)]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
+    }
+
+    func set(_ status: String, forWorktree path: String) {
+        store.set(status, forKey: WorktreeDiscovery.canonicalPath(path))
+    }
+
+    func forget(worktreePath path: String) {
+        store.remove(forKey: WorktreeDiscovery.canonicalPath(path))
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/Sources/Core/IntegrationWorktreeStore.swift
+++ b/Sources/Core/IntegrationWorktreeStore.swift
@@ -11,8 +11,14 @@ final class IntegrationWorktreeStore {
     static let shared = IntegrationWorktreeStore()
 
     private let store = PersistedStringMap(fileName: "integration-worktrees.json")
+    /// Membership cache. `isIntegrationWorktree` is asked once per pane per
+    /// render, on a two-second poll, so it must not rebuild a set each time.
+    private var knownPaths: Set<String>
+    private let lock = NSLock()
 
-    private init() {}
+    private init() {
+        knownPaths = store.values
+    }
 
     func worktreePath(forRepo repoPath: String) -> String? {
         store[WorktreeDiscovery.canonicalPath(repoPath)]?.nonEmptyTrimmed
@@ -23,17 +29,25 @@ final class IntegrationWorktreeStore {
             WorktreeDiscovery.canonicalPath(worktreePath),
             forKey: WorktreeDiscovery.canonicalPath(repoPath)
         )
+        refreshCache()
     }
 
     func forget(repoPath: String) {
         store.remove(forKey: WorktreeDiscovery.canonicalPath(repoPath))
+        refreshCache()
+    }
+
+    private func refreshCache() {
+        let values = store.values
+        lock.lock(); knownPaths = values; lock.unlock()
     }
 
     /// Whether this path is some repo's integration worktree. Used to keep it
     /// out of the fleet groupings, so it is asked often and must not touch disk.
     func isIntegrationWorktree(_ path: String) -> Bool {
-        let canonical = WorktreeDiscovery.canonicalPath(path)
-        return store.values.contains(canonical)
+        lock.lock(); let known = knownPaths; lock.unlock()
+        guard !known.isEmpty else { return false }
+        return known.contains(WorktreeDiscovery.canonicalPath(path))
     }
 }
 

--- a/Sources/Core/IntegrationWorktreeStore.swift
+++ b/Sources/Core/IntegrationWorktreeStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Remembers which worktree is a repo's integration checkout, keyed by repo
+/// path. One per repo.
+///
+/// Identity is recorded rather than inferred from the path: the directory name
+/// is a convention, and a convention is not something the rest of the app
+/// should have to re-derive every time it needs to know whether a worktree is
+/// a fleet member or the place they get combined.
+final class IntegrationWorktreeStore {
+    static let shared = IntegrationWorktreeStore()
+
+    private let store = PersistedStringMap(fileName: "integration-worktrees.json")
+
+    private init() {}
+
+    func worktreePath(forRepo repoPath: String) -> String? {
+        store[WorktreeDiscovery.canonicalPath(repoPath)]?.nonEmptyTrimmed
+    }
+
+    func set(_ worktreePath: String, forRepo repoPath: String) {
+        store.set(
+            WorktreeDiscovery.canonicalPath(worktreePath),
+            forKey: WorktreeDiscovery.canonicalPath(repoPath)
+        )
+    }
+
+    func forget(repoPath: String) {
+        store.remove(forKey: WorktreeDiscovery.canonicalPath(repoPath))
+    }
+
+    /// Whether this path is some repo's integration worktree. Used to keep it
+    /// out of the fleet groupings, so it is asked often and must not touch disk.
+    func isIntegrationWorktree(_ path: String) -> Bool {
+        let canonical = WorktreeDiscovery.canonicalPath(path)
+        return store.values.contains(canonical)
+    }
+}
+
+private extension String {
+    var nonEmptyTrimmed: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/Core/PersistedStringMap.swift
+++ b/Sources/Core/PersistedStringMap.swift
@@ -32,6 +32,13 @@ final class PersistedStringMap {
         persist(snapshot)
     }
 
+    /// Snapshot of the stored values. Callers that ask on every render need an
+    /// in-memory answer, not a file read.
+    var values: Set<String> {
+        lock.lock(); defer { lock.unlock() }
+        return Set(map.values)
+    }
+
     /// Drop a key. Worktree paths get reused — a stale entry left behind by a
     /// deleted worktree would answer for whatever is created at that path next.
     func remove(forKey key: String) {

--- a/Sources/Core/ProcessRunner.swift
+++ b/Sources/Core/ProcessRunner.swift
@@ -39,6 +39,7 @@ enum ProcessRunner {
         arguments: [String],
         currentDirectory: String? = nil,
         standardInput: String? = nil,
+        environment: [String: String]? = nil,
         timeout: TimeInterval?,
         maxCapturedBytes: Int = defaultMaxCapturedBytes
     ) -> Capture {
@@ -47,6 +48,11 @@ enum ProcessRunner {
         process.arguments = arguments
         if let currentDirectory {
             process.currentDirectoryURL = URL(fileURLWithPath: currentDirectory, isDirectory: true)
+        }
+        if let environment {
+            // Merged over the inherited environment, never replacing it: a bare
+            // dictionary would strip PATH and HOME, and git reads both.
+            process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
         }
 
         let outPipe = Pipe()

--- a/Sources/Core/WorktreeTitleResolver.swift
+++ b/Sources/Core/WorktreeTitleResolver.swift
@@ -2,18 +2,27 @@ import Foundation
 
 /// Resolves the human-facing title for a worktree, shared by the top capsule and
 /// the mini cards.
-/// Order: Claude/Cursor session title → task description → last user prompt → branch.
+/// Order: integration state → Claude/Cursor session title → task description →
+/// last user prompt → branch.
 enum WorktreeTitleResolver {
     static func resolve(
         worktreePath: String,
         lastUserPrompt: String,
         branch: String,
+        /// The integration checkout has no agent and no task, so every later
+        /// source would describe a shell. Its own state is the only honest
+        /// title, and it goes first for that reason.
+        integrationStatus: (String) -> String? = { IntegrationStatusStore.shared.status(forWorktree: $0) },
         sessionTitle: (String) -> String? = { path in
             SessionTitleLookup.title(worktreePath: path)
                 ?? CursorSessionTitleLookup.title(worktreePath: path)
         },
         taskDescription: (String) -> String? = { WorktreeTaskStore.shared.task(forWorktree: $0) }
     ) -> String {
+        if let state = integrationStatus(worktreePath)?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !state.isEmpty {
+            return state
+        }
         if let summary = sessionTitle(worktreePath)?.trimmingCharacters(in: .whitespacesAndNewlines),
            !summary.isEmpty {
             return summary

--- a/Sources/Git/GitProcess.swift
+++ b/Sources/Git/GitProcess.swift
@@ -17,9 +17,10 @@ enum GitProcess {
     static func run(
         _ arguments: [String],
         in directory: String,
-        timeout: TimeInterval = defaultTimeout
+        timeout: TimeInterval = defaultTimeout,
+        environment: [String: String]? = nil
     ) -> String? {
-        let result = capture(arguments, in: directory, timeout: timeout)
+        let result = capture(arguments, in: directory, timeout: timeout, environment: environment)
         return result.succeeded ? result.stdout : nil
     }
 
@@ -27,12 +28,14 @@ enum GitProcess {
     static func capture(
         _ arguments: [String],
         in directory: String,
-        timeout: TimeInterval = defaultTimeout
+        timeout: TimeInterval = defaultTimeout,
+        environment: [String: String]? = nil
     ) -> Result {
         ProcessRunner.capture(
             executable: URL(fileURLWithPath: executable),
             arguments: arguments,
             currentDirectory: directory,
+            environment: environment,
             timeout: timeout
         )
     }

--- a/Sources/Git/IntegrationBuilder.swift
+++ b/Sources/Git/IntegrationBuilder.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+/// One worktree offered to an integration round.
+struct IntegrationSource: Equatable {
+    /// How this shows up in the report — a branch, or a worktree's name.
+    let label: String
+    /// Commit to merge, normally from `WorktreeSnapshotter`.
+    let commit: String
+}
+
+/// A source that did not make it in, and what it collided on.
+struct IntegrationExclusion: Equatable {
+    let label: String
+    /// Paths git could not merge. Empty only if git reported a conflict without
+    /// naming one, which would be a git bug rather than a state to act on.
+    let conflictingPaths: [String]
+}
+
+struct IntegrationResult: Equatable {
+    /// The integrated commit. Equal to the base when nothing merged in.
+    let commit: String
+    let base: String
+    /// Labels that merged, in the order they were applied.
+    let included: [String]
+    let excluded: [IntegrationExclusion]
+    /// Paths carrying conflict markers. Only ever populated in
+    /// `.includeWithMarkers`, where a conflicted source is kept rather than
+    /// dropped.
+    let conflictedPaths: [String]
+
+    var isEmpty: Bool { commit == base }
+    var hasConflicts: Bool { !excluded.isEmpty || !conflictedPaths.isEmpty }
+}
+
+/// What to do with a source that will not merge cleanly.
+enum IntegrationConflictMode {
+    /// Drop it. The result stays buildable and testable, at the cost of that
+    /// source's other work.
+    case excludeConflicting
+    /// Keep it, conflict markers and all. Nothing is lost and nothing compiles;
+    /// this is the mode for looking at a conflict, not for running tests.
+    case includeWithMarkers
+}
+
+/// Combines several worktrees into one commit without checking anything out.
+///
+/// Every merge happens in the object database: `merge-tree` produces a tree,
+/// `commit-tree` turns it into a commit, and that commit is the next merge's
+/// left side. Nothing here touches a worktree or an index, so nothing here can
+/// leave one wedged mid-merge — which is what makes it safe to run
+/// automatically. A `git merge` in a checkout could not be: one conflict and
+/// the integration worktree sits in a conflicted state until someone clears it.
+///
+/// Conflicts are therefore a *result*, reported per source, rather than a
+/// failure that stops the round.
+///
+/// Order matters and cannot not matter: when two sources collide, whichever is
+/// applied second is the one reported. `sources` is applied as given, so the
+/// caller owns that order and gets the same answer twice for the same input.
+enum IntegrationBuilder {
+    static let timeout: TimeInterval = 60
+
+    static func build(
+        repoPath: String,
+        base: String,
+        sources: [IntegrationSource],
+        mode: IntegrationConflictMode = .excludeConflicting
+    ) -> IntegrationResult? {
+        guard let baseCommit = GitProcess.run(
+            ["rev-parse", "--verify", "--quiet", base],
+            in: repoPath,
+            timeout: timeout
+        )?.trimmingCharacters(in: .whitespacesAndNewlines), !baseCommit.isEmpty else {
+            return nil
+        }
+
+        var accumulator = baseCommit
+        var included: [String] = []
+        var excluded: [IntegrationExclusion] = []
+        var conflicted: [String] = []
+
+        for source in sources {
+            guard let merge = mergeTree(accumulator, source.commit, repoPath: repoPath) else {
+                // git could not run the merge at all — a missing commit, say.
+                // Treat it like a conflict with nothing to name rather than
+                // abandoning the whole round.
+                excluded.append(IntegrationExclusion(label: source.label, conflictingPaths: []))
+                continue
+            }
+
+            if merge.conflictingPaths.isEmpty {
+                guard let next = commit(tree: merge.tree, onto: accumulator, merging: source, repoPath: repoPath) else {
+                    excluded.append(IntegrationExclusion(label: source.label, conflictingPaths: []))
+                    continue
+                }
+                accumulator = next
+                included.append(source.label)
+                continue
+            }
+
+            switch mode {
+            case .excludeConflicting:
+                excluded.append(
+                    IntegrationExclusion(label: source.label, conflictingPaths: merge.conflictingPaths)
+                )
+            case .includeWithMarkers:
+                guard let next = commit(tree: merge.tree, onto: accumulator, merging: source, repoPath: repoPath) else {
+                    excluded.append(
+                        IntegrationExclusion(label: source.label, conflictingPaths: merge.conflictingPaths)
+                    )
+                    continue
+                }
+                accumulator = next
+                included.append(source.label)
+                for path in merge.conflictingPaths where !conflicted.contains(path) {
+                    conflicted.append(path)
+                }
+            }
+        }
+
+        return IntegrationResult(
+            commit: accumulator,
+            base: baseCommit,
+            included: included,
+            excluded: excluded,
+            conflictedPaths: conflicted
+        )
+    }
+
+    // MARK: - merge-tree
+
+    struct MergeTreeOutcome: Equatable {
+        /// Always present: on a conflict this tree carries the merge with
+        /// conflict markers in the paths below.
+        let tree: String
+        let conflictingPaths: [String]
+    }
+
+    /// `git merge-tree --write-tree`, which merges two commits and writes the
+    /// result to the object database without a worktree or an index.
+    static func mergeTree(_ lhs: String, _ rhs: String, repoPath: String) -> MergeTreeOutcome? {
+        let result = GitProcess.capture(
+            ["merge-tree", "--write-tree", "--name-only", "-z", lhs, rhs],
+            in: repoPath,
+            timeout: timeout
+        )
+        // Exit 0 is a clean merge and 1 a conflicted one; both print a tree.
+        // Anything else is a real failure, and prints nothing usable.
+        guard result.exitCode == 0 || result.exitCode == 1 else { return nil }
+        return parseMergeTree(result.stdout)
+    }
+
+    /// `<tree>\0` on success; `<tree>\0<path>\0...\0\0<informational records>`
+    /// on conflict, the empty field closing the path list.
+    static func parseMergeTree(_ output: String) -> MergeTreeOutcome? {
+        var fields = output.components(separatedBy: "\0")
+        guard let tree = fields.first?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !tree.isEmpty else { return nil }
+        fields.removeFirst()
+
+        var paths: [String] = []
+        for field in fields {
+            if field.isEmpty { break }
+            paths.append(field)
+        }
+        return MergeTreeOutcome(tree: tree, conflictingPaths: paths)
+    }
+
+    private static func commit(
+        tree: String,
+        onto accumulator: String,
+        merging source: IntegrationSource,
+        repoPath: String
+    ) -> String? {
+        WorktreeSnapshotter.commitTree(
+            tree: tree,
+            parents: [accumulator, source.commit],
+            message: "seahelm: integrate \(source.label)",
+            repoPath: repoPath
+        )
+    }
+}

--- a/Sources/Git/IntegrationBuilder.swift
+++ b/Sources/Git/IntegrationBuilder.swift
@@ -18,7 +18,14 @@ struct IntegrationExclusion: Equatable {
 
 struct IntegrationResult: Equatable {
     /// The integrated commit. Equal to the base when nothing merged in.
+    ///
+    /// Not an identity: `commit-tree` stamps a timestamp, so two rounds over an
+    /// unchanged fleet produce different commits holding the same files. Compare
+    /// `tree` to ask whether anything actually changed.
     let commit: String
+    /// The integrated tree — the change key. Same tree, same files, whatever
+    /// the commits say.
+    let tree: String
     let base: String
     /// Labels that merged, in the order they were applied.
     let included: [String]
@@ -33,7 +40,7 @@ struct IntegrationResult: Equatable {
 }
 
 /// What to do with a source that will not merge cleanly.
-enum IntegrationConflictMode {
+enum IntegrationConflictMode: Equatable {
     /// Drop it. The result stays buildable and testable, at the cost of that
     /// source's other work.
     case excludeConflicting
@@ -118,8 +125,17 @@ enum IntegrationBuilder {
             }
         }
 
+        guard let tree = GitProcess.run(
+            ["rev-parse", "--verify", "--quiet", "\(accumulator)^{tree}"],
+            in: repoPath,
+            timeout: timeout
+        )?.trimmingCharacters(in: .whitespacesAndNewlines), !tree.isEmpty else {
+            return nil
+        }
+
         return IntegrationResult(
             commit: accumulator,
+            tree: tree,
             base: baseCommit,
             included: included,
             excluded: excluded,

--- a/Sources/Git/IntegrationWorktree.swift
+++ b/Sources/Git/IntegrationWorktree.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Why a freshly built integration was not checked out.
+enum IntegrationHoldReason: Equatable {
+    /// Someone edited files in the integration checkout. Publishing would
+    /// discard them, so it waits to be told.
+    case dirtyWorktree
+}
+
+enum IntegrationPublishOutcome: Equatable {
+    /// Checked out. The integration worktree is now at this commit.
+    case published(commit: String)
+    /// Already there — the build produced what is already checked out.
+    case unchanged(commit: String)
+    /// Built, not checked out. The commit is kept so the caller can offer it.
+    case held(reason: IntegrationHoldReason, commit: String)
+    case failed(String)
+}
+
+/// The integration checkout: creating it, and moving it to a built commit.
+///
+/// It is deliberately **detached**. A branch would be a thing to manage — a name
+/// to reset, something pushable, and an entry in `git branch -a`, which is what
+/// the new-branch dialog offers as a base. A worktree based on the integration
+/// branch would then inherit a half-tested mixture of everyone's work. Detached,
+/// there is no ref to pick.
+///
+/// Publishing is one `reset --hard` onto a commit that is *already merged*, so
+/// it cannot fail partway and cannot leave a conflicted checkout. That is the
+/// difference between this and running `git merge` here, and it is what makes
+/// the operation safe to repeat unattended.
+enum IntegrationWorktree {
+    static let timeout: TimeInterval = 60
+
+    /// Directory name inside the repo's worktree folder.
+    static let directoryName = "integration"
+
+    /// Sibling of the agent worktrees, matching `WorktreeCreator`'s layout.
+    static func defaultPath(forRepo repoPath: String) -> String {
+        let repoURL = URL(fileURLWithPath: repoPath)
+        return repoURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("\(repoURL.lastPathComponent)-worktrees/\(directoryName)")
+            .path
+    }
+
+    enum CreateError: LocalizedError {
+        case pathExists(String)
+        case noBaseRef
+        case gitFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .pathExists(let path): return "Path already exists: \(path)"
+            case .noBaseRef: return "Could not find a trunk to base the integration on"
+            case .gitFailed(let message): return message
+            }
+        }
+    }
+
+    /// Creates the detached checkout at `base`. Does not record it anywhere —
+    /// the caller owns the store, so this stays testable without touching the
+    /// user's config.
+    @discardableResult
+    static func create(repoPath: String, at path: String, base: String) throws -> String {
+        if FileManager.default.fileExists(atPath: path) {
+            throw CreateError.pathExists(path)
+        }
+        let parent = URL(fileURLWithPath: path).deletingLastPathComponent().path
+        try FileManager.default.createDirectory(atPath: parent, withIntermediateDirectories: true)
+
+        let result = GitProcess.capture(
+            ["worktree", "add", "--detach", path, base],
+            in: repoPath,
+            timeout: timeout
+        )
+        guard result.succeeded else {
+            throw CreateError.gitFailed(result.stderr.isEmpty ? "git worktree add failed" : result.stderr)
+        }
+        return path
+    }
+
+    /// Removes the checkout. Detached, so there is no branch to clean up after.
+    static func remove(repoPath: String, path: String) -> Bool {
+        GitProcess.capture(
+            ["worktree", "remove", "--force", path],
+            in: repoPath,
+            timeout: timeout
+        ).succeeded
+    }
+
+    /// Moves the checkout onto `commit`.
+    ///
+    /// `reset --hard` discards anything uncommitted, so a dirty checkout holds
+    /// instead — this is the one irreversible step in the feature, and it needs
+    /// a deliberate `force` rather than happening quietly while someone is
+    /// mid-edit.
+    static func publish(commit: String, to path: String, force: Bool = false) -> IntegrationPublishOutcome {
+        // Trees, not commits. `commit-tree` stamps a timestamp, so rebuilding an
+        // unchanged fleet yields a different commit holding identical files —
+        // comparing commits would make every round look like a change and reset
+        // the checkout for nothing.
+        guard let headTree = revParse("HEAD^{tree}", in: path) else {
+            return .failed("Not a worktree: \(path)")
+        }
+        let targetTree = revParse("\(commit)^{tree}", in: path)
+
+        let status = GitProcess.run(
+            ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            in: path,
+            timeout: timeout
+        )
+        let isDirty = !(status ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+        if let targetTree, targetTree == headTree, !isDirty {
+            return .unchanged(commit: commit)
+        }
+        if isDirty && !force {
+            return .held(reason: .dirtyWorktree, commit: commit)
+        }
+
+        let result = GitProcess.capture(["reset", "--hard", commit], in: path, timeout: timeout)
+        guard result.succeeded else {
+            return .failed(result.stderr.isEmpty ? "git reset --hard failed" : result.stderr)
+        }
+        return .published(commit: commit)
+    }
+
+    private static func revParse(_ rev: String, in path: String) -> String? {
+        let value = GitProcess.run(["rev-parse", "--verify", "--quiet", rev], in: path, timeout: timeout)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (value?.isEmpty == false) ? value : nil
+    }
+
+    /// True when the checkout carries edits that publishing would discard.
+    static func hasLocalEdits(at path: String) -> Bool {
+        guard let status = GitProcess.run(
+            ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            in: path,
+            timeout: timeout
+        ) else { return false }
+        return !status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/Sources/Git/WorktreeSnapshotter.swift
+++ b/Sources/Git/WorktreeSnapshotter.swift
@@ -87,6 +87,13 @@ enum WorktreeSnapshotter {
         return WorktreeSnapshot(commit: commit, tree: tree, head: head)
     }
 
+    /// The worktree's HEAD, with nothing on top. For a worktree whose agent is
+    /// mid-turn: its last self-consistent state, where a live snapshot would
+    /// catch half a file.
+    static func head(worktreePath: String) -> String? {
+        revParse("HEAD", in: worktreePath)
+    }
+
     /// `commit-tree` with seahelm's identity, so it works in a repo where the
     /// user has configured none.
     static func commitTree(

--- a/Sources/Git/WorktreeSnapshotter.swift
+++ b/Sources/Git/WorktreeSnapshotter.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// A worktree's full current state as a commit: what is committed, plus what is
+/// staged, modified and untracked on top of it.
+struct WorktreeSnapshot: Equatable {
+    /// Commit holding the state. Equal to `head` when nothing is outstanding.
+    let commit: String
+    /// Tree of that commit. This is the change key: two snapshots with the same
+    /// tree describe the same files, whatever their commits are.
+    let tree: String
+    /// The worktree's own HEAD at snapshot time.
+    let head: String
+
+    /// Nothing outstanding — the snapshot is HEAD itself, no objects written.
+    var isClean: Bool { commit == head }
+}
+
+/// Captures a worktree without disturbing it.
+///
+/// Integration needs a commit per worktree, but an agent's turn usually ends
+/// with work that is edited and not committed — and requiring a commit first
+/// brings back everything wrong with `git add -A && git commit`: the repo's
+/// pre-commit hooks, whatever `-A` happens to sweep up, and a history full of
+/// machine commits.
+///
+/// So the snapshot is built in a scratch index instead. `GIT_INDEX_FILE` points
+/// `read-tree`/`add` at a temporary file, `write-tree` turns it into a tree and
+/// `commit-tree` into a commit. The worktree, the real index and HEAD are never
+/// touched, so an agent working in that directory cannot tell this happened.
+///
+/// `git stash create` looks like it would do this and is the obvious first
+/// guess, but it omits untracked files — which is most of what an agent
+/// produces.
+enum WorktreeSnapshotter {
+    /// `add -A` walks the whole worktree, so this gets more room than a quick
+    /// lookup, and rather less than a command that runs the repo's hooks.
+    static let timeout: TimeInterval = 60
+
+    /// Snapshots carry seahelm's own identity rather than the user's: they are
+    /// machine artefacts of a throwaway integration, and should not read as
+    /// something the user authored.
+    static let authorName = "seahelm"
+    static let authorEmail = "seahelm@localhost"
+
+    static func snapshot(worktreePath: String) -> WorktreeSnapshot? {
+        guard let head = revParse("HEAD", in: worktreePath),
+              let headTree = revParse("HEAD^{tree}", in: worktreePath) else {
+            // Unborn branch, or not a worktree at all. Nothing to integrate.
+            return nil
+        }
+
+        // The common case by a wide margin, and the only one that writes no
+        // objects: skip straight to HEAD when there is nothing on top of it.
+        guard let status = GitProcess.run(
+            ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            in: worktreePath,
+            timeout: timeout
+        ), !status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return WorktreeSnapshot(commit: head, tree: headTree, head: head)
+        }
+
+        guard let scratch = makeScratchIndex() else { return nil }
+        defer { try? FileManager.default.removeItem(at: scratch.directory) }
+        let env = ["GIT_INDEX_FILE": scratch.indexPath]
+
+        guard GitProcess.run(["read-tree", "HEAD"], in: worktreePath, timeout: timeout, environment: env) != nil,
+              GitProcess.run(["add", "-A"], in: worktreePath, timeout: timeout, environment: env) != nil,
+              let tree = GitProcess.run(["write-tree"], in: worktreePath, timeout: timeout, environment: env)?
+                  .trimmingCharacters(in: .whitespacesAndNewlines),
+              !tree.isEmpty else {
+            return nil
+        }
+
+        // An `add -A` that changes nothing still lands here when status saw only
+        // ignored noise; returning HEAD keeps the commit out of the graph.
+        if tree == headTree {
+            return WorktreeSnapshot(commit: head, tree: headTree, head: head)
+        }
+
+        guard let commit = commitTree(
+            tree: tree,
+            parents: [head],
+            message: "seahelm: worktree snapshot",
+            repoPath: worktreePath
+        ) else { return nil }
+
+        return WorktreeSnapshot(commit: commit, tree: tree, head: head)
+    }
+
+    /// `commit-tree` with seahelm's identity, so it works in a repo where the
+    /// user has configured none.
+    static func commitTree(
+        tree: String,
+        parents: [String],
+        message: String,
+        repoPath: String
+    ) -> String? {
+        var args = ["-c", "user.name=\(authorName)", "-c", "user.email=\(authorEmail)", "commit-tree", tree]
+        for parent in parents {
+            args.append(contentsOf: ["-p", parent])
+        }
+        args.append(contentsOf: ["-m", message])
+        return GitProcess.run(args, in: repoPath, timeout: timeout)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nonEmpty
+    }
+
+    private static func revParse(_ rev: String, in worktreePath: String) -> String? {
+        GitProcess.run(["rev-parse", "--verify", "--quiet", rev], in: worktreePath, timeout: timeout)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nonEmpty
+    }
+
+    /// A private directory holding one scratch index. The directory is what
+    /// gets cleaned up — git writes lock files next to the index, so removing
+    /// the index alone leaves them behind.
+    private struct ScratchIndex {
+        let directory: URL
+        var indexPath: String { directory.appendingPathComponent("index").path }
+    }
+
+    private static func makeScratchIndex() -> ScratchIndex? {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-index-\(UUID().uuidString)")
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            NSLog("WorktreeSnapshotter: could not create scratch index dir: \(error)")
+            return nil
+        }
+        return ScratchIndex(directory: dir)
+    }
+}
+
+private extension String {
+    var nonEmpty: String? { isEmpty ? nil : self }
+}

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -2305,7 +2305,12 @@ final class DashboardOverviewView: NSView {
         headerSub.stringValue = running > 0 ? "\(panes.count) · \(running) running" : "\(panes.count)"
 
         let panesByPath = Dictionary(panes.map { ($0.worktreePath, $0) }, uniquingKeysWith: { first, _ in first })
-        let groupingItems = panes.map { $0.groupingItem(creationDate: Self.creationDate($0.worktreePath)) }
+        let groupingItems = panes.map {
+            $0.groupingItem(
+                creationDate: Self.creationDate($0.worktreePath),
+                isIntegration: IntegrationWorktreeStore.shared.isIntegrationWorktree($0.worktreePath)
+            )
+        }
         let groups = WorktreeGrouping.groups(groupingItems, mode: groupingMode, now: now())
 
         // A mode switch is an explicit navigation action. If its previous

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -103,6 +103,9 @@ class DashboardViewController: NSViewController {
     /// The "+" on a project group header was clicked. Args: the project title and
     /// the rect + view to anchor the create popover to.
     var onAddWorktreeToProject: ((String, NSRect, NSView) -> Void)?
+    /// Fold this project's worktrees into its integration checkout. Equivalent
+    /// to typing `/integrate` with that repo selected.
+    var onIntegrateProject: ((String) -> Void)?
     /// The fleet header "+" was clicked: open the folder picker to add a repo.
     var onRequestAddRepo: (() -> Void)?
 
@@ -354,6 +357,9 @@ class DashboardViewController: NSViewController {
         // "+" on a project group header: the anchored create form, scoped to that
         // project. The window owns the create itself (it holds the repo map and the
         // worktree-create path), so forward the click with its anchor view.
+        overviewView.onIntegrate = { [weak self] project in
+            self?.onIntegrateProject?(project)
+        }
         overviewView.onAddWorktree = { [weak self] project, rect, anchor in
             self?.onAddWorktreeToProject?(project, rect, anchor)
         }
@@ -1972,6 +1978,7 @@ final class DashboardOverviewView: NSView {
     /// the button's rect in this view's coordinates, and this view (the popover's
     /// anchor — see `addWorktreeClicked`).
     var onAddWorktree: ((String, NSRect, NSView) -> Void)?
+    var onIntegrate: ((String) -> Void)?
     /// The header "+" was clicked: add a repo via the folder picker.
     var onAddRepo: (() -> Void)?
     /// The bottom shortcut strip was clicked — show the full `?` cheat-sheet.
@@ -2014,7 +2021,11 @@ final class DashboardOverviewView: NSView {
     /// Project title per "add worktree" button, indexed by the button's tag —
     /// rebuilt with the rows on every render.
     private var addWorktreeProjects: [String] = []
+    /// Tag → project for the integrate buttons, rebuilt on every full render
+    /// exactly like `addWorktreeProjects`.
+    private var integrateProjects: [String] = []
     private static let addWorktreeButtonIdentifier = NSUserInterfaceItemIdentifier("seahelm.addWorktree")
+    private static let integrateButtonIdentifier = NSUserInterfaceItemIdentifier("seahelm.integrate")
     private var revealedRowID: String?
     /// The one row currently painting the hover tint, if any.
     private weak var hoveredRow: FleetHoverRow?
@@ -2349,6 +2360,7 @@ final class DashboardOverviewView: NSView {
         paneRowViewsByStationID = [:]
         renderedGroupTitles = []
         addWorktreeProjects = []
+        integrateProjects = []
         revealedRowID = nil
 
         for (groupIndex, group) in groups.enumerated() {
@@ -2543,6 +2555,15 @@ final class DashboardOverviewView: NSView {
             .filter { $0.identifier == Self.addWorktreeButtonIdentifier }
             .compactMap { addWorktreeProjects[safeIndex: $0.tag] }
     }
+    /// Project titles behind the rendered "integrate" buttons, in group order.
+    var integrateProjectsForTesting: [String] {
+        stack.arrangedSubviews
+            .compactMap { $0 as? NSStackView }
+            .flatMap { $0.arrangedSubviews }
+            .compactMap { $0 as? NSButton }
+            .filter { $0.identifier == Self.integrateButtonIdentifier }
+            .compactMap { integrateProjects[safeIndex: $0.tag] }
+    }
     var renderedSelectedRowIDForTesting: String? { rowViewsByID[selectedId] == nil ? nil : selectedId }
     /// Ids of every row currently painting the hover tint — more than one means
     /// the scroll-leaves-a-trail bug is back.
@@ -2605,6 +2626,12 @@ final class DashboardOverviewView: NSView {
             let spacer = NSView()
             spacer.setContentHuggingPriority(.defaultLow - 1, for: .horizontal)
             views.append(spacer)
+            // Only worth offering once there is more than one worktree to fold
+            // together — on a single-worktree project it would integrate a repo
+            // with itself.
+            if group.items.count > 1 {
+                views.append(makeIntegrateButton(project: group.title))
+            }
             let button = makeAddWorktreeButton(project: group.title)
             views.append(button)
             addButton = button
@@ -2620,6 +2647,44 @@ final class DashboardOverviewView: NSView {
             addButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         }
         return row
+    }
+
+    /// Trailing "integrate" affordance on a project group header. Equivalent to
+    /// `/integrate` with that repo selected, and the only place the feature
+    /// announces itself — otherwise it is a command you have to already know.
+    private func makeIntegrateButton(project: String) -> NSButton {
+        let button = NSButton()
+        button.isBordered = false
+        button.bezelStyle = .inline
+        button.refusesFirstResponder = true
+        if let image = NSImage(systemSymbolName: "arrow.trianglehead.merge", accessibilityDescription: nil)?
+            .withSymbolConfiguration(.init(pointSize: 11, weight: .medium))
+            ?? NSImage(systemSymbolName: "arrow.triangle.merge", accessibilityDescription: nil)?
+            .withSymbolConfiguration(.init(pointSize: 11, weight: .medium)) {
+            button.image = image
+            button.title = ""
+            button.imagePosition = .imageOnly
+        } else {
+            button.title = "⑃"
+            button.font = AppFont.mono(size: 12)
+        }
+        button.contentTintColor = Self.inkFaint
+        let description = "Integrate \(project)"
+        button.toolTip = description
+        button.setAccessibilityLabel(description)
+        button.identifier = Self.integrateButtonIdentifier
+        button.target = self
+        button.action = #selector(integrateClicked(_:))
+        button.tag = integrateProjects.count
+        integrateProjects.append(project)
+        button.setContentHuggingPriority(.required, for: .horizontal)
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return button
+    }
+
+    @objc private func integrateClicked(_ sender: NSButton) {
+        guard let project = integrateProjects[safeIndex: sender.tag] else { return }
+        onIntegrate?(project)
     }
 
     /// Trailing "add worktree" affordance on a project group header. Equivalent

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -106,6 +106,10 @@ class DashboardViewController: NSViewController {
     /// Fold this project's worktrees into its integration checkout. Equivalent
     /// to typing `/integrate` with that repo selected.
     var onIntegrateProject: ((String) -> Void)?
+    /// Master switch for the integration feature, forwarded to the fleet view.
+    var integrationEnabled: Bool = true {
+        didSet { overviewView.integrationEnabled = integrationEnabled }
+    }
     /// The fleet header "+" was clicked: open the folder picker to add a repo.
     var onRequestAddRepo: (() -> Void)?
 
@@ -2032,6 +2036,18 @@ final class DashboardOverviewView: NSView {
     /// without writing into the user's real config directory.
     private let isIntegrationWorktree: (String) -> Bool
     private let integrationStatus: (String) -> String?
+    /// Master switch, pushed down from settings. Off hides the button, the
+    /// banner and the pinned row — the checkout on disk is left alone.
+    var integrationEnabled: Bool = true {
+        didSet {
+            guard integrationEnabled != oldValue else { return }
+            // The flag changes what the header and banner hold, which the
+            // structure signature does not describe — drop it so the next pass
+            // is a full render rather than an incremental one.
+            lastStructureSignature = nil
+            render(latestPanes, revealSelection: false)
+        }
+    }
     private let integrationBanner = NSStackView()
     private var integrationBannerHeight: NSLayoutConstraint!
     private var integrationBannerLines: [String] = []
@@ -2185,7 +2201,7 @@ final class DashboardOverviewView: NSView {
     /// path, because the line changes far more often than the fleet's structure
     /// does — that is the whole reason it lives outside `stack`.
     private func refreshIntegrationBanner(_ panes: [WorktreeRowInfo]) {
-        let checkouts = groupingMode == .status || groupingMode == .activityTime
+        let checkouts = integrationEnabled && (groupingMode == .status || groupingMode == .activityTime)
             ? panes.filter { isIntegrationWorktree($0.worktreePath) }
             : []
 
@@ -2392,7 +2408,7 @@ final class DashboardOverviewView: NSView {
         let groupingItems = panes.map {
             $0.groupingItem(
                 creationDate: Self.creationDate($0.worktreePath),
-                isIntegration: isIntegrationWorktree($0.worktreePath)
+                isIntegration: integrationEnabled && isIntegrationWorktree($0.worktreePath)
             )
         }
         let groups = WorktreeGrouping.groups(groupingItems, mode: groupingMode, now: now())
@@ -2709,7 +2725,7 @@ final class DashboardOverviewView: NSView {
             // Only worth offering once there is more than one worktree to fold
             // together — on a single-worktree project it would integrate a repo
             // with itself.
-            if group.items.count > 1 {
+            if integrationEnabled, group.items.count > 1 {
                 views.append(makeIntegrateButton(project: group.title))
             }
             let button = makeAddWorktreeButton(project: group.title)

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -2024,6 +2024,17 @@ final class DashboardOverviewView: NSView {
     /// Tag → project for the integrate buttons, rebuilt on every full render
     /// exactly like `addWorktreeProjects`.
     private var integrateProjects: [String] = []
+    /// Integration checkouts, shown above the fleet in the modes that group by
+    /// status or time. Deliberately outside `stack`: those groupings leave the
+    /// checkout out, and a banner inside the scrolling stack would go stale
+    /// whenever `render` takes the incremental path.
+    /// Seams, so a test can describe a fleet with an integration checkout
+    /// without writing into the user's real config directory.
+    private let isIntegrationWorktree: (String) -> Bool
+    private let integrationStatus: (String) -> String?
+    private let integrationBanner = NSStackView()
+    private var integrationBannerHeight: NSLayoutConstraint!
+    private var integrationBannerLines: [String] = []
     private static let addWorktreeButtonIdentifier = NSUserInterfaceItemIdentifier("seahelm.addWorktree")
     private static let integrateButtonIdentifier = NSUserInterfaceItemIdentifier("seahelm.integrate")
     private var revealedRowID: String?
@@ -2043,6 +2054,8 @@ final class DashboardOverviewView: NSView {
         let preference = WorktreeGroupingPreference(defaults: .standard)
         groupingPreference = preference
         now = Date.init
+        isIntegrationWorktree = { IntegrationWorktreeStore.shared.isIntegrationWorktree($0) }
+        integrationStatus = { IntegrationStatusStore.shared.status(forWorktree: $0) }
         groupingMode = preference.load()
         super.init(frame: frameRect)
         setup()
@@ -2051,15 +2064,25 @@ final class DashboardOverviewView: NSView {
         let preference = WorktreeGroupingPreference(defaults: .standard)
         groupingPreference = preference
         now = Date.init
+        isIntegrationWorktree = { IntegrationWorktreeStore.shared.isIntegrationWorktree($0) }
+        integrationStatus = { IntegrationStatusStore.shared.status(forWorktree: $0) }
         groupingMode = preference.load()
         super.init(coder: coder)
         setup()
     }
 
-    init(frame frameRect: NSRect, defaults: UserDefaults, now: @escaping () -> Date) {
+    init(
+        frame frameRect: NSRect,
+        defaults: UserDefaults,
+        now: @escaping () -> Date,
+        isIntegrationWorktree: @escaping (String) -> Bool = { IntegrationWorktreeStore.shared.isIntegrationWorktree($0) },
+        integrationStatus: @escaping (String) -> String? = { IntegrationStatusStore.shared.status(forWorktree: $0) }
+    ) {
         let preference = WorktreeGroupingPreference(defaults: defaults)
         groupingPreference = preference
         self.now = now
+        self.isIntegrationWorktree = isIntegrationWorktree
+        self.integrationStatus = integrationStatus
         groupingMode = preference.load()
         super.init(frame: frameRect)
         setup()
@@ -2114,6 +2137,13 @@ final class DashboardOverviewView: NSView {
                                                object: scroll.contentView)
         addSubview(scroll)
 
+        // --- Integration banner (status / time groupings only) ---
+        integrationBanner.orientation = .vertical
+        integrationBanner.spacing = 3
+        integrationBanner.alignment = .leading
+        integrationBanner.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(integrationBanner)
+
         // --- Bottom shortcut strip ---
         hintBar.onShowAllShortcuts = { [weak self] in self?.onShowAllShortcuts?() }
         addSubview(hintBar)
@@ -2128,7 +2158,11 @@ final class DashboardOverviewView: NSView {
             headerLine.trailingAnchor.constraint(equalTo: trailingAnchor),
             headerLine.heightAnchor.constraint(equalToConstant: 1),
 
-            scroll.topAnchor.constraint(equalTo: headerLine.bottomAnchor, constant: 14),
+            integrationBanner.topAnchor.constraint(equalTo: headerLine.bottomAnchor, constant: 10),
+            integrationBanner.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 15),
+            integrationBanner.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -15),
+
+            scroll.topAnchor.constraint(equalTo: integrationBanner.bottomAnchor, constant: 4),
             scroll.leadingAnchor.constraint(equalTo: leadingAnchor),
             scroll.trailingAnchor.constraint(equalTo: trailingAnchor),
             scroll.bottomAnchor.constraint(equalTo: hintBar.topAnchor),
@@ -2139,6 +2173,45 @@ final class DashboardOverviewView: NSView {
 
             stack.widthAnchor.constraint(equalTo: scroll.contentView.widthAnchor),
         ])
+        // Collapsed by default; height is the only thing that moves, so showing
+        // and hiding it never reflows the rest of the column.
+        integrationBannerHeight = integrationBanner.heightAnchor.constraint(equalToConstant: 0)
+        integrationBannerHeight.isActive = true
+    }
+
+    /// Rebuilds the banner from the panes that are integration checkouts.
+    ///
+    /// Called on every update, including the ones that take the incremental
+    /// path, because the line changes far more often than the fleet's structure
+    /// does — that is the whole reason it lives outside `stack`.
+    private func refreshIntegrationBanner(_ panes: [WorktreeRowInfo]) {
+        let checkouts = groupingMode == .status || groupingMode == .activityTime
+            ? panes.filter { isIntegrationWorktree($0.worktreePath) }
+            : []
+
+        // Compare the rendered text, not the paths: the line changes far more
+        // often than the set of checkouts does, and rebuilding labels on every
+        // poll would churn views for nothing.
+        let lines = checkouts.map { checkout in
+            "⑃  " + (integrationStatus(checkout.worktreePath) ?? "integration · not built yet")
+        }
+        guard lines != integrationBannerLines else { return }
+        integrationBannerLines = lines
+
+        integrationBanner.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        guard !lines.isEmpty else {
+            integrationBannerHeight.constant = 0
+            return
+        }
+
+        for line in lines {
+            let label = NSTextField(labelWithString: line)
+            label.font = AppFont.mono(size: 11)
+            label.textColor = Self.inkDim
+            label.lineBreakMode = .byTruncatingTail
+            integrationBanner.addArrangedSubview(label)
+        }
+        integrationBannerHeight.constant = CGFloat(lines.count) * 15 + CGFloat(max(0, lines.count - 1)) * 3
     }
 
     /// Header: add a whole repo via the folder picker.
@@ -2319,7 +2392,7 @@ final class DashboardOverviewView: NSView {
         let groupingItems = panes.map {
             $0.groupingItem(
                 creationDate: Self.creationDate($0.worktreePath),
-                isIntegration: IntegrationWorktreeStore.shared.isIntegrationWorktree($0.worktreePath)
+                isIntegration: isIntegrationWorktree($0.worktreePath)
             )
         }
         let groups = WorktreeGrouping.groups(groupingItems, mode: groupingMode, now: now())
@@ -2333,6 +2406,8 @@ final class DashboardOverviewView: NSView {
            !groups.contains(where: { group in group.items.contains(where: { $0.id == selectedId }) }) {
             selectedId = groups.first?.items.first?.id ?? ""
         }
+
+        refreshIntegrationBanner(panes)
 
         let structureSignature = Self.structureSignature(for: groups, panesByPath: panesByPath, groupingMode: groupingMode)
         if !revealSelection, structureSignature == lastStructureSignature {
@@ -2554,6 +2629,11 @@ final class DashboardOverviewView: NSView {
             .compactMap { $0 as? NSButton }
             .filter { $0.identifier == Self.addWorktreeButtonIdentifier }
             .compactMap { addWorktreeProjects[safeIndex: $0.tag] }
+    }
+    /// Lines currently shown in the integration banner, top to bottom.
+    var integrationBannerLinesForTesting: [String] {
+        integrationBanner.arrangedSubviews
+            .compactMap { ($0 as? NSTextField)?.stringValue }
     }
     /// Project titles behind the rendered "integrate" buttons, in group order.
     var integrateProjectsForTesting: [String] {

--- a/Sources/UI/Dashboard/WorktreeGrouping.swift
+++ b/Sources/UI/Dashboard/WorktreeGrouping.swift
@@ -32,10 +32,34 @@ struct WorktreeGroupingItem: Equatable {
     let lastActivityAt: Date?
     let isMainWorktree: Bool
     let creationDate: Date
+    /// The repo's integration checkout rather than a fleet member. It has no
+    /// agent, so its status and activity describe a shell, not work — see
+    /// `groups(_:mode:now:calendar:)` for what that changes.
+    let isIntegration: Bool
+
+    init(
+        id: String,
+        path: String,
+        repository: String,
+        status: AgentStatus,
+        lastActivityAt: Date?,
+        isMainWorktree: Bool,
+        creationDate: Date,
+        isIntegration: Bool = false
+    ) {
+        self.id = id
+        self.path = path
+        self.repository = repository
+        self.status = status
+        self.lastActivityAt = lastActivityAt
+        self.isMainWorktree = isMainWorktree
+        self.creationDate = creationDate
+        self.isIntegration = isIntegration
+    }
 }
 
 extension WorktreeRowInfo {
-    func groupingItem(creationDate: Date) -> WorktreeGroupingItem {
+    func groupingItem(creationDate: Date, isIntegration: Bool = false) -> WorktreeGroupingItem {
         WorktreeGroupingItem(
             id: id,
             path: worktreePath,
@@ -43,7 +67,8 @@ extension WorktreeRowInfo {
             status: AgentStatus.highestPriority(paneStatuses),
             lastActivityAt: lastActivityAt,
             isMainWorktree: isMainWorktree,
-            creationDate: creationDate
+            creationDate: creationDate,
+            isIntegration: isIntegration
         )
     }
 }
@@ -64,11 +89,18 @@ enum WorktreeGrouping {
     ) -> [WorktreeGroup] {
         switch mode {
         case .repository, .pane:
+            // Belongs to its repo, so it belongs in the repo's group — pinned
+            // just under main rather than sorted among the agents.
             return repositoryGroups(items)
         case .status:
-            return statusGroups(items)
+            // Status groups answer "what needs me now" and time buckets answer
+            // "what has been happening". The integration checkout is neither: it
+            // has no agent, so its status is a shell's and its activity is
+            // terminal output. Including it would only dilute both views. It is
+            // surfaced separately instead.
+            return statusGroups(items.filter { !$0.isIntegration })
         case .activityTime:
-            return activityGroups(items, now: now, calendar: calendar)
+            return activityGroups(items.filter { !$0.isIntegration }, now: now, calendar: calendar)
         }
     }
 
@@ -165,6 +197,12 @@ enum WorktreeGrouping {
     ) -> Bool {
         if lhs.isMainWorktree != rhs.isMainWorktree {
             return lhs.isMainWorktree
+        }
+        // Pinned under main, explicitly rather than by creation date: it is a
+        // fixture of the repo, and sorting it by when it happened to be made
+        // would move it every time it is recreated.
+        if lhs.isIntegration != rhs.isIntegration {
+            return lhs.isIntegration
         }
         if lhs.creationDate != rhs.creationDate {
             return lhs.creationDate < rhs.creationDate

--- a/Sources/UI/Settings/SettingsViewController.swift
+++ b/Sources/UI/Settings/SettingsViewController.swift
@@ -78,6 +78,10 @@ class SettingsViewController: NSViewController {
     private lazy var copyOnSelectToggle = SettingsControls.toggle(
         on: GhosttyConfigImporter.copyOnSelectEnabled(),
         target: self, action: #selector(copyOnSelectChanged))
+    private lazy var integrationEnabledToggle = SettingsControls.toggle(
+        on: config.integrationEnabled, target: self, action: #selector(integrationControlChanged))
+    private lazy var autoIntegrateToggle = SettingsControls.toggle(
+        on: config.autoIntegrate, target: self, action: #selector(controlChanged))
     private lazy var revealGhosttyConfButton = SettingsControls.button(
         "Reveal ghostty.conf", target: self, action: #selector(revealGhosttyConfClicked))
 
@@ -319,6 +323,7 @@ class SettingsViewController: NSViewController {
                                     content: SettingsControls.surface(pathScrollView), height: 140),
                 SettingsRow.actions([addButton, removeButton]),
             ]),
+            makeIntegrationGroup(),
             SettingsGroupView(title: "Terminal", rows: [
                 SettingsRow.make("Scrollback rows cached",
                                  subtitle: "How much of each pane's viewport the status poll re-reads every cycle.",
@@ -331,6 +336,20 @@ class SettingsViewController: NSViewController {
                                  control: revealGhosttyConfButton),
             ]),
         ]
+    }
+
+    private func makeIntegrationGroup() -> NSView {
+        // Built here rather than inline so the dependent toggle's enabled state
+        // is set once, at construction, and not left to the first click.
+        refreshIntegrationEnabledState()
+        return SettingsGroupView(title: "Integration", rows: [
+            SettingsRow.make("Integration worktree",
+                             subtitle: "A throwaway checkout per project holding every worktree folded onto trunk, to run integration tests in. Off hides it everywhere; a checkout already on disk is left alone.",
+                             control: integrationEnabledToggle),
+            SettingsRow.make("Keep it current",
+                             subtitle: "Rebuild it as agents finish turns. Only ever touches a project that already has a checkout — running /integrate once is what creates one.",
+                             control: autoIntegrateToggle),
+        ])
     }
 
     // MARK: - Agents
@@ -673,6 +692,16 @@ class SettingsViewController: NSViewController {
     /// there is nothing to cancel back to.
     @objc private func controlChanged() { applyChanges() }
 
+    /// The master switch owns whether the finer one can be reached at all.
+    @objc private func integrationControlChanged() {
+        refreshIntegrationEnabledState()
+        applyChanges()
+    }
+
+    private func refreshIntegrationEnabledState() {
+        autoIntegrateToggle.isEnabled = integrationEnabledToggle.state == .on
+    }
+
     @objc private func copyOnSelectChanged() {
         let enabled = copyOnSelectToggle.state == .on
         guard GhosttyConfigImporter.setCopyOnSelect(enabled) else { return }
@@ -687,6 +716,8 @@ class SettingsViewController: NSViewController {
     private func applyChanges() {
         // Update config from UI
         config.workspacePaths = workspacePaths
+        config.integrationEnabled = integrationEnabledToggle.state == .on
+        config.autoIntegrate = autoIntegrateToggle.state == .on
         config.terminalRowCacheSize = Int(cacheSizeField.stringValue) ?? 200
         config.agentMemoryGuard = AgentMemoryGuardConfig(
             warnMB: Self.parseGBField(memoryWarnField, fallbackMB: config.agentMemoryGuard.warnMB),

--- a/Sources/UI/SidePanel/WorktreeSidePanelViewController.swift
+++ b/Sources/UI/SidePanel/WorktreeSidePanelViewController.swift
@@ -154,9 +154,20 @@ final class WorktreeSidePanelViewController: NSViewController {
     /// Identity of a tab's container, so a test can prove it was reused not rebuilt.
     func containerForTesting(_ tab: SidePanelTab) -> NSView? { tabContainers[tab] }
 
-    init(worktreePath: String?, initialTab: SidePanelTab = .firstMate) {
+    /// Seam for tests, so one can describe an integration checkout without
+    /// writing into the user's real config directory.
+    private let integrationState: (String) -> IntegrationPanelState?
+
+    init(
+        worktreePath: String?,
+        initialTab: SidePanelTab = .firstMate,
+        integrationState: @escaping (String) -> IntegrationPanelState? = {
+            IntegrationStatusStore.shared.state(forWorktree: $0)
+        }
+    ) {
         self.worktreePath = worktreePath
         self.selectedTab = initialTab
+        self.integrationState = integrationState
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -610,8 +621,23 @@ final class WorktreeSidePanelViewController: NSViewController {
             header.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
         ])
 
+        // An integration checkout's diff is the fold of several worktrees, so
+        // the file list alone does not say whose work it is — or whose was left
+        // out. That belongs here rather than behind a fourth chrome icon that
+        // would be dead for every other worktree.
+        let composition = worktreePath.flatMap(integrationState).map(makeIntegrationComposition)
+        if let composition {
+            contentView.addSubview(composition)
+            NSLayoutConstraint.activate([
+                composition.topAnchor.constraint(equalTo: header.bottomAnchor, constant: 6),
+                composition.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 12),
+                composition.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -12),
+            ])
+        }
+        let listTop = composition ?? header
+
         if changedFiles.isEmpty {
-            showPlaceholder("No changes", identifier: "sidePanel.changesEmpty", below: header)
+            showPlaceholder("No changes", identifier: "sidePanel.changesEmpty", below: listTop)
             return
         }
 
@@ -624,7 +650,7 @@ final class WorktreeSidePanelViewController: NSViewController {
         contentView.addSubview(scrollView)
 
         NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: header.bottomAnchor, constant: 8),
+            scrollView.topAnchor.constraint(equalTo: listTop.bottomAnchor, constant: 8),
             scrollView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 6),
             scrollView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -6),
             scrollView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
@@ -645,6 +671,47 @@ final class WorktreeSidePanelViewController: NSViewController {
                 scrollView.reflectScrolledClipView(scrollView.contentView)
             }
         }
+    }
+
+    /// What the last round folded in, and what it could not.
+    private func makeIntegrationComposition(_ state: IntegrationPanelState) -> NSView {
+        var lines: [(String, NSColor)] = []
+        lines.append((
+            state.included.isEmpty ? "nothing folded in" : "in: " + state.included.joined(separator: ", "),
+            Theme.textSecondary
+        ))
+        for excluded in state.excluded {
+            let where_ = excluded.paths.isEmpty ? "" : " · " + excluded.paths.joined(separator: ", ")
+            lines.append(("excluded: \(excluded.label)\(where_)", .systemOrange))
+        }
+        if !state.conflictedPaths.isEmpty {
+            lines.append(("conflict markers: " + state.conflictedPaths.joined(separator: ", "), .systemOrange))
+        }
+        if state.isHeld {
+            lines.append(("not checked out — local edits here · /integrate force", .systemOrange))
+        }
+
+        let stack = NSStackView(views: lines.map { text, color in
+            let label = NSTextField(labelWithString: text)
+            label.font = AppFont.mono(size: 10.5)
+            label.textColor = color
+            label.lineBreakMode = .byTruncatingTail
+            return label
+        })
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 2
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.setAccessibilityIdentifier("sidePanel.integrationComposition")
+        return stack
+    }
+
+    /// Composition lines currently rendered, top to bottom.
+    var integrationCompositionLinesForTesting: [String] {
+        guard let stack = contentView.subviews.first(where: {
+            $0.accessibilityIdentifier() == "sidePanel.integrationComposition"
+        }) as? NSStackView else { return [] }
+        return stack.arrangedSubviews.compactMap { ($0 as? NSTextField)?.stringValue }
     }
 
     private func makeChangesFlatScrollView() -> NSScrollView {

--- a/Tests/BridgeCommandParserTests.swift
+++ b/Tests/BridgeCommandParserTests.swift
@@ -260,14 +260,22 @@ final class BridgeCommandParserTests: XCTestCase {
 
     // MARK: - /integrate
 
-    func testIntegrateDefaultsToDroppingConflicts() {
-        XCTAssertEqual(parse("/integrate"), .success(.integrate(mode: .excludeConflicting)))
-        XCTAssertEqual(parse("/integrate clean"), .success(.integrate(mode: .excludeConflicting)))
+    func testIntegrateDefaultsToDroppingConflictsAndNotForcing() {
+        XCTAssertEqual(parse("/integrate"), .success(.integrate(mode: .excludeConflicting, force: false)))
+        XCTAssertEqual(parse("/integrate clean"), .success(.integrate(mode: .excludeConflicting, force: false)))
     }
 
     func testIntegrateFullKeepsConflictingWorktrees() {
-        XCTAssertEqual(parse("/integrate full"), .success(.integrate(mode: .includeWithMarkers)))
-        XCTAssertEqual(parse("/integrate FULL"), .success(.integrate(mode: .includeWithMarkers)))
+        XCTAssertEqual(parse("/integrate full"), .success(.integrate(mode: .includeWithMarkers, force: false)))
+        XCTAssertEqual(parse("/integrate FULL"), .success(.integrate(mode: .includeWithMarkers, force: false)))
+    }
+
+    /// `force` is the escape hatch from the one hold the feature has, and is
+    /// independent of how conflicts are treated.
+    func testIntegrateForceCombinesWithEitherMode() {
+        XCTAssertEqual(parse("/integrate force"), .success(.integrate(mode: .excludeConflicting, force: true)))
+        XCTAssertEqual(parse("/integrate full force"), .success(.integrate(mode: .includeWithMarkers, force: true)))
+        XCTAssertEqual(parse("/integrate force full"), .success(.integrate(mode: .includeWithMarkers, force: true)))
     }
 
     /// An unrecognised argument is a typo, not a silent fallback to the default:

--- a/Tests/BridgeCommandParserTests.swift
+++ b/Tests/BridgeCommandParserTests.swift
@@ -258,6 +258,24 @@ final class BridgeCommandParserTests: XCTestCase {
         XCTAssertFalse(list.contains("1. alpha / feat-x"), "repo/branch should not repeat per row: \(list)")
     }
 
+    // MARK: - /integrate
+
+    func testIntegrateDefaultsToDroppingConflicts() {
+        XCTAssertEqual(parse("/integrate"), .success(.integrate(mode: .excludeConflicting)))
+        XCTAssertEqual(parse("/integrate clean"), .success(.integrate(mode: .excludeConflicting)))
+    }
+
+    func testIntegrateFullKeepsConflictingWorktrees() {
+        XCTAssertEqual(parse("/integrate full"), .success(.integrate(mode: .includeWithMarkers)))
+        XCTAssertEqual(parse("/integrate FULL"), .success(.integrate(mode: .includeWithMarkers)))
+    }
+
+    /// An unrecognised argument is a typo, not a silent fallback to the default:
+    /// `/integrate ful` must not quietly drop someone's conflicting work.
+    func testIntegrateRejectsAnUnknownArgument() {
+        XCTAssertEqual(parse("/integrate ful"), .failure(.unknownTarget("ful")))
+    }
+
     func testFormatterEmptyStates() {
         XCTAssertEqual(BridgeCommandFormatter.agentList([], currentId: nil), "No panes in this worktree.")
         XCTAssertTrue(BridgeCommandFormatter.worktreeList([], currentPath: nil).contains("No worktrees"))

--- a/Tests/BridgeCommandRouterTests.swift
+++ b/Tests/BridgeCommandRouterTests.swift
@@ -13,7 +13,7 @@ final class BridgeCommandRouterTests: XCTestCase {
                     removeRepo: @escaping (String) -> Void = { _ in },
                     removeWorktree: @escaping (String) -> Void = { _ in },
                     flagIssue: @escaping (String) -> Void = { _ in },
-                    integrate: @escaping (IntegrationConflictMode) -> Void = { _ in },
+                    integrate: @escaping (IntegrationConflictMode, Bool) -> Void = { _, _ in },
                     agentCount: @escaping () -> Int = { 0 }) -> BridgeCommandRouter {
         BridgeCommandRouter(queue: queue, createWorktree: created,
                             selectWorktree: selectWorktree, selectAgent: selectAgent,
@@ -30,11 +30,12 @@ final class BridgeCommandRouterTests: XCTestCase {
     /// before the final checkout can disturb a worktree.
     func testIntegrateCallsClosureNotQueue() {
         let q = PendingOrdersQueue()
-        var modes: [IntegrationConflictMode] = []
-        let router = makeRouter(queue: q, integrate: { modes.append($0) })
-        router.route(.integrate(mode: .excludeConflicting))
-        router.route(.integrate(mode: .includeWithMarkers))
-        XCTAssertEqual(modes, [.excludeConflicting, .includeWithMarkers])
+        var calls: [(IntegrationConflictMode, Bool)] = []
+        let router = makeRouter(queue: q, integrate: { calls.append(($0, $1)) })
+        router.route(.integrate(mode: .excludeConflicting, force: false))
+        router.route(.integrate(mode: .includeWithMarkers, force: true))
+        XCTAssertEqual(calls.map(\.0), [.excludeConflicting, .includeWithMarkers])
+        XCTAssertEqual(calls.map(\.1), [false, true])
         XCTAssertTrue(q.all().isEmpty)
     }
 

--- a/Tests/BridgeCommandRouterTests.swift
+++ b/Tests/BridgeCommandRouterTests.swift
@@ -13,6 +13,7 @@ final class BridgeCommandRouterTests: XCTestCase {
                     removeRepo: @escaping (String) -> Void = { _ in },
                     removeWorktree: @escaping (String) -> Void = { _ in },
                     flagIssue: @escaping (String) -> Void = { _ in },
+                    integrate: @escaping (IntegrationConflictMode) -> Void = { _ in },
                     agentCount: @escaping () -> Int = { 0 }) -> BridgeCommandRouter {
         BridgeCommandRouter(queue: queue, createWorktree: created,
                             selectWorktree: selectWorktree, selectAgent: selectAgent,
@@ -20,8 +21,21 @@ final class BridgeCommandRouterTests: XCTestCase {
                             removeAll: removeAll, addRepo: addRepo, removeRepo: removeRepo,
                             removeWorktree: removeWorktree,
                             flagIssue: flagIssue,
+                            integrate: integrate,
                             activePaneCount: agentCount,
                             branchForPath: { _ in "feat-x" }, projectForPath: { _ in "repo" })
+    }
+
+    /// `/integrate` runs directly rather than becoming a card: nothing it does
+    /// before the final checkout can disturb a worktree.
+    func testIntegrateCallsClosureNotQueue() {
+        let q = PendingOrdersQueue()
+        var modes: [IntegrationConflictMode] = []
+        let router = makeRouter(queue: q, integrate: { modes.append($0) })
+        router.route(.integrate(mode: .excludeConflicting))
+        router.route(.integrate(mode: .includeWithMarkers))
+        XCTAssertEqual(modes, [.excludeConflicting, .includeWithMarkers])
+        XCTAssertTrue(q.all().isEmpty)
     }
 
     func testRemoveRepoCallsClosureNotQueue() {

--- a/Tests/ConfigTests.swift
+++ b/Tests/ConfigTests.swift
@@ -477,4 +477,22 @@ final class ConfigTests: XCTestCase {
         XCTAssertEqual(config.agents[0].rules[0].status, "Running")
         XCTAssertEqual(config.agents[0].rules[0].patterns, ["working"])
     }
+
+    /// Both integration flags default on, so a config written before they
+    /// existed keeps the feature exactly as it behaved.
+    func testIntegrationFlagsDefaultOnForOlderConfigs() throws {
+        let json = Data("{}".utf8)
+        let config = try JSONDecoder().decode(Config.self, from: json)
+        XCTAssertTrue(config.integrationEnabled)
+        XCTAssertTrue(config.autoIntegrate)
+    }
+
+    func testIntegrationFlagsRoundTrip() throws {
+        var config = try JSONDecoder().decode(Config.self, from: Data("{}".utf8))
+        config.integrationEnabled = false
+        config.autoIntegrate = false
+        let decoded = try JSONDecoder().decode(Config.self, from: try JSONEncoder().encode(config))
+        XCTAssertFalse(decoded.integrationEnabled)
+        XCTAssertFalse(decoded.autoIntegrate)
+    }
 }

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -262,6 +262,42 @@ final class DashboardOverviewGroupingTests: XCTestCase {
         ]
     }
 
+    // MARK: - the master switch
+
+    /// Off means the feature is not there: no button, no banner, and the
+    /// checkout stops being pinned — it just sorts as an ordinary worktree.
+    func testDisablingIntegrationHidesEverySurface() {
+        withDefaults { defaults in
+            let view = makeViewWithIntegration(defaults: defaults, status: "integration · 2 worktrees")
+            view.update(fleetWithIntegration())
+            XCTAssertEqual(view.integrateProjectsForTesting, ["alpha"])
+
+            view.integrationEnabled = false
+            XCTAssertEqual(view.integrateProjectsForTesting, [])
+
+            view.selectGroupingModeForTesting(.status)
+            XCTAssertEqual(view.integrationBannerLinesForTesting, [])
+        }
+    }
+
+    /// Turning it back on restores them without needing new pane data — the
+    /// structure signature does not describe the flag, so the view has to force
+    /// a full render itself.
+    func testReEnablingIntegrationRestoresTheSurfacesWithoutNewData() {
+        withDefaults { defaults in
+            let view = makeViewWithIntegration(defaults: defaults, status: "integration · 2 worktrees")
+            view.update(fleetWithIntegration())
+            view.integrationEnabled = false
+            XCTAssertEqual(view.integrateProjectsForTesting, [])
+
+            view.integrationEnabled = true
+            XCTAssertEqual(view.integrateProjectsForTesting, ["alpha"])
+
+            view.selectGroupingModeForTesting(.status)
+            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  integration · 2 worktrees"])
+        }
+    }
+
     func testPausedRenderHoldsRowsUntilResumed() {
         withDefaults { defaults in
             let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -163,6 +163,40 @@ final class DashboardOverviewGroupingTests: XCTestCase {
         }
     }
 
+    /// The integrate button is the feature's only announcement — without it,
+    /// `/integrate` is a command you have to already know exists.
+    func testProjectGroupsCarryAnIntegrateButtonOnlyWhereThereIsSomethingToFold() {
+        withDefaults { defaults in
+            let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
+                                             defaults: defaults,
+                                             now: { self.now })
+            view.update([
+                makePane(name: "one", project: "alpha", worktreePath: "/a1",
+                         paneStatuses: [.idle], isMainWorktree: true,
+                         lastActivityAt: now.addingTimeInterval(-100)),
+                makePane(name: "two", project: "alpha", worktreePath: "/a2",
+                         paneStatuses: [.idle], isMainWorktree: false,
+                         lastActivityAt: now.addingTimeInterval(-200)),
+                // A single-worktree project has nothing to fold together.
+                makePane(name: "solo", project: "bravo", worktreePath: "/b1",
+                         paneStatuses: [.idle], isMainWorktree: true,
+                         lastActivityAt: now.addingTimeInterval(-300)),
+            ])
+
+            XCTAssertEqual(view.integrateProjectsForTesting, ["alpha"])
+
+            view.selectGroupingModeForTesting(.pane)
+            XCTAssertEqual(view.integrateProjectsForTesting, ["alpha"])
+
+            // Status and time groups have no project header to hang it on, and
+            // the checkout is deliberately absent from those views anyway.
+            view.selectGroupingModeForTesting(.status)
+            XCTAssertEqual(view.integrateProjectsForTesting, [])
+            view.selectGroupingModeForTesting(.activityTime)
+            XCTAssertEqual(view.integrateProjectsForTesting, [])
+        }
+    }
+
     func testPausedRenderHoldsRowsUntilResumed() {
         withDefaults { defaults in
             let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -197,6 +197,71 @@ final class DashboardOverviewGroupingTests: XCTestCase {
         }
     }
 
+    // MARK: - the integration banner
+
+    /// Status and time groupings leave the checkout out of the list on purpose,
+    /// so it needs somewhere else to be visible. The banner is that place, and
+    /// it must not appear in the modes that already show the checkout as a row.
+    func testBannerAppearsOnlyInStatusAndTimeGroupings() {
+        withDefaults { defaults in
+            let view = makeViewWithIntegration(defaults: defaults, status: "integration · 2 worktrees")
+            view.update(fleetWithIntegration())
+
+            XCTAssertEqual(view.integrationBannerLinesForTesting, [],
+                           "grouped by project the checkout is a pinned row, not a banner")
+
+            view.selectGroupingModeForTesting(.status)
+            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  integration · 2 worktrees"])
+
+            view.selectGroupingModeForTesting(.activityTime)
+            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  integration · 2 worktrees"])
+
+            view.selectGroupingModeForTesting(.pane)
+            XCTAssertEqual(view.integrationBannerLinesForTesting, [])
+        }
+    }
+
+    /// A checkout that exists but has never been built still says so, rather
+    /// than showing an empty strip.
+    func testBannerFallsBackWhenNoRoundHasRunYet() {
+        withDefaults { defaults in
+            let view = makeViewWithIntegration(defaults: defaults, status: nil)
+            view.update(fleetWithIntegration())
+            view.selectGroupingModeForTesting(.status)
+            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  integration · not built yet"])
+        }
+    }
+
+    func testNoBannerWithoutAnIntegrationCheckout() {
+        withDefaults { defaults in
+            let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
+                                             defaults: defaults, now: { self.now },
+                                             isIntegrationWorktree: { _ in false },
+                                             integrationStatus: { _ in nil })
+            view.update(fleetWithIntegration())
+            view.selectGroupingModeForTesting(.status)
+            XCTAssertEqual(view.integrationBannerLinesForTesting, [])
+        }
+    }
+
+    private func makeViewWithIntegration(defaults: UserDefaults, status: String?) -> DashboardOverviewView {
+        DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
+                              defaults: defaults, now: { self.now },
+                              isIntegrationWorktree: { $0 == "/alpha-worktrees/integration" },
+                              integrationStatus: { _ in status })
+    }
+
+    private func fleetWithIntegration() -> [WorktreeRowInfo] {
+        [
+            makePane(name: "main", project: "alpha", worktreePath: "/alpha",
+                     paneStatuses: [.idle], isMainWorktree: true,
+                     lastActivityAt: now.addingTimeInterval(-100)),
+            makePane(name: "integration", project: "alpha", worktreePath: "/alpha-worktrees/integration",
+                     paneStatuses: [.idle], isMainWorktree: false,
+                     lastActivityAt: now.addingTimeInterval(-50)),
+        ]
+    }
+
     func testPausedRenderHoldsRowsUntilResumed() {
         withDefaults { defaults in
             let view = DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),

--- a/Tests/IntegrationBuilderTests.swift
+++ b/Tests/IntegrationBuilderTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+@testable import seahelm
+
+/// Combining several worktrees into one commit, entirely in the object
+/// database. The property that matters most is negative: none of this may
+/// touch a worktree, because that is what makes it safe to run unattended.
+final class IntegrationBuilderTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func tearDown() {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        super.tearDown()
+    }
+
+    // MARK: - parsing
+
+    func testParseCleanMergeIsJustATree() {
+        let outcome = IntegrationBuilder.parseMergeTree("abc123\0")
+        XCTAssertEqual(outcome?.tree, "abc123")
+        XCTAssertEqual(outcome?.conflictingPaths, [])
+    }
+
+    /// The empty field closes the path list; everything after it is git's
+    /// informational block and must not be read as a path.
+    func testParseConflictStopsAtTheEmptyField() {
+        let output = "abc123\0shared.txt\0src/app.swift\0\0" + "1\0shared.txt\0Auto-merging\0"
+        let outcome = IntegrationBuilder.parseMergeTree(output)
+        XCTAssertEqual(outcome?.tree, "abc123")
+        XCTAssertEqual(outcome?.conflictingPaths, ["shared.txt", "src/app.swift"])
+    }
+
+    func testParseRejectsEmptyOutput() {
+        XCTAssertNil(IntegrationBuilder.parseMergeTree(""))
+        XCTAssertNil(IntegrationBuilder.parseMergeTree("\0"))
+    }
+
+    // MARK: - building
+
+    func testIndependentSourcesAllMergeIn() throws {
+        let repo = try makeFleet()
+        let result = try XCTUnwrap(IntegrationBuilder.build(
+            repoPath: repo,
+            base: "main",
+            sources: [source("agentA", repo: repo), source("agentD", repo: repo)]
+        ))
+        XCTAssertEqual(result.included, ["agentA", "agentD"])
+        XCTAssertTrue(result.excluded.isEmpty)
+        XCTAssertFalse(result.hasConflicts)
+        XCTAssertEqual(filesIn(commit: result.commit, repo: repo),
+                       ["a.txt", "base.txt", "d.txt", "shared.txt"])
+    }
+
+    /// The default: keep the result testable by dropping the source that will
+    /// not merge, and say which one and on what.
+    func testConflictingSourceIsExcludedAndReported() throws {
+        let repo = try makeFleet()
+        let result = try XCTUnwrap(IntegrationBuilder.build(
+            repoPath: repo,
+            base: "main",
+            sources: [source("agentB", repo: repo), source("agentC", repo: repo)]
+        ))
+        XCTAssertEqual(result.included, ["agentB"])
+        XCTAssertEqual(result.excluded, [
+            IntegrationExclusion(label: "agentC", conflictingPaths: ["shared.txt"]),
+        ])
+        XCTAssertTrue(result.conflictedPaths.isEmpty)
+        // agentB won the file, and agentC's own work went with the exclusion.
+        XCTAssertEqual(show(path: "shared.txt", commit: result.commit, repo: repo), "l1\nBBB\nl3\n")
+        XCTAssertFalse(filesIn(commit: result.commit, repo: repo).contains("c_extra.txt"))
+    }
+
+    /// The other mode: nothing is dropped, and the conflict is carried in the
+    /// tree as markers. Note `c_extra.txt` — the work that exclusion costs.
+    func testIncludeWithMarkersKeepsEverything() throws {
+        let repo = try makeFleet()
+        let result = try XCTUnwrap(IntegrationBuilder.build(
+            repoPath: repo,
+            base: "main",
+            sources: [source("agentB", repo: repo), source("agentC", repo: repo)],
+            mode: .includeWithMarkers
+        ))
+        XCTAssertEqual(result.included, ["agentB", "agentC"])
+        XCTAssertTrue(result.excluded.isEmpty)
+        XCTAssertEqual(result.conflictedPaths, ["shared.txt"])
+        XCTAssertTrue(filesIn(commit: result.commit, repo: repo).contains("c_extra.txt"))
+        let shared = show(path: "shared.txt", commit: result.commit, repo: repo)
+        XCTAssertTrue(shared.contains("<<<<<<<"), shared)
+        XCTAssertTrue(shared.contains("BBB"), shared)
+        XCTAssertTrue(shared.contains("CCC"), shared)
+    }
+
+    /// Which of two colliding sources is reported depends on order, so the
+    /// order given must be the order applied — same input, same answer.
+    func testOrderDecidesWhichSideIsExcludedAndIsStable() throws {
+        let repo = try makeFleet()
+        let bFirst = try XCTUnwrap(IntegrationBuilder.build(
+            repoPath: repo, base: "main",
+            sources: [source("agentB", repo: repo), source("agentC", repo: repo)]))
+        let cFirst = try XCTUnwrap(IntegrationBuilder.build(
+            repoPath: repo, base: "main",
+            sources: [source("agentC", repo: repo), source("agentB", repo: repo)]))
+        XCTAssertEqual(bFirst.excluded.map(\.label), ["agentC"])
+        XCTAssertEqual(cFirst.excluded.map(\.label), ["agentB"])
+
+        let repeated = try XCTUnwrap(IntegrationBuilder.build(
+            repoPath: repo, base: "main",
+            sources: [source("agentB", repo: repo), source("agentC", repo: repo)]))
+        XCTAssertEqual(repeated.commit, bFirst.commit)
+    }
+
+    func testNoSourcesYieldsTheBaseItself() throws {
+        let repo = try makeFleet()
+        let result = try XCTUnwrap(IntegrationBuilder.build(repoPath: repo, base: "main", sources: []))
+        XCTAssertTrue(result.isEmpty)
+        XCTAssertEqual(result.commit, result.base)
+    }
+
+    func testUnknownBaseYieldsNothing() throws {
+        let repo = try makeFleet()
+        XCTAssertNil(IntegrationBuilder.build(repoPath: repo, base: "no/such/ref", sources: []))
+    }
+
+    /// A source git cannot merge at all is excluded like any other, rather than
+    /// abandoning the round.
+    func testUnresolvableSourceIsExcludedNotFatal() throws {
+        let repo = try makeFleet()
+        let bogus = IntegrationSource(label: "ghost", commit: String(repeating: "0", count: 40))
+        let result = try XCTUnwrap(IntegrationBuilder.build(
+            repoPath: repo, base: "main",
+            sources: [bogus, source("agentA", repo: repo)]))
+        XCTAssertEqual(result.included, ["agentA"])
+        XCTAssertEqual(result.excluded.map(\.label), ["ghost"])
+    }
+
+    /// The safety property the whole design rests on.
+    func testBuildingTouchesNoWorktree() throws {
+        let repo = try makeFleet()
+        let statusBefore = gitOutput(["status", "--porcelain"], in: repo)
+        let headBefore = gitOutput(["rev-parse", "HEAD"], in: repo)
+        let branchBefore = gitOutput(["branch", "--show-current"], in: repo)
+
+        _ = IntegrationBuilder.build(
+            repoPath: repo, base: "main",
+            sources: [source("agentB", repo: repo), source("agentC", repo: repo)])
+
+        XCTAssertEqual(gitOutput(["status", "--porcelain"], in: repo), statusBefore)
+        XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: repo), headBefore)
+        XCTAssertEqual(gitOutput(["branch", "--show-current"], in: repo), branchBefore)
+    }
+
+    /// End to end with the snapshotter: uncommitted work integrates too, which
+    /// is the point — an agent's turn usually ends before a commit.
+    func testUncommittedWorkIntegratesViaSnapshot() throws {
+        let repo = try makeFleet()
+        let worktree = tempDir.appendingPathComponent("wtA").path
+        runGit(["worktree", "add", worktree, "agentA"], in: repo)
+        try "in progress\n".write(toFile: worktree + "/wip.txt", atomically: true, encoding: .utf8)
+
+        let snapshot = try XCTUnwrap(WorktreeSnapshotter.snapshot(worktreePath: worktree))
+        let result = try XCTUnwrap(IntegrationBuilder.build(
+            repoPath: repo, base: "main",
+            sources: [IntegrationSource(label: "agentA", commit: snapshot.commit)]))
+
+        XCTAssertEqual(result.included, ["agentA"])
+        XCTAssertTrue(filesIn(commit: result.commit, repo: repo).contains("wip.txt"))
+    }
+
+    // MARK: - helpers
+
+    private func source(_ branch: String, repo: String) -> IntegrationSource {
+        IntegrationSource(label: branch, commit: gitOutput(["rev-parse", branch], in: repo))
+    }
+
+    /// main, plus four branches: A and D independent, B and C fighting over the
+    /// same line of `shared.txt`. C also carries unrelated work, so exclusion
+    /// has a visible cost.
+    private func makeFleet() throws -> String {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-int-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let repo = tempDir.appendingPathComponent("repo").path
+        runGit(["init", "-b", "main", repo], in: tempDir.path)
+        try "l1\nl2\nl3\n".write(toFile: repo + "/shared.txt", atomically: true, encoding: .utf8)
+        try "base\n".write(toFile: repo + "/base.txt", atomically: true, encoding: .utf8)
+        commitAll(repo, "base")
+
+        try branch("agentA", from: "main", in: repo) {
+            try "A\n".write(toFile: repo + "/a.txt", atomically: true, encoding: .utf8)
+        }
+        try branch("agentB", from: "main", in: repo) {
+            try "l1\nBBB\nl3\n".write(toFile: repo + "/shared.txt", atomically: true, encoding: .utf8)
+        }
+        try branch("agentC", from: "main", in: repo) {
+            try "l1\nCCC\nl3\n".write(toFile: repo + "/shared.txt", atomically: true, encoding: .utf8)
+            try "C\n".write(toFile: repo + "/c_extra.txt", atomically: true, encoding: .utf8)
+        }
+        try branch("agentD", from: "main", in: repo) {
+            try "D\n".write(toFile: repo + "/d.txt", atomically: true, encoding: .utf8)
+        }
+        runGit(["checkout", "main"], in: repo)
+        return repo
+    }
+
+    private func branch(_ name: String, from base: String, in repo: String, _ work: () throws -> Void) rethrows {
+        runGit(["checkout", "-b", name, base], in: repo)
+        try work()
+        commitAll(repo, "\(name) work")
+        runGit(["checkout", base], in: repo)
+    }
+
+    private func commitAll(_ repo: String, _ message: String) {
+        runGit(["add", "-A"], in: repo)
+        runGit(["-c", "user.name=T", "-c", "user.email=t@t", "commit", "-m", message], in: repo)
+    }
+
+    private func filesIn(commit: String, repo: String) -> [String] {
+        gitOutput(["ls-tree", "-r", "--name-only", commit], in: repo)
+            .split(separator: "\n").map(String.init).sorted()
+    }
+
+    private func show(path: String, commit: String, repo: String) -> String {
+        gitOutput(["show", "\(commit):\(path)"], in: repo, trim: false)
+    }
+
+    @discardableResult
+    private func gitOutput(_ args: [String], in directory: String, trim: Bool = true) -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = URL(fileURLWithPath: directory)
+        let out = Pipe(); let err = Pipe()
+        process.standardOutput = out; process.standardError = err
+        try? process.run()
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        let errData = err.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, String(data: errData, encoding: .utf8) ?? "")
+        let text = String(data: data, encoding: .utf8) ?? ""
+        return trim ? text.trimmingCharacters(in: .whitespacesAndNewlines) : text
+    }
+
+    private func runGit(_ args: [String], in directory: String) {
+        gitOutput(args, in: directory)
+    }
+}

--- a/Tests/IntegrationBuilderTests.swift
+++ b/Tests/IntegrationBuilderTests.swift
@@ -103,10 +103,27 @@ final class IntegrationBuilderTests: XCTestCase {
         XCTAssertEqual(bFirst.excluded.map(\.label), ["agentC"])
         XCTAssertEqual(cFirst.excluded.map(\.label), ["agentB"])
 
+        // The tree, not the commit: `commit-tree` stamps a timestamp, so two
+        // rounds a second apart over the same fleet produce different commits
+        // holding identical files. That is exactly why `tree` is the change key
+        // the publish path compares.
         let repeated = try XCTUnwrap(IntegrationBuilder.build(
             repoPath: repo, base: "main",
             sources: [source("agentB", repo: repo), source("agentC", repo: repo)]))
-        XCTAssertEqual(repeated.commit, bFirst.commit)
+        XCTAssertEqual(repeated.tree, bFirst.tree)
+        XCTAssertEqual(repeated.included, bFirst.included)
+        XCTAssertEqual(repeated.excluded, bFirst.excluded)
+    }
+
+    /// The change key has to survive the timestamp that makes commits differ,
+    /// or the "nothing changed, do nothing" path never fires.
+    func testTreeIsStableAcrossRebuildsWhileCommitsAreNot() throws {
+        let repo = try makeFleet()
+        let sources = [source("agentA", repo: repo), source("agentD", repo: repo)]
+        let first = try XCTUnwrap(IntegrationBuilder.build(repoPath: repo, base: "main", sources: sources))
+        let second = try XCTUnwrap(IntegrationBuilder.build(repoPath: repo, base: "main", sources: sources))
+        XCTAssertEqual(first.tree, second.tree)
+        XCTAssertEqual(first.tree, gitOutput(["rev-parse", "\(first.commit)^{tree}"], in: repo))
     }
 
     func testNoSourcesYieldsTheBaseItself() throws {

--- a/Tests/IntegrationCoordinatorTests.swift
+++ b/Tests/IntegrationCoordinatorTests.swift
@@ -127,7 +127,8 @@ final class IntegrationCoordinatorTests: XCTestCase {
                         result: IntegrationResult(commit: "c", tree: "t", base: "b",
                                                   included: [], excluded: [], conflictedPaths: []),
                         outcome: .unchanged(commit: "c"),
-                        unsnapshotable: []
+                        unsnapshotable: [],
+                        committedOnly: []
                     )
                 }
             )

--- a/Tests/IntegrationCoordinatorTests.swift
+++ b/Tests/IntegrationCoordinatorTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import seahelm
+
+/// The automatic trigger. Everything here is about *when* a round runs — the
+/// round itself is covered by IntegrationWorktreeTests.
+final class IntegrationCoordinatorTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var checkout: String!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-intcoord-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        checkout = tempDir.appendingPathComponent("integration").path
+        try? FileManager.default.createDirectory(atPath: checkout, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        super.tearDown()
+    }
+
+    // MARK: - what triggers
+
+    func testFinishingATurnSchedulesARound() {
+        let harness = Harness(checkout: checkout)
+        harness.coordinator.handle(harness.transition(from: .running, to: .idle))
+        harness.waitForRound()
+        XCTAssertEqual(harness.rounds, 1)
+    }
+
+    /// Only the edge *out of* running is a stage of work reaching a rest.
+    func testOtherEdgesDoNotSchedule() {
+        let harness = Harness(checkout: checkout)
+        harness.coordinator.handle(harness.transition(from: .idle, to: .running))
+        harness.coordinator.handle(harness.transition(from: .waiting, to: .idle))
+        harness.coordinator.handle(harness.transition(from: .running, to: .running))
+        harness.waitForRound(expecting: 0)
+        XCTAssertEqual(harness.rounds, 0)
+    }
+
+    /// A burst of agents finishing together is one round, not one each.
+    func testConcurrentFinishesCoalesceIntoOneRound() {
+        let harness = Harness(checkout: checkout)
+        for _ in 0..<5 {
+            harness.coordinator.handle(harness.transition(from: .running, to: .idle))
+        }
+        harness.waitForRound()
+        XCTAssertEqual(harness.rounds, 1)
+    }
+
+    // MARK: - what suppresses
+
+    func testDisabledDoesNothing() {
+        let harness = Harness(checkout: checkout, enabled: false)
+        harness.coordinator.handle(harness.transition(from: .running, to: .idle))
+        harness.waitForRound(expecting: 0)
+        XCTAssertEqual(harness.rounds, 0)
+    }
+
+    /// Opting in is creating the checkout. A repo without one is never touched,
+    /// so switching this on cannot conjure directories on disk.
+    func testRepoWithoutACheckoutIsNeverTouched() {
+        let harness = Harness(checkout: tempDir.appendingPathComponent("absent").path)
+        harness.coordinator.handle(harness.transition(from: .running, to: .idle))
+        harness.waitForRound(expecting: 0)
+        XCTAssertEqual(harness.rounds, 0)
+    }
+
+    /// Publishing pulls files out from under whatever is running in the
+    /// checkout, so a busy one is skipped rather than built for.
+    func testBusyCheckoutSkipsTheRound() {
+        let harness = Harness(checkout: checkout, checkoutBusy: true)
+        harness.coordinator.handle(harness.transition(from: .running, to: .idle))
+        harness.waitForRound(expecting: 0)
+        XCTAssertEqual(harness.rounds, 0)
+    }
+
+    // MARK: - reporting
+
+    func testReportsAreForwarded() {
+        let harness = Harness(checkout: checkout)
+        harness.coordinator.handle(harness.transition(from: .running, to: .idle))
+        harness.waitForRound()
+        XCTAssertEqual(harness.reports.count, 1)
+        XCTAssertEqual(harness.reports.first?.integrationWorktreePath, checkout)
+    }
+
+    /// A round that cannot run must not take the coordinator down with it.
+    func testAFailedRoundIsSwallowed() {
+        let harness = Harness(checkout: checkout, roundThrows: true)
+        harness.coordinator.handle(harness.transition(from: .running, to: .idle))
+        harness.waitForRound(expecting: 0)
+        XCTAssertTrue(harness.reports.isEmpty)
+        XCTAssertEqual(harness.rounds, 1, "it was attempted")
+    }
+
+    // MARK: - harness
+
+    private final class Harness {
+        private(set) var rounds = 0
+        private(set) var reports: [IntegrationRunReport] = []
+        let coordinator: IntegrationCoordinator
+        private let checkout: String
+
+        init(checkout: String, enabled: Bool = true, checkoutBusy: Bool = false, roundThrows: Bool = false) {
+            self.checkout = checkout
+            var roundCount = 0
+            var collected: [IntegrationRunReport] = []
+            let box = Box()
+            coordinator = IntegrationCoordinator(
+                coalesceWindow: 0.05,
+                isEnabled: { enabled },
+                repoRoot: { _ in "/repo" },
+                worktrees: { _ in [] },
+                integrationPath: { _ in checkout },
+                isCheckoutBusy: { _ in checkoutBusy },
+                onReport: { report, _ in collected.append(report); box.reports = collected },
+                runRound: { _, path, _ in
+                    roundCount += 1
+                    box.rounds = roundCount
+                    if roundThrows { throw IntegrationRunError.noBaseRef }
+                    return IntegrationRunReport(
+                        integrationWorktreePath: path,
+                        result: IntegrationResult(commit: "c", tree: "t", base: "b",
+                                                  included: [], excluded: [], conflictedPaths: []),
+                        outcome: .unchanged(commit: "c"),
+                        unsnapshotable: []
+                    )
+                }
+            )
+            self.box = box
+        }
+
+        private let box: Box
+        final class Box { var rounds = 0; var reports: [IntegrationRunReport] = [] }
+
+        func transition(from old: AgentStatus, to new: AgentStatus) -> StatusTransition {
+            StatusTransition(worktreePath: "/repo/agent", branch: "b", project: "p", terminalID: "t",
+                             oldStatus: old, newStatus: new, holdSeconds: 0, isCompletionSignal: true)
+        }
+
+        /// The coalesce window plus room for the background hop back. A case
+        /// expecting nothing still has to wait out the window to prove it.
+        func waitForRound(expecting expected: Int = 1) {
+            let deadline = Date().addingTimeInterval(coordinator.coalesceWindow + 0.6)
+            while Date() < deadline {
+                RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+                if expected > 0, box.rounds >= expected, box.reports.count >= expected { break }
+            }
+            rounds = box.rounds
+            reports = box.reports
+        }
+    }
+}

--- a/Tests/IntegrationWorktreeTests.swift
+++ b/Tests/IntegrationWorktreeTests.swift
@@ -1,0 +1,242 @@
+import XCTest
+@testable import seahelm
+
+/// The integration checkout and one full round through it.
+final class IntegrationWorktreeTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func tearDown() {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        super.tearDown()
+    }
+
+    // MARK: - lifecycle
+
+    /// Detached on purpose: a branch would be pushable, resettable, and would
+    /// show up in the base picker for new worktrees.
+    func testCreatedCheckoutIsDetachedAndLeavesNoBranch() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+
+        XCTAssertEqual(gitOutput(["branch", "--show-current"], in: path), "")
+        XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: path),
+                       gitOutput(["rev-parse", "main"], in: repo))
+        XCTAssertFalse(gitOutput(["branch", "--list"], in: repo).contains("integration"))
+    }
+
+    func testCreateRefusesAnOccupiedPath() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        XCTAssertThrowsError(try IntegrationWorktree.create(repoPath: repo, at: path, base: "main"))
+    }
+
+    // MARK: - publishing
+
+    func testPublishMovesTheCheckoutToTheBuiltCommit() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let target = gitOutput(["rev-parse", "agentA"], in: repo)
+
+        XCTAssertEqual(IntegrationWorktree.publish(commit: target, to: path), .published(commit: target))
+        XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: path), target)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path + "/a.txt"))
+    }
+
+    func testPublishingWhatIsAlreadyCheckedOutIsANoop() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let head = gitOutput(["rev-parse", "HEAD"], in: path)
+        XCTAssertEqual(IntegrationWorktree.publish(commit: head, to: path), .unchanged(commit: head))
+    }
+
+    /// Rebuilding an unchanged fleet yields a *different* commit — `commit-tree`
+    /// stamps a timestamp — holding the same files. Publishing must recognise
+    /// that as nothing to do, or every round resets the checkout for no reason
+    /// and yanks files from under whatever is running there.
+    func testARebuiltCommitWithTheSameTreeIsStillANoop() throws {
+        let repo = try makeFleet()
+        let worktrees = try addWorktrees(["agentA"], in: repo)
+        let path = tempDir.appendingPathComponent("integration").path
+
+        let first = try IntegrationRunner.run(repoPath: repo, integrationPath: path, worktrees: worktrees)
+        XCTAssertEqual(first.outcome, .published(commit: first.result.commit))
+
+        let second = try IntegrationRunner.run(repoPath: repo, integrationPath: path, worktrees: worktrees)
+        XCTAssertEqual(second.result.tree, first.result.tree, "same fleet, same files")
+        XCTAssertEqual(second.outcome, .unchanged(commit: second.result.commit))
+        XCTAssertFalse(second.needsAttention)
+        XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: path), first.result.commit,
+                       "an unchanged round must leave the checkout exactly where it was")
+    }
+
+    /// The one irreversible step in the feature. It must not fire on its own
+    /// while someone is mid-edit in the integration checkout.
+    func testLocalEditsHoldThePublishUntilForced() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        try "hand edit\n".write(toFile: path + "/base.txt", atomically: true, encoding: .utf8)
+        let target = gitOutput(["rev-parse", "agentA"], in: repo)
+        let headBefore = gitOutput(["rev-parse", "HEAD"], in: path)
+
+        XCTAssertTrue(IntegrationWorktree.hasLocalEdits(at: path))
+        XCTAssertEqual(
+            IntegrationWorktree.publish(commit: target, to: path),
+            .held(reason: .dirtyWorktree, commit: target)
+        )
+        XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: path), headBefore, "a hold must not move HEAD")
+        XCTAssertEqual(try String(contentsOfFile: path + "/base.txt", encoding: .utf8), "hand edit\n")
+
+        XCTAssertEqual(
+            IntegrationWorktree.publish(commit: target, to: path, force: true),
+            .published(commit: target)
+        )
+        XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: path), target)
+    }
+
+    /// Untracked files count as edits too — losing an agent's new file to a
+    /// silent reset is the same accident as losing a modified one.
+    func testUntrackedFilesAlsoHoldThePublish() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        try "scratch\n".write(toFile: path + "/scratch.txt", atomically: true, encoding: .utf8)
+        let target = gitOutput(["rev-parse", "agentA"], in: repo)
+        XCTAssertEqual(
+            IntegrationWorktree.publish(commit: target, to: path),
+            .held(reason: .dirtyWorktree, commit: target)
+        )
+    }
+
+    // MARK: - a full round
+
+    func testRunCreatesTheCheckoutAndIntegratesTheFleet() throws {
+        let repo = try makeFleet()
+        let worktrees = try addWorktrees(["agentA", "agentD"], in: repo)
+        let path = tempDir.appendingPathComponent("integration").path
+
+        let report = try IntegrationRunner.run(
+            repoPath: repo, integrationPath: path, worktrees: worktrees
+        )
+        XCTAssertEqual(report.result.included.sorted(), ["agentA", "agentD"])
+        XCTAssertEqual(report.outcome, .published(commit: report.result.commit))
+        XCTAssertFalse(report.needsAttention, "a clean round should stay quiet")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path + "/a.txt"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path + "/d.txt"))
+    }
+
+    func testRunReportsAConflictAndStaysBuildable() throws {
+        let repo = try makeFleet()
+        let worktrees = try addWorktrees(["agentB", "agentC"], in: repo)
+        let path = tempDir.appendingPathComponent("integration").path
+
+        let report = try IntegrationRunner.run(
+            repoPath: repo, integrationPath: path, worktrees: worktrees
+        )
+        XCTAssertEqual(report.result.included, ["agentB"])
+        XCTAssertEqual(report.result.excluded.map(\.label), ["agentC"])
+        XCTAssertTrue(report.needsAttention)
+        XCTAssertTrue(report.summary.contains("shared.txt"), report.summary)
+        // No conflict markers reached the checkout: it still compiles.
+        let shared = try String(contentsOfFile: path + "/shared.txt", encoding: .utf8)
+        XCTAssertFalse(shared.contains("<<<<<<<"), shared)
+    }
+
+    /// The reason snapshots exist: an agent's turn ends before a commit.
+    func testRunPicksUpUncommittedWorkInAWorktree() throws {
+        let repo = try makeFleet()
+        let worktrees = try addWorktrees(["agentA"], in: repo)
+        try "in progress\n".write(toFile: worktrees[0].path + "/wip.txt", atomically: true, encoding: .utf8)
+        let path = tempDir.appendingPathComponent("integration").path
+
+        let report = try IntegrationRunner.run(
+            repoPath: repo, integrationPath: path, worktrees: worktrees
+        )
+        XCTAssertEqual(report.result.included, ["agentA"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path + "/wip.txt"))
+    }
+
+    /// The checkout must never merge itself back in.
+    func testRunExcludesTheIntegrationCheckoutAndMain() throws {
+        let repo = try makeFleet()
+        var worktrees = try addWorktrees(["agentA"], in: repo)
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        worktrees.append(WorktreeInfo(path: path, branch: "", commitHash: "", isMainWorktree: false, isDetached: true))
+        worktrees.append(WorktreeInfo(path: repo, branch: "main", commitHash: "", isMainWorktree: true))
+
+        let report = try IntegrationRunner.run(
+            repoPath: repo, integrationPath: path, worktrees: worktrees
+        )
+        XCTAssertEqual(report.result.included, ["agentA"])
+    }
+
+    func testSourceOrderIsStable() throws {
+        let repo = try makeFleet()
+        let worktrees = try addWorktrees(["agentD", "agentA"], in: repo)
+        let first = IntegrationRunner.sources(from: worktrees, excluding: []).map(\.path)
+        let second = IntegrationRunner.sources(from: worktrees.reversed(), excluding: []).map(\.path)
+        XCTAssertEqual(first, second)
+    }
+
+    // MARK: - helpers
+
+    private func addWorktrees(_ branches: [String], in repo: String) throws -> [WorktreeInfo] {
+        try branches.map { branch in
+            let path = tempDir.appendingPathComponent("wt-\(branch)").path
+            runGit(["worktree", "add", path, branch], in: repo)
+            return WorktreeInfo(path: path, branch: branch, commitHash: "", isMainWorktree: false)
+        }
+    }
+
+    private func makeFleet() throws -> String {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-intwt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let repo = tempDir.appendingPathComponent("repo").path
+        runGit(["init", "-b", "main", repo], in: tempDir.path)
+        try "l1\nl2\nl3\n".write(toFile: repo + "/shared.txt", atomically: true, encoding: .utf8)
+        try "base\n".write(toFile: repo + "/base.txt", atomically: true, encoding: .utf8)
+        commitAll(repo, "base")
+        try branch("agentA", in: repo) { try "A\n".write(toFile: repo + "/a.txt", atomically: true, encoding: .utf8) }
+        try branch("agentB", in: repo) { try "l1\nBBB\nl3\n".write(toFile: repo + "/shared.txt", atomically: true, encoding: .utf8) }
+        try branch("agentC", in: repo) { try "l1\nCCC\nl3\n".write(toFile: repo + "/shared.txt", atomically: true, encoding: .utf8) }
+        try branch("agentD", in: repo) { try "D\n".write(toFile: repo + "/d.txt", atomically: true, encoding: .utf8) }
+        runGit(["checkout", "main"], in: repo)
+        return repo
+    }
+
+    private func branch(_ name: String, in repo: String, _ work: () throws -> Void) rethrows {
+        runGit(["checkout", "-b", name, "main"], in: repo)
+        try work()
+        commitAll(repo, "\(name) work")
+        runGit(["checkout", "main"], in: repo)
+    }
+
+    private func commitAll(_ repo: String, _ message: String) {
+        runGit(["add", "-A"], in: repo)
+        runGit(["-c", "user.name=T", "-c", "user.email=t@t", "commit", "-m", message], in: repo)
+    }
+
+    @discardableResult
+    private func gitOutput(_ args: [String], in directory: String) -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = URL(fileURLWithPath: directory)
+        let out = Pipe(); let err = Pipe()
+        process.standardOutput = out; process.standardError = err
+        try? process.run()
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        _ = err.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (String(data: data, encoding: .utf8) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func runGit(_ args: [String], in directory: String) { gitOutput(args, in: directory) }
+}

--- a/Tests/IntegrationWorktreeTests.swift
+++ b/Tests/IntegrationWorktreeTests.swift
@@ -176,6 +176,46 @@ final class IntegrationWorktreeTests: XCTestCase {
         XCTAssertEqual(report.result.included, ["agentA"])
     }
 
+    /// A round is triggered by one agent finishing but folds in every
+    /// worktree. One that is still mid-turn contributes its HEAD, not a torn
+    /// working tree — half a file failing the integration would look like a
+    /// real conflict.
+    func testBusyWorktreeContributesItsCommittedWorkOnly() throws {
+        let repo = try makeFleet()
+        let worktrees = try addWorktrees(["agentA"], in: repo)
+        try "half written\n".write(toFile: worktrees[0].path + "/torn.txt", atomically: true, encoding: .utf8)
+        let path = tempDir.appendingPathComponent("integration").path
+
+        let report = try IntegrationRunner.run(
+            repoPath: repo, integrationPath: path, worktrees: worktrees,
+            isBusy: { _ in true }
+        )
+        XCTAssertEqual(report.result.included, ["agentA"])
+        XCTAssertEqual(report.committedOnly, ["agentA"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path + "/a.txt"), "its commit is in")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path + "/torn.txt"),
+                       "its half-written file is not")
+        // An agent still working is the normal case, so a partial round stays
+        // quiet: the note is ambient on the card, not a card of its own.
+        XCTAssertFalse(report.needsAttention)
+        XCTAssertTrue(report.cardLine.contains("1 still working"), report.cardLine)
+    }
+
+    /// The same worktree comes in whole once its turn ends.
+    func testWorkArrivesInFullOnTheRoundAfterTheAgentStops() throws {
+        let repo = try makeFleet()
+        let worktrees = try addWorktrees(["agentA"], in: repo)
+        try "now finished\n".write(toFile: worktrees[0].path + "/torn.txt", atomically: true, encoding: .utf8)
+        let path = tempDir.appendingPathComponent("integration").path
+
+        _ = try IntegrationRunner.run(repoPath: repo, integrationPath: path,
+                                      worktrees: worktrees, isBusy: { _ in true })
+        let after = try IntegrationRunner.run(repoPath: repo, integrationPath: path,
+                                              worktrees: worktrees, isBusy: { _ in false })
+        XCTAssertTrue(after.committedOnly.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path + "/torn.txt"))
+    }
+
     func testSourceOrderIsStable() throws {
         let repo = try makeFleet()
         let worktrees = try addWorktrees(["agentD", "agentA"], in: repo)

--- a/Tests/WorktreeGroupingTests.swift
+++ b/Tests/WorktreeGroupingTests.swift
@@ -16,7 +16,8 @@ final class WorktreeGroupingTests: XCTestCase {
         status: AgentStatus = .idle,
         activity: Date? = nil,
         main: Bool = false,
-        created: Date = .distantPast
+        created: Date = .distantPast,
+        integration: Bool = false
     ) -> WorktreeGroupingItem {
         WorktreeGroupingItem(
             id: path,
@@ -25,8 +26,55 @@ final class WorktreeGroupingTests: XCTestCase {
             status: status,
             lastActivityAt: activity,
             isMainWorktree: main,
-            creationDate: created
+            creationDate: created,
+            isIntegration: integration
         )
+    }
+
+    // MARK: - the integration checkout
+
+    /// Pinned under main rather than sorted by creation date: it is a fixture of
+    /// the repo, and creation-date order would move it whenever it is recreated.
+    func testIntegrationPinsDirectlyBelowMainRegardlessOfAge() {
+        let groups = WorktreeGrouping.groups([
+            item("/repo/old", repo: "alpha", created: Date(timeIntervalSince1970: 10)),
+            item("/repo/integration", repo: "alpha", created: Date(timeIntervalSince1970: 9_000), integration: true),
+            item("/repo", repo: "alpha", main: true, created: Date(timeIntervalSince1970: 5_000)),
+            item("/repo/new", repo: "alpha", created: Date(timeIntervalSince1970: 20)),
+        ], mode: .repository, now: now)
+
+        XCTAssertEqual(groups.first?.items.map(\.path), ["/repo", "/repo/integration", "/repo/old", "/repo/new"])
+    }
+
+    func testPaneModePinsItTheSameWay() {
+        let groups = WorktreeGrouping.groups([
+            item("/repo/a", repo: "alpha", created: Date(timeIntervalSince1970: 10)),
+            item("/repo/integration", repo: "alpha", integration: true),
+            item("/repo", repo: "alpha", main: true),
+        ], mode: .pane, now: now)
+
+        XCTAssertEqual(groups.first?.items.map(\.path), ["/repo", "/repo/integration", "/repo/a"])
+    }
+
+    /// Status groups answer "what needs me now". The checkout has no agent, so
+    /// its status is a shell's and would only dilute the answer.
+    func testStatusGroupingLeavesTheIntegrationOut() {
+        let groups = WorktreeGrouping.groups([
+            item("/repo/a", repo: "alpha", status: .waiting),
+            item("/repo/integration", repo: "alpha", status: .idle, integration: true),
+        ], mode: .status, now: now)
+
+        XCTAssertEqual(groups.flatMap { $0.items.map(\.path) }, ["/repo/a"])
+    }
+
+    /// Same for time buckets: its "activity" is terminal output, not work.
+    func testActivityGroupingLeavesTheIntegrationOut() {
+        let groups = WorktreeGrouping.groups([
+            item("/repo/a", repo: "alpha", activity: now.addingTimeInterval(-60)),
+            item("/repo/integration", repo: "alpha", activity: now, integration: true),
+        ], mode: .activityTime, now: now, calendar: utcCalendar)
+
+        XCTAssertEqual(groups.flatMap { $0.items.map(\.path) }, ["/repo/a"])
     }
 
     func testRepositoryGroupsRemainInFirstSeenOrderAndNormalizeEmptyName() {

--- a/Tests/WorktreeSidePanelViewControllerTests.swift
+++ b/Tests/WorktreeSidePanelViewControllerTests.swift
@@ -79,4 +79,97 @@ final class WorktreeSidePanelViewControllerTests: XCTestCase {
         XCTAssertEqual(roots.first?.children.first?.children.map(\.name), ["Main.swift"])
         XCTAssertEqual(roots.last?.entry?.path, "README.md")
     }
+
+    // MARK: - Integration composition
+
+    private func makeIntegrationVC(_ state: IntegrationPanelState?) -> WorktreeSidePanelViewController {
+        WorktreeSidePanelViewController(
+            worktreePath: "/repo-worktrees/integration",
+            initialTab: .changes,
+            integrationState: { _ in state }
+        )
+    }
+
+    /// The Changes tab runs its `git diff` off the main thread, so the strip
+    /// only exists once that lands.
+    private func compositionLines(_ vc: WorktreeSidePanelViewController) -> [String] {
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+            if !vc.integrationCompositionLinesForTesting.isEmpty { break }
+        }
+        return vc.integrationCompositionLinesForTesting
+    }
+
+    /// An integration checkout's diff is several worktrees folded together, so
+    /// the file list alone never says whose work it is.
+    func testCompositionNamesWhatWentInAndWhatDidNot() {
+        let vc = makeIntegrationVC(IntegrationPanelState(
+            line: "integration · 2 worktrees",
+            included: ["agentA", "agentB"],
+            excluded: [.init(label: "agentC", paths: ["shared.txt"])],
+            conflictedPaths: [],
+            isHeld: false
+        ))
+        vc.loadViewIfNeeded()
+        vc.selectTab(.changes)
+
+        XCTAssertEqual(compositionLines(vc), [
+            "in: agentA, agentB",
+            "excluded: agentC · shared.txt",
+        ])
+    }
+
+    /// A held round is the one state a user has to act on, so it says how.
+    func testCompositionSurfacesAHeldCheckout() {
+        let vc = makeIntegrationVC(IntegrationPanelState(
+            line: "integration · 1 worktree · pending",
+            included: ["agentA"],
+            excluded: [],
+            conflictedPaths: [],
+            isHeld: true
+        ))
+        vc.loadViewIfNeeded()
+        vc.selectTab(.changes)
+
+        XCTAssertEqual(compositionLines(vc), [
+            "in: agentA",
+            "not checked out — local edits here · /integrate force",
+        ])
+    }
+
+    func testCompositionReportsConflictMarkers() {
+        let vc = makeIntegrationVC(IntegrationPanelState(
+            line: "integration · 2 worktrees",
+            included: ["agentA", "agentC"],
+            excluded: [],
+            conflictedPaths: ["shared.txt"],
+            isHeld: false
+        ))
+        vc.loadViewIfNeeded()
+        vc.selectTab(.changes)
+
+        let lines = compositionLines(vc)
+        XCTAssertTrue(lines.contains("conflict markers: shared.txt"), "\(lines)")
+    }
+
+    /// Every other worktree's Changes tab is untouched.
+    func testOrdinaryWorktreeShowsNoComposition() {
+        let vc = makeIntegrationVC(nil)
+        vc.loadViewIfNeeded()
+        vc.selectTab(.changes)
+        XCTAssertEqual(compositionLines(vc), [])
+    }
+
+    // MARK: - state store round trip
+
+    func testStoreDecodesStructuredStateAndLegacyPlainText() {
+        let state = IntegrationPanelState(line: "integration · 3 worktrees", included: ["a"],
+                                          excluded: [], conflictedPaths: [], isHeld: false)
+        let encoded = String(data: try! JSONEncoder().encode(state), encoding: .utf8)!
+        XCTAssertEqual(IntegrationStatusStore.decode(encoded), state)
+        // Entries written before the store held structured state must not blank
+        // the card on upgrade.
+        XCTAssertNil(IntegrationStatusStore.decode("integration · 3 worktrees"))
+    }
 }

--- a/Tests/WorktreeSnapshotterTests.swift
+++ b/Tests/WorktreeSnapshotterTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import seahelm
+
+/// The snapshot primitive: a worktree's current state as a commit, taken
+/// without the worktree noticing.
+final class WorktreeSnapshotterTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func tearDown() {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        super.tearDown()
+    }
+
+    /// Nothing outstanding: the snapshot is HEAD, and no objects are written.
+    func testCleanWorktreeSnapshotsAsHeadItself() throws {
+        let repo = try makeRepo()
+        let snapshot = try XCTUnwrap(WorktreeSnapshotter.snapshot(worktreePath: repo))
+        XCTAssertTrue(snapshot.isClean)
+        XCTAssertEqual(snapshot.commit, snapshot.head)
+        XCTAssertEqual(snapshot.commit, gitOutput(["rev-parse", "HEAD"], in: repo))
+    }
+
+    /// The case `git stash create` gets wrong, and the reason this exists.
+    func testSnapshotCapturesUntrackedFiles() throws {
+        let repo = try makeRepo()
+        try "brand new\n".write(toFile: repo + "/untracked.txt", atomically: true, encoding: .utf8)
+
+        let snapshot = try XCTUnwrap(WorktreeSnapshotter.snapshot(worktreePath: repo))
+        XCTAssertFalse(snapshot.isClean)
+        XCTAssertEqual(filesIn(commit: snapshot.commit, repo: repo), ["tracked.txt", "untracked.txt"])
+    }
+
+    func testSnapshotCapturesModificationsAndDeletions() throws {
+        let repo = try makeRepo()
+        try "changed\n".write(toFile: repo + "/tracked.txt", atomically: true, encoding: .utf8)
+        try "second\n".write(toFile: repo + "/second.txt", atomically: true, encoding: .utf8)
+        runGit(["add", "second.txt"], in: repo)
+        runGit(["-c", "user.name=T", "-c", "user.email=t@t", "commit", "-m", "add second"], in: repo)
+        try FileManager.default.removeItem(atPath: repo + "/second.txt")
+
+        let snapshot = try XCTUnwrap(WorktreeSnapshotter.snapshot(worktreePath: repo))
+        XCTAssertEqual(filesIn(commit: snapshot.commit, repo: repo), ["tracked.txt"])
+        XCTAssertEqual(show(path: "tracked.txt", commit: snapshot.commit, repo: repo), "changed\n")
+    }
+
+    /// The whole point: an agent working in the directory must not be able to
+    /// tell a snapshot happened.
+    func testSnapshotLeavesWorktreeIndexAndHeadUntouched() throws {
+        let repo = try makeRepo()
+        try "dirty\n".write(toFile: repo + "/tracked.txt", atomically: true, encoding: .utf8)
+        try "new\n".write(toFile: repo + "/untracked.txt", atomically: true, encoding: .utf8)
+        let statusBefore = gitOutput(["status", "--porcelain"], in: repo)
+        let headBefore = gitOutput(["rev-parse", "HEAD"], in: repo)
+        let branchBefore = gitOutput(["branch", "--show-current"], in: repo)
+
+        _ = WorktreeSnapshotter.snapshot(worktreePath: repo)
+
+        XCTAssertEqual(gitOutput(["status", "--porcelain"], in: repo), statusBefore)
+        XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: repo), headBefore)
+        XCTAssertEqual(gitOutput(["branch", "--show-current"], in: repo), branchBefore)
+    }
+
+    func testIgnoredFilesAreNotSnapshotted() throws {
+        let repo = try makeRepo()
+        try "build/\n".write(toFile: repo + "/.gitignore", atomically: true, encoding: .utf8)
+        runGit(["add", ".gitignore"], in: repo)
+        runGit(["-c", "user.name=T", "-c", "user.email=t@t", "commit", "-m", "ignore build"], in: repo)
+        try FileManager.default.createDirectory(atPath: repo + "/build", withIntermediateDirectories: true)
+        try "junk\n".write(toFile: repo + "/build/out.txt", atomically: true, encoding: .utf8)
+
+        let snapshot = try XCTUnwrap(WorktreeSnapshotter.snapshot(worktreePath: repo))
+        XCTAssertTrue(snapshot.isClean, "only ignored noise is not a change")
+    }
+
+    /// The dedup key the coordinator will poll on: same files, same tree.
+    func testTreeIsStableForIdenticalContent() throws {
+        let repo = try makeRepo()
+        try "same\n".write(toFile: repo + "/untracked.txt", atomically: true, encoding: .utf8)
+        let first = try XCTUnwrap(WorktreeSnapshotter.snapshot(worktreePath: repo))
+        let second = try XCTUnwrap(WorktreeSnapshotter.snapshot(worktreePath: repo))
+        XCTAssertEqual(first.tree, second.tree)
+
+        try "different\n".write(toFile: repo + "/untracked.txt", atomically: true, encoding: .utf8)
+        let third = try XCTUnwrap(WorktreeSnapshotter.snapshot(worktreePath: repo))
+        XCTAssertNotEqual(first.tree, third.tree)
+    }
+
+    /// A repo with no commit has nothing to snapshot on top of.
+    func testUnbornBranchYieldsNoSnapshot() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-snap-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let repo = tempDir.appendingPathComponent("empty").path
+        runGit(["init", "-b", "main", repo], in: tempDir.path)
+        XCTAssertNil(WorktreeSnapshotter.snapshot(worktreePath: repo))
+    }
+
+    // MARK: - helpers
+
+    private func makeRepo() throws -> String {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-snap-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let repo = tempDir.appendingPathComponent("repo").path
+        runGit(["init", "-b", "main", repo], in: tempDir.path)
+        try "base\n".write(toFile: repo + "/tracked.txt", atomically: true, encoding: .utf8)
+        runGit(["add", "-A"], in: repo)
+        runGit(["-c", "user.name=T", "-c", "user.email=t@t", "commit", "-m", "init"], in: repo)
+        return repo
+    }
+
+    private func filesIn(commit: String, repo: String) -> [String] {
+        gitOutput(["ls-tree", "-r", "--name-only", commit], in: repo)
+            .split(separator: "\n").map(String.init).sorted()
+    }
+
+    private func show(path: String, commit: String, repo: String) -> String {
+        gitOutput(["show", "\(commit):\(path)"], in: repo, trim: false)
+    }
+
+    @discardableResult
+    private func gitOutput(_ args: [String], in directory: String, trim: Bool = true) -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = args
+        process.currentDirectoryURL = URL(fileURLWithPath: directory)
+        let out = Pipe(); let err = Pipe()
+        process.standardOutput = out; process.standardError = err
+        try? process.run()
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        let errData = err.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, String(data: errData, encoding: .utf8) ?? "")
+        let text = String(data: data, encoding: .utf8) ?? ""
+        return trim ? text.trimmingCharacters(in: .whitespacesAndNewlines) : text
+    }
+
+    private func runGit(_ args: [String], in directory: String) {
+        gitOutput(args, in: directory)
+    }
+}

--- a/Tests/WorktreeTitleResolverTests.swift
+++ b/Tests/WorktreeTitleResolverTests.swift
@@ -67,4 +67,43 @@ final class WorktreeTitleResolverTests: XCTestCase {
         )
         XCTAssertEqual(title, "the prompt")
     }
+
+    /// The integration checkout has no agent and no task, so every other source
+    /// would end up describing a shell. Its own state wins outright.
+    func testIntegrationStateOutranksEveryOtherSource() {
+        let title = WorktreeTitleResolver.resolve(
+            worktreePath: "/repo-worktrees/integration",
+            lastUserPrompt: "a prompt",
+            branch: "some-branch",
+            integrationStatus: { _ in "integration · 3 worktrees" },
+            sessionTitle: { _ in "a session summary" },
+            taskDescription: { _ in "a task" }
+        )
+        XCTAssertEqual(title, "integration · 3 worktrees")
+    }
+
+    /// Every other worktree is unaffected — no status, no change in order.
+    func testAbsentIntegrationStateChangesNothing() {
+        let title = WorktreeTitleResolver.resolve(
+            worktreePath: "/repo-worktrees/agent",
+            lastUserPrompt: "a prompt",
+            branch: "some-branch",
+            integrationStatus: { _ in nil },
+            sessionTitle: { _ in nil },
+            taskDescription: { _ in "a task" }
+        )
+        XCTAssertEqual(title, "a task")
+    }
+
+    func testBlankIntegrationStateFallsThrough() {
+        let title = WorktreeTitleResolver.resolve(
+            worktreePath: "/repo-worktrees/integration",
+            lastUserPrompt: "a prompt",
+            branch: "some-branch",
+            integrationStatus: { _ in "   " },
+            sessionTitle: { _ in nil },
+            taskDescription: { _ in nil }
+        )
+        XCTAssertEqual(title, "a prompt")
+    }
 }

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0B486DC8922CD428C8D48A90 /* CursorSessionTitleLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201D21B0CA40F70C2EDF3073 /* CursorSessionTitleLookupTests.swift */; };
 		0C553E03E27CDC10711D9EDD /* NewBranchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1768F75790892B5D280CBC0 /* NewBranchDialog.swift */; };
 		0DA6D2D48F320DFB8671C67C /* ClaudeStatuslineBridgeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EFCABEFB8EEA92A8B6FA13 /* ClaudeStatuslineBridgeInstaller.swift */; };
+		0DCC5CC757854AB4054F646F /* IntegrationWorktreeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAC3559992F8B4562068B449 /* IntegrationWorktreeStore.swift */; };
 		0E3AA9FF166CC516F1B7264B /* ZmxChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F98DB046516F2EB312E63F /* ZmxChannel.swift */; };
 		0F1F7BA79FAD1F778C22E92B /* WorktreeTaskStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EEEE2451A4C40006552810 /* WorktreeTaskStore.swift */; };
 		0F42CE97488379120CBB967A /* StackedWorktreeBaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F52B822BB29970B0615304 /* StackedWorktreeBaseTests.swift */; };
@@ -65,6 +66,7 @@
 		28F64A45113C9031DE991377 /* WrappedPathAtClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF8621D5464BAE7F393215 /* WrappedPathAtClickTests.swift */; };
 		29495AEAADEAB3360FDADEDB /* GmailAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88D1AA083189266856E9B02 /* GmailAccessToken.swift */; };
 		29FFE70A579739BDA4A737AC /* GitHubPRService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A864EF5AD3DEA27B0135D7D1 /* GitHubPRService.swift */; };
+		2AB9FBCF955A1C0BC01C1C3C /* IntegrationWorktreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90EF92DD407F1B5BBC3F3FC1 /* IntegrationWorktreeTests.swift */; };
 		2BC7A5243BDCCBADED457B44 /* SplitContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF31BD8D110A45D923D8B7D /* SplitContainerView.swift */; };
 		2C2802EE819E3CFE15765F18 /* WebhookStatusProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D1A230FCEF8663316AD13F /* WebhookStatusProviderTests.swift */; };
 		2CE3679CE395A49CDD452CEB /* FuzzyMatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358662BE2D7B5944F3C610F9 /* FuzzyMatchTests.swift */; };
@@ -167,6 +169,7 @@
 		65BBAC7799C70383810BFEE3 /* TabSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC183C3A20588D380EF62682 /* TabSelectionTests.swift */; };
 		6626F9EC5169BC7231EEA9BA /* ClaudeUsageSummaryProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED032A4F5701E6B65774EBAB /* ClaudeUsageSummaryProviderTests.swift */; };
 		67534BADE19F84A44C2CE74E /* UsageReadoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574B7FE2D9B877BB71343689 /* UsageReadoutTests.swift */; };
+		68AC25AFDA14448CAE9FA7A2 /* IntegrationRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F1B159E50F3F6CDA6466BE /* IntegrationRunner.swift */; };
 		6A163C3D07926CCCE88526ED /* ClaudeStatuslineBridgeInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72216A51E95B79080610E0C6 /* ClaudeStatuslineBridgeInstallerTests.swift */; };
 		6AC11D3AF38BF0EEAD1C57F3 /* PaneTitleResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49437644810F143C24E9273B /* PaneTitleResolverTests.swift */; };
 		6B44C70CFE8C5CE5F00533F6 /* ChromeCollapseUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37A61F49272C1D9D5FAF19F2 /* ChromeCollapseUITests.swift */; };
@@ -395,6 +398,7 @@
 		E03AA117E6413878273128F9 /* BridgePanelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F647B139CCD0468E41CBBB6F /* BridgePanelViewController.swift */; };
 		E0D71AAD78443B2E6D4BB573 /* StatusDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7598CDC2F8E33DD35632FAB7 /* StatusDetectorTests.swift */; };
 		E100AB08193BEDC6CD9E62C1 /* IngestOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340F0D26DC8D1C8F72279B6A /* IngestOutcome.swift */; };
+		E134224DD16226B5C25277C5 /* IntegrationWorktree.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B6751DF6EEC2F5FB03616F /* IntegrationWorktree.swift */; };
 		E2066652132155948F7F9B1F /* SplitContainerLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E960699EF752C67ED06FF552 /* SplitContainerLayoutTests.swift */; };
 		E2CE378761CC355AC0091ECC /* RepoPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D82DD1EFBD20111AC9BF2 /* RepoPage.swift */; };
 		E38E545F2B88EE35F5D68621 /* OnboardingThemeStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E255132C2399E444871CFA /* OnboardingThemeStepView.swift */; };
@@ -712,6 +716,7 @@
 		8EA68D37F6726B55761155E3 /* AgentRegistryBackgroundBusyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryBackgroundBusyTests.swift; sourceTree = "<group>"; };
 		902196E72A614F0FF9C90514 /* AVKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVKit.framework; path = System/Library/Frameworks/AVKit.framework; sourceTree = SDKROOT; };
 		90BFD1E80754F390DB43E63A /* SeahelmHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmHookInstallerTests.swift; sourceTree = "<group>"; };
+		90EF92DD407F1B5BBC3F3FC1 /* IntegrationWorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationWorktreeTests.swift; sourceTree = "<group>"; };
 		9108B00E116887EE759F5A7C /* SessionTitleLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionTitleLookupTests.swift; sourceTree = "<group>"; };
 		910A1A1AF1F5DDDA3A675836 /* ReturnToPort.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturnToPort.swift; sourceTree = "<group>"; };
 		911314F4B91E512511E3FC21 /* EventHubTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventHubTests.swift; sourceTree = "<group>"; };
@@ -749,6 +754,7 @@
 		A94DAD757D9F452B11283244 /* Manifests */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Manifests; path = Resources/Manifests; sourceTree = SOURCE_ROOT; };
 		AA151402CD4A6E95C947C0AB /* ExternalChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalChannel.swift; sourceTree = "<group>"; };
 		AA3A8892B1DC42E27FCD2A98 /* CodexUsageSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageSummaryProvider.swift; sourceTree = "<group>"; };
+		AAC3559992F8B4562068B449 /* IntegrationWorktreeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationWorktreeStore.swift; sourceTree = "<group>"; };
 		AB8C0AA934FBBE1D3F9E6831 /* AgentManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentManifest.swift; sourceTree = "<group>"; };
 		ADAB7F280D7925E9A0CD660C /* HostGatewayStaticFiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayStaticFiles.swift; sourceTree = "<group>"; };
 		ADC1F3A1FF1F0CC45B8BD0A8 /* NormalizedEventDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalizedEventDecoderTests.swift; sourceTree = "<group>"; };
@@ -812,6 +818,7 @@
 		C687ACEF28BB0481292D8AAF /* GmailMailPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GmailMailPoller.swift; sourceTree = "<group>"; };
 		C6F98DB046516F2EB312E63F /* ZmxChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZmxChannel.swift; sourceTree = "<group>"; };
 		C71C3A59719695387993016D /* FuzzyMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatch.swift; sourceTree = "<group>"; };
+		C8F1B159E50F3F6CDA6466BE /* IntegrationRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationRunner.swift; sourceTree = "<group>"; };
 		C9BF7C60A5333E90B1FFEDB5 /* SpinnerDotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerDotView.swift; sourceTree = "<group>"; };
 		CA55CCCA9FF0DB650A2D0CDE /* GmailOAuthCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GmailOAuthCoordinator.swift; sourceTree = "<group>"; };
 		CB28B1CB12CE417A892A04C4 /* VTPipelineBenchmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VTPipelineBenchmarks.swift; sourceTree = "<group>"; };
@@ -858,6 +865,7 @@
 		E060A70CCB13E3B97F8BB18E /* FirstMateCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateCoordinatorTests.swift; sourceTree = "<group>"; };
 		E08BEAA55278BCB719905234 /* OnboardingWelcomeStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWelcomeStepView.swift; sourceTree = "<group>"; };
 		E0A70D4315E684DAEAFF18A8 /* OpenCodePluginInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodePluginInstaller.swift; sourceTree = "<group>"; };
+		E0B6751DF6EEC2F5FB03616F /* IntegrationWorktree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationWorktree.swift; sourceTree = "<group>"; };
 		E0CD4486C05DC41B6EBC51CC /* MarkdownPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPreviewView.swift; sourceTree = "<group>"; };
 		E1479F39CD088308B1796C1F /* ChromeLayoutStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeLayoutStateTests.swift; sourceTree = "<group>"; };
 		E16FBC8322498A92AB007AAB /* ModalPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalPage.swift; sourceTree = "<group>"; };
@@ -1015,6 +1023,8 @@
 				0B383B7D494355714192C928 /* IMessageRuleCoalescer.swift */,
 				0129F6EBD2E1650EFE04DC4A /* IMessageSender.swift */,
 				340F0D26DC8D1C8F72279B6A /* IngestOutcome.swift */,
+				C8F1B159E50F3F6CDA6466BE /* IntegrationRunner.swift */,
+				AAC3559992F8B4562068B449 /* IntegrationWorktreeStore.swift */,
 				B4A702B5B856603AEC1DAAFA /* MailBody.swift */,
 				366D03974E15A858BE536AE1 /* MailHTML.swift */,
 				93F4FC4D61D58DD56DB8E9FE /* MailPaneRouter.swift */,
@@ -1172,6 +1182,7 @@
 				4E3492399099DDDAE527C6CA /* GitHubDiffAdapter.swift */,
 				E2BAEF3139798D53AE355496 /* GitProcess.swift */,
 				8D8B57E510DFD6E674BE5080 /* IntegrationBuilder.swift */,
+				E0B6751DF6EEC2F5FB03616F /* IntegrationWorktree.swift */,
 				159B10196D13B333CFC76E1D /* SuggestGuidanceWriter.swift */,
 				F0479C060435CDD5ED956DFE /* WorktreeCreator.swift */,
 				7F2C37E0232BF78E7DCFAAC4 /* WorktreeDeleter.swift */,
@@ -1390,6 +1401,7 @@
 				3FA6E78D00BFAF395356B892 /* IMessageRuleTests.swift */,
 				9A6626CE19664527CAF45610 /* InlineWorktreeCreateViewTests.swift */,
 				A1876E1900448D0350043DB3 /* IntegrationBuilderTests.swift */,
+				90EF92DD407F1B5BBC3F3FC1 /* IntegrationWorktreeTests.swift */,
 				C09670C63C69A22AF3AE348B /* IslandProjectGroupTests.swift */,
 				77AAEF167452AD3BAB184D84 /* KeyboardSubstateControllerTests.swift */,
 				85D2312DE47C6FDA0B8652EE /* LayoutNodeTests.swift */,
@@ -1930,6 +1942,7 @@
 				19A26EE54A5CE77EB9A5A51B /* IdeaStoreTests.swift in Sources */,
 				7264850316B48C75C53EA138 /* InlineWorktreeCreateViewTests.swift in Sources */,
 				969A1488531C0DC09B3C0D84 /* IntegrationBuilderTests.swift in Sources */,
+				2AB9FBCF955A1C0BC01C1C3C /* IntegrationWorktreeTests.swift in Sources */,
 				6D77816EA35B10D7A42D5491 /* IslandProjectGroupTests.swift in Sources */,
 				73225618467620F782EF0465 /* KeyboardSubstateControllerTests.swift in Sources */,
 				926281EDB1D02F36BD5782DE /* LayoutNodeTests.swift in Sources */,
@@ -2162,6 +2175,9 @@
 				E100AB08193BEDC6CD9E62C1 /* IngestOutcome.swift in Sources */,
 				81E16B0856AC19CEF54AC77A /* InlineWorktreeCreateView.swift in Sources */,
 				1F121DE08BEE76DF3987C368 /* IntegrationBuilder.swift in Sources */,
+				68AC25AFDA14448CAE9FA7A2 /* IntegrationRunner.swift in Sources */,
+				E134224DD16226B5C25277C5 /* IntegrationWorktree.swift in Sources */,
+				0DCC5CC757854AB4054F646F /* IntegrationWorktreeStore.swift in Sources */,
 				8EABBB670FE78F05B40F735B /* IslandModel.swift in Sources */,
 				426F95A44B1C856837684FCF /* IslandPanelController.swift in Sources */,
 				1F8744F999963A2E2F376171 /* IslandRootView.swift in Sources */,

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		0F1F7BA79FAD1F778C22E92B /* WorktreeTaskStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60EEEE2451A4C40006552810 /* WorktreeTaskStore.swift */; };
 		0F42CE97488379120CBB967A /* StackedWorktreeBaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95F52B822BB29970B0615304 /* StackedWorktreeBaseTests.swift */; };
 		0F486115B10D4353770B261C /* SessionRestoreConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFAE60D0EF11A5DC22B2B73 /* SessionRestoreConfigTests.swift */; };
+		0F78AFF34ACE62201D0582E6 /* IntegrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9C5F9EE967F8B87332014 /* IntegrationCoordinatorTests.swift */; };
 		0FDF118A34CA87216F2FD70D /* GitProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BAEF3139798D53AE355496 /* GitProcess.swift */; };
 		1063EE7F5505310F9DEE6E07 /* SuggestGuidanceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159B10196D13B333CFC76E1D /* SuggestGuidanceWriter.swift */; };
 		10D70ABC6FF1371989A62258 /* ClaudeUsageSummaryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258A1C3E5F11466A79C1CAF3 /* ClaudeUsageSummaryProvider.swift */; };
@@ -102,6 +103,7 @@
 		40A381BEFFBC2C3848BF59F5 /* PaneProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9890C9BDCA01771964CF26FD /* PaneProgressBar.swift */; };
 		4106001E365F2AFE29B0F586 /* AgentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055E765E62830F8CD924C76F /* AgentStatus.swift */; };
 		426F95A44B1C856837684FCF /* IslandPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2761438177A32EEF5CCFE031 /* IslandPanelController.swift */; };
+		42729ADC959CA03BA771E6C2 /* IntegrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256BB7C447703DD227B69806 /* IntegrationCoordinator.swift */; };
 		4344E9AEB5D00D092883F299 /* KeyboardMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 798BF92EBF7B02019D1265F7 /* KeyboardMode.swift */; };
 		43BD24E5D16ABA5AC477E89C /* DashboardFocusControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA242C3631BD163C19CFDD38 /* DashboardFocusControllerTests.swift */; };
 		43EF6A61FC26F6221292A0A3 /* WebhookStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8F5AD2CC7C21E82564BA10 /* WebhookStatusProvider.swift */; };
@@ -286,6 +288,7 @@
 		A0A5267095AB8E2FBAAB8C03 /* ghostty.conf in Resources */ = {isa = PBXBuildFile; fileRef = E4BEF7BAC8EF2918D2F601F7 /* ghostty.conf */; };
 		A2A33CDFDE9F70751E8F5DF0 /* SmokeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E7934A548F91E1E9FB161C /* SmokeTests.swift */; };
 		A3C6B5F047EBF420EA393C13 /* TodoStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77ABED3BE7AAC378B4E6B068 /* TodoStore.swift */; };
+		A4511021DEF08E77298E6F09 /* IntegrationStatusStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811DF1463E1F5D6EFC56F68A /* IntegrationStatusStore.swift */; };
 		A56AD79B6223CC0089D6B6F6 /* SeahelmUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E2397B00081F3F0861460E /* SeahelmUITestCase.swift */; };
 		A5B666A67B06796F7E431A77 /* WatchFeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5884DCB29BD98E4B9A1938AD /* WatchFeedTests.swift */; };
 		A5F8DD0A3B1785C4F7861188 /* StationRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532D40CAB3DC6BC206BB94C4 /* StationRegistry.swift */; };
@@ -485,6 +488,7 @@
 		091FF7815D565EA0D1CD27E4 /* zmx-attach.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = "zmx-attach.py"; sourceTree = "<group>"; };
 		092C7E1E287BA335DCA70204 /* ActivityEventExtractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityEventExtractorTests.swift; sourceTree = "<group>"; };
 		09698EDB6719D1778DF79D4B /* SeahelmControlDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmControlDataSource.swift; sourceTree = "<group>"; };
+		09F9C5F9EE967F8B87332014 /* IntegrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		0A25DADE8C435CBAA6E78BAB /* ThemedBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedBackgroundView.swift; sourceTree = "<group>"; };
 		0B383B7D494355714192C928 /* IMessageRuleCoalescer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMessageRuleCoalescer.swift; sourceTree = "<group>"; };
 		0BE2B74AFEED5F242C1B2763 /* ProjectColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectColor.swift; sourceTree = "<group>"; };
@@ -525,6 +529,7 @@
 		249CA31487C12997605E1512 /* TaskProgressParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskProgressParserTests.swift; sourceTree = "<group>"; };
 		24BD97D45539400A4E3160E2 /* FirstMateConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateConfig.swift; sourceTree = "<group>"; };
 		25346A39BB85A9E74B496865 /* EditLayoutContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLayoutContainerView.swift; sourceTree = "<group>"; };
+		256BB7C447703DD227B69806 /* IntegrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationCoordinator.swift; sourceTree = "<group>"; };
 		258A1C3E5F11466A79C1CAF3 /* ClaudeUsageSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeUsageSummaryProvider.swift; sourceTree = "<group>"; };
 		26EFCABEFB8EEA92A8B6FA13 /* ClaudeStatuslineBridgeInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeStatuslineBridgeInstaller.swift; sourceTree = "<group>"; };
 		27293C9549D95350D5CA8E80 /* DiffReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffReviewView.swift; sourceTree = "<group>"; };
@@ -694,6 +699,7 @@
 		7FB76BDD5A8BB0E59DA78D13 /* GrowingTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowingTextView.swift; sourceTree = "<group>"; };
 		8106508B943DF9C7053C6A11 /* GmailOAuthCallbackPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GmailOAuthCallbackPage.swift; sourceTree = "<group>"; };
 		810968D6A752BC9C5B9C5F27 /* WorktreeDeleterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDeleterTests.swift; sourceTree = "<group>"; };
+		811DF1463E1F5D6EFC56F68A /* IntegrationStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationStatusStore.swift; sourceTree = "<group>"; };
 		826B5E1EB796AA82415B329F /* OSC133ParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSC133ParserTests.swift; sourceTree = "<group>"; };
 		82C1E60B8144F4FB489FADD2 /* RegionFocusControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionFocusControllerTests.swift; sourceTree = "<group>"; };
 		849C6707188E7E90997D691A /* SplitTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitTree.swift; sourceTree = "<group>"; };
@@ -1023,7 +1029,9 @@
 				0B383B7D494355714192C928 /* IMessageRuleCoalescer.swift */,
 				0129F6EBD2E1650EFE04DC4A /* IMessageSender.swift */,
 				340F0D26DC8D1C8F72279B6A /* IngestOutcome.swift */,
+				256BB7C447703DD227B69806 /* IntegrationCoordinator.swift */,
 				C8F1B159E50F3F6CDA6466BE /* IntegrationRunner.swift */,
+				811DF1463E1F5D6EFC56F68A /* IntegrationStatusStore.swift */,
 				AAC3559992F8B4562068B449 /* IntegrationWorktreeStore.swift */,
 				B4A702B5B856603AEC1DAAFA /* MailBody.swift */,
 				366D03974E15A858BE536AE1 /* MailHTML.swift */,
@@ -1401,6 +1409,7 @@
 				3FA6E78D00BFAF395356B892 /* IMessageRuleTests.swift */,
 				9A6626CE19664527CAF45610 /* InlineWorktreeCreateViewTests.swift */,
 				A1876E1900448D0350043DB3 /* IntegrationBuilderTests.swift */,
+				09F9C5F9EE967F8B87332014 /* IntegrationCoordinatorTests.swift */,
 				90EF92DD407F1B5BBC3F3FC1 /* IntegrationWorktreeTests.swift */,
 				C09670C63C69A22AF3AE348B /* IslandProjectGroupTests.swift */,
 				77AAEF167452AD3BAB184D84 /* KeyboardSubstateControllerTests.swift */,
@@ -1942,6 +1951,7 @@
 				19A26EE54A5CE77EB9A5A51B /* IdeaStoreTests.swift in Sources */,
 				7264850316B48C75C53EA138 /* InlineWorktreeCreateViewTests.swift in Sources */,
 				969A1488531C0DC09B3C0D84 /* IntegrationBuilderTests.swift in Sources */,
+				0F78AFF34ACE62201D0582E6 /* IntegrationCoordinatorTests.swift in Sources */,
 				2AB9FBCF955A1C0BC01C1C3C /* IntegrationWorktreeTests.swift in Sources */,
 				6D77816EA35B10D7A42D5491 /* IslandProjectGroupTests.swift in Sources */,
 				73225618467620F782EF0465 /* KeyboardSubstateControllerTests.swift in Sources */,
@@ -2175,7 +2185,9 @@
 				E100AB08193BEDC6CD9E62C1 /* IngestOutcome.swift in Sources */,
 				81E16B0856AC19CEF54AC77A /* InlineWorktreeCreateView.swift in Sources */,
 				1F121DE08BEE76DF3987C368 /* IntegrationBuilder.swift in Sources */,
+				42729ADC959CA03BA771E6C2 /* IntegrationCoordinator.swift in Sources */,
 				68AC25AFDA14448CAE9FA7A2 /* IntegrationRunner.swift in Sources */,
+				A4511021DEF08E77298E6F09 /* IntegrationStatusStore.swift in Sources */,
 				E134224DD16226B5C25277C5 /* IntegrationWorktree.swift in Sources */,
 				0DCC5CC757854AB4054F646F /* IntegrationWorktreeStore.swift in Sources */,
 				8EABBB670FE78F05B40F735B /* IslandModel.swift in Sources */,

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		1BB8C6D16F033D0337FB2BAD /* CursorSessionTitleLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2AD81803E67D6EC8F90EA5 /* CursorSessionTitleLookup.swift */; };
 		1E992A5758BD000FADE4E084 /* WebhookEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F66DA28CC57BFA18891872D /* WebhookEvent.swift */; };
 		1E9E18DF38B9685E5EE65D23 /* SeahelmSkillInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3EAA643D3A58E42AE2B7CD /* SeahelmSkillInstaller.swift */; };
+		1F121DE08BEE76DF3987C368 /* IntegrationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D8B57E510DFD6E674BE5080 /* IntegrationBuilder.swift */; };
 		1F17BE40E11A063D21FD2B1C /* ControlSocketServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536A8D31229E4F3D3D5D4DE8 /* ControlSocketServerTests.swift */; };
 		1F8744F999963A2E2F376171 /* IslandRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543222F7078995AB79534CD4 /* IslandRootView.swift */; };
 		2016934685236AC44DC4F54F /* UpdateDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E8C45661088CE99AA27E805 /* UpdateDriver.swift */; };
@@ -218,6 +219,7 @@
 		82716362C00AE8D58C2C0C97 /* ChromeHeaderPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E4048B5F3E4C7759600A8DD /* ChromeHeaderPage.swift */; };
 		831980CBE1E33D059A978E82 /* WorktreePathIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C1E76E23951B9F8DB873E3C /* WorktreePathIndexTests.swift */; };
 		844747226335348450B94EEA /* PtyGridAbsorbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C4FA6FDE7FEC53DDB662BD /* PtyGridAbsorbTests.swift */; };
+		85197A128E0E3812C3B34508 /* WorktreeSnapshotterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97096F35E0C4B14D1874C672 /* WorktreeSnapshotterTests.swift */; };
 		8579DC09CEA0D01A125D5273 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C282D98A9A6117C70B06D3F1 /* NotificationManager.swift */; };
 		859DBEFE2BAE0BA0C975FD3E /* TaskProgressParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EE31EC02520149C8E193C0 /* TaskProgressParser.swift */; };
 		862DDEDAF094D4C2523B632F /* ClaudeHooksSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFC2B75DCC01AF5F766AF1B /* ClaudeHooksSetupTests.swift */; };
@@ -253,6 +255,7 @@
 		93EFC966AC0956AF645C3B0E /* DialogPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54362D573E93E8E8D59A1517 /* DialogPage.swift */; };
 		964D05E6C8C5D093CB6633E2 /* ThemedBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A25DADE8C435CBAA6E78BAB /* ThemedBackgroundView.swift */; };
 		9684C23FB2CD701D95E47EDA /* HostGatewayServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F8EA0DFCBD7F74049EA635 /* HostGatewayServerTests.swift */; };
+		969A1488531C0DC09B3C0D84 /* IntegrationBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1876E1900448D0350043DB3 /* IntegrationBuilderTests.swift */; };
 		98451F4BB27B209594F5F732 /* FileTreeOutlineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6207F1F7B2A126A6C5D69E91 /* FileTreeOutlineControllerTests.swift */; };
 		9959580EE4A6E02EAF3ECDA4 /* UsageSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693DBDBBFD25BEA5D9BE4E26 /* UsageSummary.swift */; };
 		9A03CF75CF0BCBBD3E4778FA /* PersistedStringMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3E143D632D86B7DBBC840E /* PersistedStringMap.swift */; };
@@ -265,6 +268,7 @@
 		9B8C6AFF8B40BEA399096B15 /* SettingsRowLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5189888D351C4E3BE7FD1B0C /* SettingsRowLayoutTests.swift */; };
 		9C35BEC65A084B6F21FF11DB /* TerminalHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472ACEFBD0F23747FC60EB0D /* TerminalHeaderViewTests.swift */; };
 		9C55DE7AD6C3DCE23F18B842 /* PendingOrdersQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6CAE97113B8F2314759D70 /* PendingOrdersQueue.swift */; };
+		9CB20225E63262D49B89EFFB /* WorktreeSnapshotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6EF9DDF33CD3FBC2155391 /* WorktreeSnapshotter.swift */; };
 		9E6B89CACF0F49A0029E3BD1 /* GitDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = B032E95F9035447EBF27883B /* GitDiff.swift */; };
 		9E70B1DBD63DBC4873DC38EB /* QuickSwitcherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA513259B19E55E2FB46C9F /* QuickSwitcherViewController.swift */; };
 		9E7373708FBA84B5A512E671 /* IMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B97EA2AD344FB22E7B40CA /* IMessageRule.swift */; };
@@ -700,6 +704,7 @@
 		8AF31BD8D110A45D923D8B7D /* SplitContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitContainerView.swift; sourceTree = "<group>"; };
 		8CF331BF96A89F1DC3E9C1BD /* PRListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRListView.swift; sourceTree = "<group>"; };
 		8D716EF8AB2E7C89A0D9DBEB /* HookDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookDecoder.swift; sourceTree = "<group>"; };
+		8D8B57E510DFD6E674BE5080 /* IntegrationBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationBuilder.swift; sourceTree = "<group>"; };
 		8DAB60224D158B5E58C01717 /* AgentRegistryIngestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryIngestTests.swift; sourceTree = "<group>"; };
 		8DC6CD361867294E47A209E3 /* DialogPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogPresenter.swift; sourceTree = "<group>"; };
 		8E004E8B96865467209D3F2D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -715,6 +720,7 @@
 		95F52B822BB29970B0615304 /* StackedWorktreeBaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedWorktreeBaseTests.swift; sourceTree = "<group>"; };
 		9626FD6C7EE99EAEC76D6443 /* PRURLParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRURLParsingTests.swift; sourceTree = "<group>"; };
 		968213FDE4B08CF2A98DB961 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
+		97096F35E0C4B14D1874C672 /* WorktreeSnapshotterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSnapshotterTests.swift; sourceTree = "<group>"; };
 		975413D32056A4CFFA39C32C /* HostGatewayVTFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayVTFrame.swift; sourceTree = "<group>"; };
 		97A7E8E322E5A353D4457DBC /* HooksChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HooksChannel.swift; sourceTree = "<group>"; };
 		97C4FA6FDE7FEC53DDB662BD /* PtyGridAbsorbTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PtyGridAbsorbTests.swift; sourceTree = "<group>"; };
@@ -733,6 +739,7 @@
 		A07E3B53FF30705F3C18D603 /* PaneHistoryBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneHistoryBuffer.swift; sourceTree = "<group>"; };
 		A0FFC00EE90A3DAECD6396FC /* HostGatewayFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayFrame.swift; sourceTree = "<group>"; };
 		A17E46AFD48BFAA312D7D627 /* WorktreeGitStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeGitStatsTests.swift; sourceTree = "<group>"; };
+		A1876E1900448D0350043DB3 /* IntegrationBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationBuilderTests.swift; sourceTree = "<group>"; };
 		A51B009382FE3586E735355D /* CodexHooksSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexHooksSetup.swift; sourceTree = "<group>"; };
 		A5943C79014C5FE35819487C /* ScanDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDecoder.swift; sourceTree = "<group>"; };
 		A657EAE120C252D650A7961B /* FileTreeOutlineController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeOutlineController.swift; sourceTree = "<group>"; };
@@ -873,6 +880,7 @@
 		ECBEC0B8D9CEC4A93075C660 /* OpenedSurfaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenedSurfaceView.swift; sourceTree = "<group>"; };
 		ED032A4F5701E6B65774EBAB /* ClaudeUsageSummaryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeUsageSummaryProviderTests.swift; sourceTree = "<group>"; };
 		ED6A0AE5886DB08F5B0D024C /* StatusDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDetector.swift; sourceTree = "<group>"; };
+		ED6EF9DDF33CD3FBC2155391 /* WorktreeSnapshotter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSnapshotter.swift; sourceTree = "<group>"; };
 		ED8CD5E438686EF96609A1FD /* IMessageConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMessageConfig.swift; sourceTree = "<group>"; };
 		EF22C41D6F582FFD30D8BD2D /* HTMLPreviewResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLPreviewResourceTests.swift; sourceTree = "<group>"; };
 		EF3E143D632D86B7DBBC840E /* PersistedStringMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedStringMap.swift; sourceTree = "<group>"; };
@@ -1163,11 +1171,13 @@
 				B032E95F9035447EBF27883B /* GitDiff.swift */,
 				4E3492399099DDDAE527C6CA /* GitHubDiffAdapter.swift */,
 				E2BAEF3139798D53AE355496 /* GitProcess.swift */,
+				8D8B57E510DFD6E674BE5080 /* IntegrationBuilder.swift */,
 				159B10196D13B333CFC76E1D /* SuggestGuidanceWriter.swift */,
 				F0479C060435CDD5ED956DFE /* WorktreeCreator.swift */,
 				7F2C37E0232BF78E7DCFAAC4 /* WorktreeDeleter.swift */,
 				C122F14B425BC7F3DF1FEB8B /* WorktreeDiscovery.swift */,
 				3B8BB5725BBA721E41CF23CF /* WorktreeGitStats.swift */,
+				ED6EF9DDF33CD3FBC2155391 /* WorktreeSnapshotter.swift */,
 			);
 			path = Git;
 			sourceTree = "<group>";
@@ -1379,6 +1389,7 @@
 				2AAB99BA4CC29AB4376ACC12 /* IMessageRuleTargetTests.swift */,
 				3FA6E78D00BFAF395356B892 /* IMessageRuleTests.swift */,
 				9A6626CE19664527CAF45610 /* InlineWorktreeCreateViewTests.swift */,
+				A1876E1900448D0350043DB3 /* IntegrationBuilderTests.swift */,
 				C09670C63C69A22AF3AE348B /* IslandProjectGroupTests.swift */,
 				77AAEF167452AD3BAB184D84 /* KeyboardSubstateControllerTests.swift */,
 				85D2312DE47C6FDA0B8652EE /* LayoutNodeTests.swift */,
@@ -1467,6 +1478,7 @@
 				6C1E76E23951B9F8DB873E3C /* WorktreePathIndexTests.swift */,
 				4C97F6C22C29552377720F4D /* WorktreePathNavigationTests.swift */,
 				63F011748A6A508BC66F267E /* WorktreeSidePanelViewControllerTests.swift */,
+				97096F35E0C4B14D1874C672 /* WorktreeSnapshotterTests.swift */,
 				517E6B353B84EA6AE224E0C1 /* WorktreeStatusAggregatorTests.swift */,
 				DF2F9EA56DB31E6555203E06 /* WorktreeTaskStoreTests.swift */,
 				B5BDC0C3284F3CAF4BD18C62 /* WorktreeTitleResolverTests.swift */,
@@ -1917,6 +1929,7 @@
 				AD939E73CEF429CD04ACE1BD /* IMessageRuleTests.swift in Sources */,
 				19A26EE54A5CE77EB9A5A51B /* IdeaStoreTests.swift in Sources */,
 				7264850316B48C75C53EA138 /* InlineWorktreeCreateViewTests.swift in Sources */,
+				969A1488531C0DC09B3C0D84 /* IntegrationBuilderTests.swift in Sources */,
 				6D77816EA35B10D7A42D5491 /* IslandProjectGroupTests.swift in Sources */,
 				73225618467620F782EF0465 /* KeyboardSubstateControllerTests.swift in Sources */,
 				926281EDB1D02F36BD5782DE /* LayoutNodeTests.swift in Sources */,
@@ -2005,6 +2018,7 @@
 				831980CBE1E33D059A978E82 /* WorktreePathIndexTests.swift in Sources */,
 				80C1779FA957EF77BB2331A1 /* WorktreePathNavigationTests.swift in Sources */,
 				E855FF11BD4FE2723AE442AD /* WorktreeSidePanelViewControllerTests.swift in Sources */,
+				85197A128E0E3812C3B34508 /* WorktreeSnapshotterTests.swift in Sources */,
 				C444DD64D874C76934185DD6 /* WorktreeStatusAggregatorTests.swift in Sources */,
 				7DD2666A7F2FE0E895A38F8B /* WorktreeTaskStoreTests.swift in Sources */,
 				75DF92B7A3EDC695B4BA5E9B /* WorktreeTitleResolverTests.swift in Sources */,
@@ -2147,6 +2161,7 @@
 				3996E70F14274967ED09305E /* IdeaStore.swift in Sources */,
 				E100AB08193BEDC6CD9E62C1 /* IngestOutcome.swift in Sources */,
 				81E16B0856AC19CEF54AC77A /* InlineWorktreeCreateView.swift in Sources */,
+				1F121DE08BEE76DF3987C368 /* IntegrationBuilder.swift in Sources */,
 				8EABBB670FE78F05B40F735B /* IslandModel.swift in Sources */,
 				426F95A44B1C856837684FCF /* IslandPanelController.swift in Sources */,
 				1F8744F999963A2E2F376171 /* IslandRootView.swift in Sources */,
@@ -2271,6 +2286,7 @@
 				B00E523253FF35D3D72AE4BE /* WorktreeRowHelpers.swift in Sources */,
 				75772A087B197B7F7050BC43 /* WorktreeShellActions.swift in Sources */,
 				73B16CF9CCB46AADB3214B8F /* WorktreeSidePanelViewController.swift in Sources */,
+				9CB20225E63262D49B89EFFB /* WorktreeSnapshotter.swift in Sources */,
 				5D6CF18A7384A74B640EFAAC /* WorktreeStatusAggregator.swift in Sources */,
 				0F1F7BA79FAD1F778C22E92B /* WorktreeTaskStore.swift in Sources */,
 				8B392DCF5756B7062714ED20 /* WorktreeTitleCache.swift in Sources */,


### PR DESCRIPTION
Folds every worktree in a repo onto trunk, in one checkout you can run integration tests in, and keeps it current on its own as agents finish turns.

## 1 — the git layer

**`WorktreeSnapshotter`** turns a worktree's current state into a commit: committed work plus whatever is staged, modified and untracked on top. It points `GIT_INDEX_FILE` at a scratch index, so the real index, the worktree and HEAD are untouched — an agent working there cannot tell it happened. A clean worktree short-circuits to HEAD and writes no objects.

`git stash create` is the obvious first guess and the wrong one: it omits untracked files, which is most of what an agent produces (same gap as #71). And requiring the agent to commit first brings back everything wrong with `git add -A && git commit` — the repo's pre-commit hooks, whatever `-A` sweeps up, a history full of machine commits.

**`IntegrationBuilder`** folds those snapshots into one commit. `merge-tree --write-tree` merges two commits into a tree, `commit-tree` makes that a commit, and it becomes the next merge's left side.

**Nothing is checked out, so nothing can be left wedged mid-merge.** That is the entire safety argument. A `git merge` in a checkout could not be run unattended: one conflict and the integration worktree sits conflicted until a human clears it — precisely the state you must never wake up to.

Conflicts are therefore a *result*: `.excludeConflicting` (default) drops the source that will not merge and names the paths it collided on, keeping the tree buildable; `.includeWithMarkers` keeps it, markers and all.

## 2 — the checkout and `/integrate`

The checkout is **detached**. A branch would be a thing to manage — a name to reset, something pushable, and an entry in `git branch -a`, which is what the new-branch dialog offers as a base, so a worktree could end up cut from a half-tested mixture of everyone's work. Detached, there is no ref to pick.

Publishing is one `reset --hard` onto an already-merged commit, so it cannot fail partway. It is also the only irreversible step here, so a checkout carrying local edits **holds** instead of being reset; untracked files count, because losing an agent's new file to a silent reset is the same accident as losing a modified one.

`/integrate` runs a round, `/integrate full` keeps conflicting worktrees, `/integrate force` discards local edits in the checkout. It executes rather than becoming a card: nothing before the final checkout can disturb a worktree.

In the grouping, the checkout is pinned directly under main in repository and pane modes — explicitly, not by creation date, since sorting a fixture by when it happened to be made moves it whenever it is recreated. Status and time modes leave it out entirely: they answer "what needs me now" and "what has been happening", and a checkout with no agent has a shell's status and terminal output for activity. Both grouping call sites, desktop and wire, tag it through one store lookup so they cannot drift.

## 3 — keeping it current

The trigger is an edge seahelm already computes: an agent leaving `.running`. A burst of agents finishing coalesces into one round after a two-second window; one round per repo runs at a time; a checkout with something running in it is skipped rather than built for.

**Opting in is creating the checkout.** The coordinator only acts on a repo that already has one, so running `/integrate` once is what turns it on for that repo, and enabling the feature cannot conjure directories for repos that never asked.

State reaches the card without touching the dashboard's render path: `WorktreeTitleResolver` gains an integration source ahead of the session title, since a checkout has no agent and no task and every later source would describe a shell.

## 4 — where it shows up

Project group headers already carry a trailing "+" that opens the helm prefilled with `/worktree @<project>`. A sibling next to it does the same for `/integrate` — the feature's only announcement, since otherwise it is a command you have to already know. It appears only where the group holds more than one worktree: folding a single-worktree project would integrate a repo with itself.

Status and time groupings deliberately leave the checkout out of the list, which meant it vanished from those modes entirely. A banner above the fleet carries it there instead. It lives **outside** `stack`, between the header rule and the scroll view, because a banner inside the scrolling stack would go stale every time `render` takes the incremental path — and it takes it on most polls. Only its height constraint moves, so showing and hiding never reflows the column, and the rebuild is gated on the rendered text rather than the set of checkouts.

Two efficiency fixes fell out of putting this on the poll path: `IntegrationWorktreeStore` caches its membership set (`isIntegrationWorktree` is asked once per pane per render and was rebuilding a `Set` each call), and both integration lookups became injectable — matching `defaults` and `now` — so tests describe a fleet with a checkout without writing to the user's real config directory.

A correction to an earlier claim in this PR's history: the render path is `DashboardOverviewView` at 1134 lines, not the 3094 I first cited — that is the whole file, which holds two classes. Reusing the existing header-button pattern needed none of the incremental-update or structure-signature surgery I had been avoiding.

## 5 — what the checkout is made of

The checkout's diff is several worktrees folded together, so the file list alone never says whose work it is, or whose was left out. The Changes tab carries that above the list, for that checkout only: what merged, what was excluded and on which paths, any files carrying conflict markers, and — the one state needing action — a checkout held back by local edits, with the command that clears it.

Deliberately **not** a fourth side-panel tab. Side-panel tabs are not self-contained here: the internal tab bar is hidden and switching is driven by the chrome header icons, whose `ChromeLeftPane` is a persisted `Codable` enum. A fourth icon would mean touching that enum, its persistence and the chrome renderer, to add an affordance that is dead for every worktree except one per repo. Inside Changes it needs none of that, and sits where someone would look anyway.

`IntegrationStatusStore` holds structured state rather than one line, so the card, the banner and this panel describe the same round and cannot disagree. Entries written before this decode as plain text and still supply the card line, so upgrading does not blank it.

## 6 — the switch

Settings ▸ General ▸ Integration, two toggles: whether the feature exists at all, and whether it keeps itself current. The second greys out under the first, since "rebuild automatically" is meaningless with nothing to rebuild.

`integration_enabled` gates every surface — button, banner, pinned row, `/integrate` from both the helm and a message, and the automatic rounds. Off hides the feature; it does **not** delete a checkout already on disk, because that is a directory someone may have work in and a settings toggle is the wrong place to destroy one. Both flags default on, so a config written before them behaves exactly as it did.

The dashboard forces a full render when the flag flips: the structure signature describes groups and rows, not this, so without dropping it the header would keep its button until some unrelated change happened to invalidate the signature.

## Two defects the tests found

**A rebuilt commit is not a new one.** The suite failed once on a determinism assertion. `commit-tree` stamps a timestamp, so rebuilding an unchanged fleet yields a *different commit holding identical files*. The test was wrong, but so was the code: `publish` compared commits, which meant "nothing changed, do nothing" would essentially never fire — every round would reset the checkout, yanking files from under whatever was running there. Since the automatic trigger depends entirely on that path, it would have shipped live. Trees are the change key now, in `IntegrationResult` as in `WorktreeSnapshot`.

**A round folded in worktrees that were mid-write.** A round is triggered by *one* agent finishing but folds in every worktree, and `sources` filtered out only main and the checkout. A worktree whose agent was actively writing got snapshotted torn — half a file, half a rename. Worse than missing the work: the integration fails to build, and the failure reads like a real conflict rather than a timing artefact. A busy worktree now contributes its HEAD, its last self-consistent state; its uncommitted work arrives whole on the round its own turn ends, which that edge was going to trigger anyway.

That note is ambient, on the card line, not a report card — an agent still working is the normal case, and a card every round would be noise. The first version of that test expected a card, which would have made the common case the loud one.

This PR had listed the risk as "torn snapshots, mitigated by triggering only on idle edges". That mitigation only ever covered the worktree that triggered the round, never the others in it.

## Tests

**1765 unit tests pass.** New coverage leans on the negative properties, because they are the safety argument:

- `testSnapshotLeavesWorktreeIndexAndHeadUntouched`, `testBuildingTouchesNoWorktree` — status, HEAD and current branch unchanged afterwards
- `testLocalEditsHoldThePublishUntilForced`, `testUntrackedFilesAlsoHoldThePublish` — the one destructive step never fires on its own
- `testARebuiltCommitWithTheSameTreeIsStillANoop` — the first defect above
- `testBusyWorktreeContributesItsCommittedWorkOnly`, `testWorkArrivesInFullOnTheRoundAfterTheAgentStops` — the second
- `testRepoWithoutACheckoutIsNeverTouched`, `testBusyCheckoutSkipsTheRound`, `testConcurrentFinishesCoalesceIntoOneRound` — what suppresses or coalesces a round
- `testDisablingIntegrationHidesEverySurface`, `testReEnablingIntegrationRestoresTheSurfacesWithoutNewData` — the switch, including the forced re-render
- `testOrderDecidesWhichSideIsExcludedAndIsStable` — merge order is the caller's, and repeatable

The coalesce window is injectable: left at its real value the coordinator tests spent 31s of suite time waiting; at 0.05 they spend 3.5s and assert the same things.

`ProcessProbeTests`, `HostGatewayServerTests`, `ControlSocketServerTests` and `ChromeCollapseAnimationTests` flake under load on port, process and animation timing. All pre-existing: each passes in isolation, and `git diff main...HEAD` touches none of their code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
