### PR TITLE
feat: pair Host Gateway with an 8-digit code over plain HTTP

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -459,11 +459,17 @@ class MainWindowController: NSWindowController, MailCommandContext {
         wc.show()
     }
 
-    /// Browser pairing window (QR + long link). Held strongly so it survives
+    /// Browser pairing window (8-digit code). Held strongly so it survives
     /// past this call. See `PairingWindowController`.
     @objc func showPairing() {
-        let (secret, mqtt) = mintPairingContext()
-        let wc = PairingWindowController(secret: secret, hostGateway: config.hostGateway, mqtt: mqtt)
+        _ = mintPairingContext()
+        let accessURL = (config.hostGateway ?? HostGatewayConfig()).resolvedPageURL
+        let code = currentPairingCode()
+        let wc = PairingWindowController(
+            accessURL: accessURL,
+            code: code,
+            onRefresh: { [weak self] in self?.refreshPairingCode() ?? "" },
+            onRevokeAll: { [weak self] in self?.revokeAllRemotes() })
         wc.showWindow(nil)
         wc.window?.center()
         NSApp.activate(ignoringOtherApps: true)
@@ -2813,8 +2819,56 @@ extension MainWindowController: SettingsDelegate {
         mintPairingContext()
     }
 
+    func settingsPairingCode(_ settings: SettingsViewController) -> String {
+        currentPairingCode()
+    }
+
+    func settingsRefreshPairingCode(_ settings: SettingsViewController) -> String {
+        refreshPairingCode()
+    }
+
+    func settingsRevokeAllRemotes(_ settings: SettingsViewController) {
+        revokeAllRemotes()
+    }
+
     func settingsHostGatewayListening(_ settings: SettingsViewController) -> Bool {
         tabCoordinator.hostGatewayIsListening
+    }
+
+    /// Ensure an 8-digit code exists on the live config (and LivePairingCode if Gateway is up).
+    @discardableResult
+    private func currentPairingCode() -> String {
+        if let live = tabCoordinator.pairingCodeLive {
+            return live.current()
+        }
+        var store = PairingCodeStore(code: config.hostGateway?.pairCode)
+        let code = store.ensureCode()
+        if config.hostGateway == nil { config.hostGateway = HostGatewayConfig() }
+        config.hostGateway?.pairCode = code
+        config.saveNow()
+        return code
+    }
+
+    @discardableResult
+    private func refreshPairingCode() -> String {
+        if let live = tabCoordinator.pairingCodeLive {
+            return live.refresh()
+        }
+        var store = PairingCodeStore(code: config.hostGateway?.pairCode)
+        let code = store.refresh()
+        if config.hostGateway == nil { config.hostGateway = HostGatewayConfig() }
+        config.hostGateway?.pairCode = code
+        config.saveNow()
+        return code
+    }
+
+    /// Rotate root secret and pairing code so every remembered browser must re-pair.
+    private func revokeAllRemotes() {
+        if config.mqtt == nil { config.mqtt = MqttConfig(host: "localhost") }
+        config.mqtt?.rootSecret = MqttCrypto.base64url(MqttCrypto.newRootSecret())
+        _ = refreshPairingCode()
+        config.saveNow()
+        tabCoordinator.applyMqttRootSecret(config.mqtt?.rootSecret ?? "")
     }
 
     /// Live panes, so a rule's target is picked from what exists rather than

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -14,6 +14,9 @@ class TabCoordinator {
     let workspaceManager = WorkspaceManager()
 
     private var hostGatewayServer: HostGatewayServer?
+    /// Shared with Settings so "Refresh code" updates what live `auth` accepts.
+    private(set) var pairingCodeLive: LivePairingCode?
+    private var pairRateLimiter: PairRateLimiter?
     private var zmxVTAttachManager: ZmxVTAttachManager?
     /// The live control data source. Also the pane lookup + write channel the
     /// iMessage rule engine and Host Gateway dispatch through.
@@ -860,12 +863,29 @@ class TabCoordinator {
     private func setupHostGateway(dataSource: ControlDataSource) {
         guard config.hostGateway?.resolvedEnabled == true else { return }
         guard hostGatewayServer == nil else { return }
-        guard let hgConfig = config.hostGateway else { return }
+        guard var hgConfig = config.hostGateway else { return }
 
         if config.mqtt == nil { config.mqtt = MqttConfig(host: "localhost") }
         let mqtt = config.mqtt!
         let macId = mqtt.macId ?? MqttConfig.deriveMacId()
         let rootB64 = mqtt.rootSecret ?? ""
+
+        var store = PairingCodeStore(code: hgConfig.pairCode)
+        let ensured = store.ensureCode()
+        if hgConfig.pairCode != ensured {
+            hgConfig.pairCode = ensured
+            config.hostGateway = hgConfig
+            saveConfig()
+        }
+        let live = LivePairingCode(store: store)
+        live.onChange = { [weak self] updated in
+            guard let self else { return }
+            self.config.hostGateway?.pairCode = updated.code
+            self.saveConfig()
+        }
+        pairingCodeLive = live
+        let limiter = PairRateLimiter()
+        pairRateLimiter = limiter
 
         let vt = ZmxVTAttachManager()
         zmxVTAttachManager = vt
@@ -874,7 +894,9 @@ class TabCoordinator {
             router: ControlRouter(dataSource: dataSource),
             expectedMacId: macId,
             rootSecretBase64url: rootB64,
-            vt: vt)
+            vt: vt,
+            pairingCode: live,
+            rateLimiter: limiter)
         server.start()
         hostGatewayServer = server
         NSLog("[TabCoordinator] Host Gateway started port=\(hgConfig.resolvedPort) pair=\(hgConfig.resolvedPublicURL)")
@@ -884,6 +906,8 @@ class TabCoordinator {
         hostGatewayServer?.stop()
         hostGatewayServer = nil
         zmxVTAttachManager = nil
+        pairingCodeLive = nil
+        pairRateLimiter = nil
     }
 
     func teardownRemoteBackends() {

--- a/Sources/Core/HostGatewayConfig.swift
+++ b/Sources/Core/HostGatewayConfig.swift
@@ -8,15 +8,19 @@ struct HostGatewayConfig: Codable, Equatable {
     /// Directory served at `/`. Empty → the bundled `seahelm-web`; set it to a
     /// working copy to iterate on the web client without rebuilding the app.
     var webRoot: String?
+    /// Eight-digit code required to pair a remote client with this host.
+    var pairCode: String?
 
     init(enabled: Bool? = nil,
          port: UInt16? = nil,
          publicURL: String? = nil,
-         webRoot: String? = nil) {
+         webRoot: String? = nil,
+         pairCode: String? = nil) {
         self.enabled = enabled
         self.port = port
         self.publicURL = publicURL
         self.webRoot = webRoot
+        self.pairCode = pairCode
     }
 
     var resolvedEnabled: Bool { enabled ?? false }
@@ -54,12 +58,14 @@ struct HostGatewayConfig: Codable, Equatable {
             publicURL: url.isEmpty ? nil : url,
             // No field carries the dev-only web root, so pass it through rather
             // than erase a working copy set by hand in config.json.
-            webRoot: existing?.webRoot)
+            webRoot: existing?.webRoot,
+            pairCode: existing?.pairCode)
     }
 
     enum CodingKeys: String, CodingKey {
         case enabled, port
         case publicURL = "public_url"
         case webRoot = "web_root"
+        case pairCode = "pair_code"
     }
 }

--- a/Sources/Core/HostGatewayServer.swift
+++ b/Sources/Core/HostGatewayServer.swift
@@ -15,6 +15,8 @@ final class HostGatewayServer {
     private let expectedMacId: String
     private let rootSecretBase64url: String
     private let vt: HostGatewayVTAttaching
+    private let pairingCode: PairingCodeVerifying?
+    private let rateLimiter: PairRateLimiter?
     private let staticFiles: HostGatewayStaticFiles
     private let queue = DispatchQueue(label: "seahelm.hostgateway", qos: .userInitiated)
 
@@ -59,12 +61,16 @@ final class HostGatewayServer {
          router: ControlRouter,
          expectedMacId: String,
          rootSecretBase64url: String,
-         vt: HostGatewayVTAttaching) {
+         vt: HostGatewayVTAttaching,
+         pairingCode: PairingCodeVerifying? = nil,
+         rateLimiter: PairRateLimiter? = nil) {
         self.config = config
         self.router = router
         self.expectedMacId = expectedMacId
         self.rootSecretBase64url = rootSecretBase64url
         self.vt = vt
+        self.pairingCode = pairingCode
+        self.rateLimiter = rateLimiter
         self.staticFiles = HostGatewayStaticFiles(
             root: HostGatewayStaticFiles.resolveRoot(override: config.webRoot))
     }
@@ -379,7 +385,10 @@ final class HostGatewayServer {
             expectedMacId: expectedMacId,
             rootSecretBase64url: rootSecretBase64url,
             vt: vt,
-            decisions: decisions)
+            decisions: decisions,
+            pairingCode: pairingCode,
+            rateLimiter: rateLimiter,
+            clientIP: Self.clientIP(of: connection))
         let key = ObjectIdentifier(connection)
         let state = ConnectionState(connection: connection, session: session)
         connections[key] = state
@@ -463,5 +472,14 @@ final class HostGatewayServer {
             contentContext: context,
             isComplete: true,
             completion: .contentProcessed { _ in })
+    }
+
+    /// Best-effort remote address for pairing rate limits. Accepted connections
+    /// expose the peer as `.hostPort`; anything else collapses to `"unknown"`.
+    static func clientIP(of connection: NWConnection) -> String {
+        if case .hostPort(let host, _) = connection.endpoint {
+            return "\(host)"
+        }
+        return "unknown"
     }
 }

--- a/Sources/Core/HostGatewaySession.swift
+++ b/Sources/Core/HostGatewaySession.swift
@@ -20,6 +20,9 @@ final class HostGatewaySession {
     private let vt: HostGatewayVTAttaching
     /// Shared with the server, which feeds it EventHub and fans out the results.
     private let decisions: HostGatewayDecisions
+    private let pairingCode: PairingCodeVerifying?
+    private let rateLimiter: PairRateLimiter?
+    private let clientIP: String
 
     /// A queued outbound frame.
     ///
@@ -62,12 +65,18 @@ final class HostGatewaySession {
          expectedMacId: String,
          rootSecretBase64url: String,
          vt: HostGatewayVTAttaching,
-         decisions: HostGatewayDecisions = HostGatewayDecisions()) {
+         decisions: HostGatewayDecisions = HostGatewayDecisions(),
+         pairingCode: PairingCodeVerifying? = nil,
+         rateLimiter: PairRateLimiter? = nil,
+         clientIP: String = "unknown") {
         self.router = router
         self.expectedMacId = expectedMacId
         self.rootSecretBase64url = rootSecretBase64url
         self.vt = vt
         self.decisions = decisions
+        self.pairingCode = pairingCode
+        self.rateLimiter = rateLimiter
+        self.clientIP = clientIP
         vtObserverToken = vt.addObserver { [weak self] event in
             self?.enqueueVT(event)
         }
@@ -206,9 +215,34 @@ final class HostGatewaySession {
     private func handleAuth(id: String, params: [String: Any]) -> [String] {
         let macId = params["mac_id"] as? String ?? ""
         let token = params["token"] as? String ?? ""
-        let ok = HostGatewayAuth.verify(
-            macId: macId, token: token,
-            expectedMacId: expectedMacId, rootSecretBase64url: rootSecretBase64url)
+        let code = params["code"] as? String ?? ""
+
+        // Token path wins when both are present (return visits).
+        if !token.isEmpty {
+            let ok = HostGatewayAuth.verify(
+                macId: macId, token: token,
+                expectedMacId: expectedMacId, rootSecretBase64url: rootSecretBase64url)
+            return finishAuth(id: id, ok: ok, params: params, issuedToken: ok ? token : nil)
+        }
+
+        if !code.isEmpty {
+            if let rateLimiter, !rateLimiter.allow(ip: clientIP) {
+                return [encodeError(id: id, code: -32029, message: "rate_limited")]
+            }
+            let matched = pairingCode?.verify(code) == true
+            if matched {
+                rateLimiter?.recordSuccess(ip: clientIP)
+                let issued = HostGatewayAuth.expectedToken(rootSecretBase64url: rootSecretBase64url)
+                return finishAuth(id: id, ok: issued != nil, params: params, issuedToken: issued)
+            }
+            rateLimiter?.recordFailure(ip: clientIP)
+            return finishAuth(id: id, ok: false, params: params, issuedToken: nil)
+        }
+
+        return finishAuth(id: id, ok: false, params: params, issuedToken: nil)
+    }
+
+    private func finishAuth(id: String, ok: Bool, params: [String: Any], issuedToken: String?) -> [String] {
         // Opt-in, so a cached page from before the binary frame keeps working
         // against a new Mac rather than rendering nothing.
         let binary = ok && (params["vt_binary"] as? Bool ?? false)
@@ -220,10 +254,16 @@ final class HostGatewaySession {
             vtDeflate = deflate
             lock.unlock()
         }
-        var out = [HostGatewayFrame.encode(.response(
-            id: id,
-            result: ["ok": ok, "vt_binary": binary, "vt_deflate": deflate],
-            error: nil))]
+        var result: [String: Any] = [
+            "ok": ok,
+            "vt_binary": binary,
+            "vt_deflate": deflate,
+        ]
+        if ok {
+            result["mac_id"] = expectedMacId
+            if let issuedToken { result["token"] = issuedToken }
+        }
+        var out = [HostGatewayFrame.encode(.response(id: id, result: result, error: nil))]
         if ok {
             // Replay what is already open. Without this a client that connects a
             // second after a question is raised waits for an event it has missed.

--- a/Sources/Core/LivePairingCode.swift
+++ b/Sources/Core/LivePairingCode.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+protocol PairingCodeVerifying: AnyObject {
+    func verify(_ raw: String) -> Bool
+}
+
+/// Thread-safe holder for the live pairing code. Settings refresh and Gateway
+/// auth sessions share one instance so a refresh is visible to the next `auth`.
+final class LivePairingCode: PairingCodeVerifying {
+    private let lock = NSLock()
+    private var store: PairingCodeStore
+    /// Fired (on the caller's thread) after `ensureCode`/`refresh` mutate the store.
+    var onChange: ((PairingCodeStore) -> Void)?
+
+    init(store: PairingCodeStore) {
+        self.store = store
+    }
+
+    func current() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        let before = store.code
+        let code = store.ensureCode()
+        if store.code != before { onChange?(store) }
+        return code
+    }
+
+    @discardableResult
+    func refresh() -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        let code = store.refresh()
+        onChange?(store)
+        return code
+    }
+
+    func verify(_ raw: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return store.verify(raw)
+    }
+
+    /// Snapshot for persistence.
+    func snapshot() -> PairingCodeStore {
+        lock.lock()
+        defer { lock.unlock() }
+        return store
+    }
+}

--- a/Sources/Core/PairRateLimiter.swift
+++ b/Sources/Core/PairRateLimiter.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+final class PairRateLimiter {
+    private let maxFailures: Int
+    private let window: TimeInterval
+    private let lock = NSLock()
+    private var failures: [String: [Date]] = [:]
+
+    init(maxFailures: Int = 5, window: TimeInterval = 60) {
+        self.maxFailures = maxFailures
+        self.window = window
+    }
+
+    func allow(ip: String, now: Date = Date()) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        prune(ip: ip, now: now)
+        return (failures[ip] ?? []).count < maxFailures
+    }
+
+    func recordFailure(ip: String, now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        prune(ip: ip, now: now)
+        failures[ip, default: []].append(now)
+    }
+
+    func recordSuccess(ip: String) {
+        lock.lock(); defer { lock.unlock() }
+        failures.removeValue(forKey: ip)
+    }
+
+    private func prune(ip: String, now: Date) {
+        guard let list = failures[ip] else { return }
+        let kept = list.filter { now.timeIntervalSince($0) < window }
+        if kept.isEmpty { failures.removeValue(forKey: ip) }
+        else { failures[ip] = kept }
+    }
+}

--- a/Sources/Core/PairingCodeStore.swift
+++ b/Sources/Core/PairingCodeStore.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Security
+
+struct PairingCodeStore: Equatable {
+    var code: String?
+
+    static func generate() -> String {
+        var bytes = [UInt8](repeating: 0, count: 8)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        precondition(status == errSecSuccess)
+        // Map each byte into 0...9 without bias that matters at this size.
+        return bytes.map { String($0 % 10) }.joined()
+    }
+
+    static func normalize(_ raw: String) -> String {
+        String(raw.filter(\.isNumber))
+    }
+
+    static func isValidFormat(_ code: String) -> Bool {
+        let n = normalize(code)
+        return n.count == 8 && n.allSatisfy(\.isNumber)
+    }
+
+    mutating func ensureCode() -> String {
+        if let code, Self.isValidFormat(code) { return Self.normalize(code) }
+        let next = Self.generate()
+        code = next
+        return next
+    }
+
+    @discardableResult
+    mutating func refresh() -> String {
+        let next = Self.generate()
+        code = next
+        return next
+    }
+
+    func verify(_ raw: String) -> Bool {
+        guard let code, Self.isValidFormat(code) else { return false }
+        let expected = Array(Self.normalize(code).utf8)
+        let got = Array(Self.normalize(raw).utf8)
+        guard expected.count == got.count, got.count == 8 else { return false }
+        var diff: UInt8 = 0
+        for (a, b) in zip(expected, got) { diff |= a ^ b }
+        return diff == 0
+    }
+}

--- a/Sources/UI/Settings/PairingWindowController.swift
+++ b/Sources/UI/Settings/PairingWindowController.swift
@@ -1,73 +1,82 @@
 import AppKit
-import CoreImage
-import CoreImage.CIFilterBuiltins
 
-/// Browser pairing UI (QR + long link), shared by Settings and the menu-item window.
+/// Browser pairing UI: 8-digit code + access URL (no QR / long link).
 ///
-/// Always shows the **QR + long link** carrying the full pairing payload
-/// (`seahelm://pair?…` with the real root secret) for camera/paste-capable
-/// clients (browser paste, phone scan of the Host Gateway entry URL).
+/// The page URL the browser already opened is the entry; the code only
+/// authorizes. Settings and the menu pairing window share this pane.
 final class PairingPaneView: NSView {
-    private let rootSecret: Data
-    /// Settable: Settings edits the Gateway's public URL on the same page that
-    /// shows this QR, and a code still encoding the old endpoint pairs a browser
-    /// to an address nothing answers on.
-    var brokerURL: String {
-        didSet {
-            guard brokerURL != oldValue else { return }
-            refresh()
-        }
+    var accessURL: String {
+        didSet { urlField.stringValue = accessURL }
     }
-    private let macId: String
-    private let qrSide: CGFloat
-    private var pairURI: String { MqttCrypto.pairURI(broker: brokerURL, macId: macId, rootSecret: rootSecret) }
 
-    private let linkField = NSTextField(labelWithString: "")
-    private let qrView = NSImageView()
+    var onRefresh: (() -> String)?
+    var onRevokeAll: (() -> Void)?
 
-    /// `qrSide` shrinks for the Settings page, where the QR shares the width
-    /// with a sidebar and does not need to be scannable across a room.
-    init(rootSecret: Data, brokerURL: String, macId: String, qrSide: CGFloat = 240) {
-        self.rootSecret = rootSecret
-        self.brokerURL = brokerURL
-        self.macId = macId
-        self.qrSide = qrSide
+    private let codeLabel = NSTextField(labelWithString: "")
+    private let urlField = NSTextField(labelWithString: "")
+    private var currentCode = ""
+
+    init(accessURL: String, code: String) {
+        self.accessURL = accessURL
         super.init(frame: .zero)
-        build(qrSide: qrSide)
+        build()
+        setCode(code)
+        urlField.stringValue = accessURL
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
+    func setCode(_ code: String) {
+        let n = PairingCodeStore.normalize(code)
+        currentCode = n
+        guard n.count == 8 else {
+            codeLabel.stringValue = n
+            return
+        }
+        let i = n.index(n.startIndex, offsetBy: 4)
+        codeLabel.stringValue = "\(n[..<i]) \(n[i...])"
+    }
+
     // MARK: - UI
 
-    private func build(qrSide: CGFloat) {
+    private func build() {
         translatesAutoresizingMaskIntoConstraints = false
 
-        qrView.imageScaling = .scaleProportionallyUpOrDown
-        qrView.wantsLayer = true
-        qrView.image = Self.qrImage(from: pairURI, side: qrSide)
+        let hint = NSTextField(labelWithString:
+            "Open the access URL in a browser, then enter this code.")
+        hint.font = .systemFont(ofSize: 11)
+        hint.textColor = .secondaryLabelColor
+        hint.maximumNumberOfLines = 2
+        hint.lineBreakMode = .byWordWrapping
+        hint.preferredMaxLayoutWidth = 360
 
-        let linkCaption = NSTextField(labelWithString: "Long link (paste in the browser client):")
-        linkCaption.font = .systemFont(ofSize: 11); linkCaption.textColor = .secondaryLabelColor
-        linkField.stringValue = pairURI
-        linkField.isSelectable = true
-        linkField.lineBreakMode = .byTruncatingMiddle
-        linkField.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        codeLabel.font = .monospacedSystemFont(ofSize: 28, weight: .semibold)
+        codeLabel.alignment = .center
+        codeLabel.setContentHuggingPriority(.required, for: .vertical)
 
-        let copyBtn = NSButton(title: "Copy link", target: self, action: #selector(copyLink))
+        let urlCaption = NSTextField(labelWithString: "Access URL")
+        urlCaption.font = .systemFont(ofSize: 11)
+        urlCaption.textColor = .secondaryLabelColor
+        urlField.isSelectable = true
+        urlField.lineBreakMode = .byTruncatingMiddle
+        urlField.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
 
-        let warn = NSTextField(labelWithString:
-            "The QR / long link contain the real secret — do not screenshot or share them. Close this window after pairing.")
-        warn.maximumNumberOfLines = 2
-        warn.lineBreakMode = .byWordWrapping
-        warn.preferredMaxLayoutWidth = 360
-        warn.font = .systemFont(ofSize: 10); warn.textColor = .tertiaryLabelColor
+        let copyCode = NSButton(title: "Copy code", target: self, action: #selector(copyCodeClicked))
+        let refresh = NSButton(title: "Refresh code", target: self, action: #selector(refreshClicked))
+        let copyURL = NSButton(title: "Copy URL", target: self, action: #selector(copyURLClicked))
+        let revoke = NSButton(title: "Revoke all remotes", target: self, action: #selector(revokeClicked))
+        revoke.hasDestructiveAction = true
+
+        let buttons = NSStackView(views: [copyCode, refresh, copyURL, revoke])
+        buttons.orientation = .horizontal
+        buttons.spacing = 8
+        buttons.alignment = .centerY
 
         let stack = NSStackView(views: [
-            qrView, linkCaption, linkField, copyBtn, warn,
+            hint, codeLabel, urlCaption, urlField, buttons,
         ])
         stack.orientation = .vertical
-        stack.alignment = .centerX
+        stack.alignment = .leading
         stack.spacing = 10
         stack.translatesAutoresizingMaskIntoConstraints = false
         addSubview(stack)
@@ -77,67 +86,50 @@ final class PairingPaneView: NSView {
             stack.trailingAnchor.constraint(equalTo: trailingAnchor),
             stack.topAnchor.constraint(equalTo: topAnchor),
             stack.bottomAnchor.constraint(equalTo: bottomAnchor),
-            qrView.widthAnchor.constraint(equalToConstant: qrSide),
-            qrView.heightAnchor.constraint(equalToConstant: qrSide),
+            codeLabel.centerXAnchor.constraint(equalTo: stack.centerXAnchor),
         ])
-    }
-
-    /// Re-encode both renderings of the payload from the current endpoint.
-    private func refresh() {
-        qrView.image = Self.qrImage(from: pairURI, side: qrSide)
-        linkField.stringValue = pairURI
     }
 
     // MARK: - Actions
 
-    @objc private func copyLink() {
+    @objc private func copyCodeClicked() {
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(pairURI, forType: .string)
+        NSPasteboard.general.setString(currentCode, forType: .string)
     }
 
-    // MARK: - QR
+    @objc private func copyURLClicked() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(accessURL, forType: .string)
+    }
 
-    private static func qrImage(from string: String, side: CGFloat) -> NSImage? {
-        let filter = CIFilter.qrCodeGenerator()
-        filter.message = Data(string.utf8)
-        filter.correctionLevel = "M"
-        guard let ci = filter.outputImage else { return nil }
-        let scale = side / ci.extent.width
-        let scaled = ci.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
-        let rep = NSCIImageRep(ciImage: scaled)
-        let img = NSImage(size: rep.size)
-        img.addRepresentation(rep)
-        return img
+    @objc private func refreshClicked() {
+        if let next = onRefresh?() { setCode(next) }
+    }
+
+    @objc private func revokeClicked() {
+        onRevokeAll?()
     }
 }
 
 /// Standalone "Pair remote client" window. Settings hosts the same pane; the
 /// menu item stays a direct route when pairing with a phone already in hand.
-///
-/// The root secret is generated once and persisted to `config.json`
-/// (`mqtt.root_secret`); Host Gateway auth derives from it on the next connect.
 final class PairingWindowController: NSWindowController {
     private let pane: PairingPaneView
 
-    /// View-only: the caller (`MainWindowController.showPairing`) owns minting +
-    /// persisting the secret on the *live* config and reloading the gateway;
-    /// this window just renders the QR / link for the given secret.
-    convenience init(secret: Data, hostGateway: HostGatewayConfig?, mqtt: MqttConfig) {
-        self.init(rootSecret: secret,
-                  brokerURL: HostGatewayPairing.clientEntryURL(hostGateway: hostGateway, mqtt: mqtt),
-                  macId: mqtt.macId ?? MqttConfig.deriveMacId())
-    }
-
-    init(rootSecret: Data, brokerURL: String, macId: String) {
-        pane = PairingPaneView(rootSecret: rootSecret, brokerURL: brokerURL, macId: macId)
-        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 420, height: 420),
+    init(accessURL: String, code: String,
+         onRefresh: @escaping () -> String,
+         onRevokeAll: @escaping () -> Void) {
+        pane = PairingPaneView(accessURL: accessURL, code: code)
+        pane.onRefresh = onRefresh
+        pane.onRevokeAll = onRevokeAll
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 440, height: 280),
                               styleMask: [.titled, .closable],
                               backing: .buffered, defer: false)
         window.title = "Pair browser client"
         super.init(window: window)
 
         guard let content = window.contentView else { return }
-        let title = NSTextField(labelWithString: "Scan / paste the long link to pair")
+        let title = NSTextField(labelWithString: "Enter this code in the browser")
         title.font = .systemFont(ofSize: 15, weight: .semibold)
         title.translatesAutoresizingMaskIntoConstraints = false
         content.addSubview(title)

--- a/Sources/UI/Settings/SettingsViewController.swift
+++ b/Sources/UI/Settings/SettingsViewController.swift
@@ -3,11 +3,18 @@ import AppKit
 protocol SettingsDelegate: AnyObject {
     func settingsDidUpdateConfig(_ settings: SettingsViewController, config: Config)
 
-    /// Mint (if needed) and persist the pairing secret on the *live* config, and
-    /// hand back what the QR needs. Settings edits a copy of the config, and a
-    /// secret minted into a copy would be lost or clobbered — so the owner of the
-    /// live config does it, exactly as the standalone pairing window does.
+    /// Mint (if needed) and persist the pairing root secret on the *live* config.
+    /// Still required so Host Gateway can issue long-lived tokens after a code auth.
     func settingsPairingContext(_ settings: SettingsViewController) -> (secret: Data, mqtt: MqttConfig)?
+
+    /// Current 8-digit pairing code (ensures one exists).
+    func settingsPairingCode(_ settings: SettingsViewController) -> String
+
+    /// Generate a new code; previous code stops working. Does not revoke tokens.
+    func settingsRefreshPairingCode(_ settings: SettingsViewController) -> String
+
+    /// Rotate root secret + refresh code; all stored browser tokens die.
+    func settingsRevokeAllRemotes(_ settings: SettingsViewController)
 
     /// Live panes, so a rule's target is picked from a project → worktree →
     /// pane cascade of what actually exists rather than typed from memory.
@@ -27,6 +34,15 @@ protocol SettingsDelegate: AnyObject {
 /// tests conform with just the config callback.
 extension SettingsDelegate {
     func settingsPairingContext(_ settings: SettingsViewController) -> (secret: Data, mqtt: MqttConfig)? { nil }
+    func settingsPairingCode(_ settings: SettingsViewController) -> String {
+        var store = PairingCodeStore(code: nil)
+        return store.ensureCode()
+    }
+    func settingsRefreshPairingCode(_ settings: SettingsViewController) -> String {
+        var store = PairingCodeStore(code: nil)
+        return store.refresh()
+    }
+    func settingsRevokeAllRemotes(_ settings: SettingsViewController) {}
     func settingsActiveSessionNames(_ settings: SettingsViewController) -> Set<String> { [] }
     func settingsPaneTargets(_ settings: SettingsViewController) -> [PaneSnapshot] { [] }
     func settings(_ settings: SettingsViewController, connectGmailAccount email: String) {}
@@ -484,31 +500,52 @@ class SettingsViewController: NSViewController {
     private func buildPairingGroups() -> [NSView] {
         let gatewayGroup = buildHostGatewayGroup()
 
-        guard let context = settingsDelegate?.settingsPairingContext(self) else {
-            return [gatewayGroup]
+        // Ensure a root secret exists so code auth can issue tokens.
+        if let context = settingsDelegate?.settingsPairingContext(self) {
+            pairingMqtt = context.mqtt
+            config.mqtt = context.mqtt
         }
-        pairingMqtt = context.mqtt
-        // Fold the minted config back into this snapshot. `settingsPairingContext`
-        // creates `mqtt` and its `rootSecret` on the *owner's* config and saves
-        // it, so from here on this view controller's copy is a version behind —
-        // and `applyChanges()` writes this copy out wholesale. Without this line,
-        // touching any Host Gateway control right after the QR appeared erased
-        // the secret it encodes, from disk and from memory, and restarted the
-        // listener with an empty one.
-        config.mqtt = context.mqtt
 
-        let pane = PairingPaneView(rootSecret: context.secret,
-                                   brokerURL: HostGatewayPairing.clientEntryURL(
-                                       hostGateway: config.hostGateway, mqtt: context.mqtt),
-                                   macId: context.mqtt.macId ?? MqttConfig.deriveMacId(),
-                                   qrSide: 180)
+        let accessURL = (config.hostGateway ?? HostGatewayConfig()).resolvedPageURL
+        let code: String = {
+            if let fromDelegate = settingsDelegate?.settingsPairingCode(self) {
+                return fromDelegate
+            }
+            var store = PairingCodeStore(code: config.hostGateway?.pairCode)
+            return store.ensureCode()
+        }()
+        // Sync into our editable copy so applyChanges does not wipe it.
+        if config.hostGateway == nil { config.hostGateway = HostGatewayConfig() }
+        config.hostGateway?.pairCode = PairingCodeStore.normalize(code)
+
+        let pane = PairingPaneView(accessURL: accessURL, code: code)
+        pane.onRefresh = { [weak self] in
+            guard let self else { return "" }
+            let next = self.settingsDelegate?.settingsRefreshPairingCode(self) ?? {
+                var store = PairingCodeStore(code: self.config.hostGateway?.pairCode)
+                return store.refresh()
+            }()
+            self.config.hostGateway?.pairCode = next
+            return next
+        }
+        pane.onRevokeAll = { [weak self] in
+            guard let self else { return }
+            self.settingsDelegate?.settingsRevokeAllRemotes(self)
+            let next = self.settingsDelegate?.settingsPairingCode(self) ?? {
+                var store = PairingCodeStore(code: nil)
+                return store.ensureCode()
+            }()
+            self.config.hostGateway?.pairCode = next
+            pane.setCode(next)
+            pane.accessURL = (self.config.hostGateway ?? HostGatewayConfig()).resolvedPageURL
+        }
         pairingPane = pane
 
         return [
             gatewayGroup,
             SettingsGroupView(title: "Browser access", rows: [
                 SettingsRow.stacked(nil,
-                                    subtitle: "Scan or paste to pair a browser with this Mac via Host Gateway.",
+                                    subtitle: "Open the access URL below in a browser and enter the 8-digit code.",
                                     content: pane),
             ]),
         ]
@@ -547,21 +584,21 @@ class SettingsViewController: NSViewController {
                              control: gatewayPortField,
                              accessibilityId: "settings.hostGateway.port"),
             SettingsRow.stacked("Public URL",
-                                subtitle: "The address remote browsers reach, written into the pair link below. Point a tunnel at the port above and paste its `wss://\u{2026}/ws` here; leave it empty for this Mac only. It has to be `wss://` or localhost: the pairing token is derived with SubtleCrypto, which a page served over plain HTTP cannot use at all.",
+                                subtitle: "Optional override for the access URL shown under Browser access (and Open page). Point a tunnel at the port above and paste its `http(s)://\u{2026}/` or leave empty for this Mac only. Pairing no longer embeds this URL in a secret.",
                                 content: gatewayPublicURLField,
                                 height: 28),
             SettingsRow.actions([gatewayOpenPageButton], leading: [gatewayStatusLabel]),
         ])
     }
 
-    /// Gateway edits move a listener, so they refresh what the page claims: the
-    /// pair link's `b=`, and whether the bind actually took.
+    /// Gateway edits move a listener, so they refresh the access URL shown on
+    /// the pairing pane and whether the bind actually took.
     @objc private func gatewayControlChanged() {
         applyChanges()
         // Echo back what was stored, so a rejected port does not sit in the field
         // looking accepted.
         gatewayPortField.stringValue = String((config.hostGateway ?? HostGatewayConfig()).resolvedPort)
-        refreshPairingLink()
+        refreshPairingDisplay()
         refreshHostGatewayStatus()
         // The listener binds on its own queue; ask again once it has had a moment
         // to succeed or fail, or a taken port reads as running.
@@ -575,9 +612,12 @@ class SettingsViewController: NSViewController {
         NSWorkspace.shared.open(url)
     }
 
-    private func refreshPairingLink() {
-        guard let pairingPane, let mqtt = pairingMqtt else { return }
-        pairingPane.brokerURL = HostGatewayPairing.clientEntryURL(hostGateway: config.hostGateway, mqtt: mqtt)
+    private func refreshPairingDisplay() {
+        guard let pairingPane else { return }
+        pairingPane.accessURL = (config.hostGateway ?? HostGatewayConfig()).resolvedPageURL
+        if let code = config.hostGateway?.pairCode {
+            pairingPane.setCode(code)
+        }
     }
 
     private func refreshHostGatewayStatus() {

--- a/Tests/HostGatewaySessionTests.swift
+++ b/Tests/HostGatewaySessionTests.swift
@@ -126,6 +126,71 @@ final class HostGatewaySessionTests: XCTestCase {
         XCTAssertEqual((obj["result"] as? [String: Any])?["ok"] as? Bool, false)
     }
 
+    private final class FakePairingCode: PairingCodeVerifying {
+        var code: String
+        init(_ code: String) { self.code = code }
+        func verify(_ raw: String) -> Bool {
+            PairingCodeStore(code: code).verify(raw)
+        }
+    }
+
+    private func sessionWithCode(_ code: String,
+                                 limiter: PairRateLimiter? = nil,
+                                 ip: String = "1.1.1.1")
+    -> (HostGatewaySession, SessionFakeDataSource, FakeVT) {
+        let ds = SessionFakeDataSource()
+        let vt = FakeVT()
+        let b64 = MqttCrypto.base64url(root)
+        let s = HostGatewaySession(
+            router: ControlRouter(dataSource: ds),
+            expectedMacId: macId,
+            rootSecretBase64url: b64,
+            vt: vt,
+            pairingCode: FakePairingCode(code),
+            rateLimiter: limiter,
+            clientIP: ip)
+        return (s, ds, vt)
+    }
+
+    func testAuthWithCodeSucceedsAndReturnsToken() {
+        let (s, _, _) = sessionWithCode("48291736")
+        let out = s.handle(text:
+            #"{"id":"a","method":"auth","params":{"code":"4829 1736","vt_binary":true,"vt_deflate":true}}"#)
+        XCTAssertEqual(out.count, 1)
+        let result = decodeResponse(out[0])["result"] as? [String: Any]
+        XCTAssertEqual(result?["ok"] as? Bool, true)
+        XCTAssertEqual(result?["mac_id"] as? String, macId)
+        XCTAssertEqual(result?["token"] as? String, token())
+        XCTAssertEqual(result?["vt_binary"] as? Bool, true)
+        XCTAssertEqual(result?["vt_deflate"] as? Bool, true)
+
+        let snap = s.handle(text: #"{"id":"2","method":"session.snapshot","params":{}}"#)
+        let snapObj = decodeResponse(snap[0])
+        XCTAssertNil(snapObj["error"])
+        XCTAssertNotNil(snapObj["result"])
+    }
+
+    func testAuthWithWrongCodeFails() {
+        let (s, _, _) = sessionWithCode("48291736")
+        let out = s.handle(text:
+            #"{"id":"a","method":"auth","params":{"code":"00000000"}}"#)
+        XCTAssertEqual((decodeResponse(out[0])["result"] as? [String: Any])?["ok"] as? Bool, false)
+        let snap = s.handle(text: #"{"id":"2","method":"session.snapshot","params":{}}"#)
+        XCTAssertEqual((decodeResponse(snap[0])["error"] as? [String: Any])?["code"] as? Int, -32001)
+    }
+
+    func testAuthCodeRateLimited() {
+        let lim = PairRateLimiter(maxFailures: 2, window: 60)
+        let (s, _, _) = sessionWithCode("48291736", limiter: lim, ip: "9.9.9.9")
+        for _ in 0..<2 {
+            _ = s.handle(text: #"{"id":"a","method":"auth","params":{"code":"00000000"}}"#)
+        }
+        let out = s.handle(text: #"{"id":"a","method":"auth","params":{"code":"00000000"}}"#)
+        let err = decodeResponse(out[0])["error"] as? [String: Any]
+        XCTAssertEqual(err?["code"] as? Int, -32029)
+        XCTAssertEqual(err?["message"] as? String, "rate_limited")
+    }
+
     func testSnapshotAfterAuthCallsRouter() {
         let (s, ds, _) = session()
         ds.panes = [PaneSnapshot(paneId: "t1", worktreePath: "/wt", branch: "main",

--- a/Tests/PairRateLimiterTests.swift
+++ b/Tests/PairRateLimiterTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import seahelm
+
+final class PairRateLimiterTests: XCTestCase {
+    func testAllowsUnderCap() {
+        let lim = PairRateLimiter(maxFailures: 5, window: 60)
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        for _ in 0..<4 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        XCTAssertTrue(lim.allow(ip: "1.1.1.1", now: t0))
+    }
+
+    func testBlocksAfterCap() {
+        let lim = PairRateLimiter(maxFailures: 5, window: 60)
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        for _ in 0..<5 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        XCTAssertFalse(lim.allow(ip: "1.1.1.1", now: t0))
+        XCTAssertTrue(lim.allow(ip: "2.2.2.2", now: t0)) // other IP free
+    }
+
+    func testWindowExpiryUnlocks() {
+        let lim = PairRateLimiter(maxFailures: 5, window: 60)
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        for _ in 0..<5 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        XCTAssertFalse(lim.allow(ip: "1.1.1.1", now: t0))
+        XCTAssertTrue(lim.allow(ip: "1.1.1.1", now: t0.addingTimeInterval(61)))
+    }
+
+    func testSuccessClearsFailures() {
+        let lim = PairRateLimiter(maxFailures: 5, window: 60)
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        for _ in 0..<4 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        lim.recordSuccess(ip: "1.1.1.1")
+        for _ in 0..<4 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        XCTAssertTrue(lim.allow(ip: "1.1.1.1", now: t0))
+    }
+}

--- a/Tests/PairingCodeStoreTests.swift
+++ b/Tests/PairingCodeStoreTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import seahelm
+
+final class PairingCodeStoreTests: XCTestCase {
+    func testGenerateIsEightDigits() {
+        for _ in 0..<20 {
+            let code = PairingCodeStore.generate()
+            XCTAssertEqual(code.count, 8)
+            XCTAssertTrue(code.allSatisfy(\.isNumber))
+        }
+    }
+
+    func testNormalizeStripsSpaces() {
+        XCTAssertEqual(PairingCodeStore.normalize("4829 1736"), "48291736")
+    }
+
+    func testVerifyAcceptsGroupedInput() {
+        var store = PairingCodeStore(code: "48291736")
+        XCTAssertTrue(store.verify("4829 1736"))
+        XCTAssertFalse(store.verify("00000000"))
+    }
+
+    func testRefreshInvalidatesOld() {
+        var store = PairingCodeStore(code: "11111111")
+        let next = store.refresh()
+        XCTAssertNotEqual(next, "11111111")
+        XCTAssertFalse(store.verify("11111111"))
+        XCTAssertTrue(store.verify(next))
+    }
+
+    func testEnsureCodeFillsMissing() {
+        var store = PairingCodeStore(code: nil)
+        let code = store.ensureCode()
+        XCTAssertEqual(code.count, 8)
+        XCTAssertEqual(store.code, code)
+    }
+
+    func testConfigRoundTripsPairCode() throws {
+        var hg = HostGatewayConfig(enabled: true, port: 2783, pairCode: "12345678")
+        let data = try JSONEncoder().encode(hg)
+        let decoded = try JSONDecoder().decode(HostGatewayConfig.self, from: data)
+        XCTAssertEqual(decoded.pairCode, "12345678")
+        // edited must keep pair code when UI does not touch it
+        let kept = HostGatewayConfig.edited(
+            enabled: true, portText: "2783", publicURLText: "", from: hg)
+        XCTAssertEqual(kept.pairCode, "12345678")
+    }
+}

--- a/clients/seahelm-web/README.md
+++ b/clients/seahelm-web/README.md
@@ -7,24 +7,26 @@
 
 ## 生产用法(Gateway-first)
 
-1. Mac 上启用 Host Gateway(Seahelm Settings → Pairing),Cloudflare Tunnel 指向 Gateway 端口。
-2. 复制 Settings 里的 `seahelm://pair?b=<wss>/ws&m=…&k=…` 链接。
-3. 浏览器打开 `index.html`(可经 Tunnel 同域托管) → **配对** → 粘贴链接 → **连接**。
+1. Mac 上启用 Host Gateway(Seahelm Settings → Host Gateway / Browser access)。
+2. 浏览器打开 Gateway 页面(如 `http://<Mac Tailscale IP>:2783/` 或 localhost)——**http / https 均可**。
+3. 在网页输入 Settings 里显示的 **8 位配对码** → 配对并连接。
 4. 连接后自动 `session.snapshot` → First Mate 渲染 pane 列表 → 点一行开 VT 终端。
+5. 浏览器会记住 token;下次打开同一页面自动重连。刷新配对码不会踢掉已配对浏览器;「撤销所有远程」才会。
 
 传输选择(自动,无需手调):
 
 | 条件 | 传输 |
 |---|---|
-| pair `b=` 路径为 `/ws`,或 `?transport=gateway` / `localStorage seahelm_transport=gateway` | **WebSocket Host Gateway** |
+| 页面同源 `/ws`(Host Gateway 托管),或 `?transport=gateway` | **WebSocket Host Gateway** |
 | `?mqtt=1`,或 broker 为 `localhost:28083` | **MQTT**(devbroker 调试) |
 
 Gateway 握手:
 
-1. `auth` → `{mac_id, token}` — `token` = `E2EE.deriveKeys(…).password`(HKDF auth 十六进制)
-2. `session.snapshot` → 填充 First Mate
-3. 选 pane → `pane.vt_open`; 服务端 push `notify` `vt.snapshot` / `vt.data`(base64 PTY 字节)
-4. 键盘 → `pane.send_keys` `{pane_session_key, b64}`
+1. 首次:`auth` → `{code}` → 返回 `{ok, mac_id, token, vt_binary, vt_deflate}`
+2. 回访:`auth` → `{mac_id, token}`(localStorage)
+3. `session.snapshot` → 填充 First Mate
+4. 选 pane → `pane.vt_open`; 服务端 push binary VT frames(或 JSON legacy)
+5. 键盘 → `pane.send_keys` `{pane_session_key, b64}`
 
 Wire 格式:
 

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -853,7 +853,7 @@ async function applyPair(link){
   const p = E2EE.parsePairURI(link);
   const { password, encKey } = await E2EE.deriveKeys(p.rootBytes);
   S.encKey = encKey; S.authPass = password; S.mac = p.mac;
-  $('broker').value = edgeBroker() || p.broker; $('mac').value = p.mac;
+  $('broker').value = defaultBroker() || edgeBroker() || p.broker; $('mac').value = p.mac;
   $('user').value = p.mac; $('pass').value = '';
   try {
     localStorage.setItem(CREDS_KEY, JSON.stringify({ b: p.broker, m: p.mac, t: password }));

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -428,7 +428,7 @@ const S = {
   focus:null, dnd:null, events:new Map(),
   // `sel` is the selected worktree path; `selPane` the pane whose terminal is shown.
   sel:null, selPane:null,
-  encKey:null, authPass:null,   // set once a seahelm:// pair link is applied (E2EE on)
+  encKey:null, authPass:null, pendingCode:null,   // authPass = long-lived token; pendingCode for first pair
   // VT terminal: `open` is the pane key currently streaming
   // One entry per mirrored pane, keyed by paneSessionKey; `focus` is the pane
   // keystrokes reach, `worktree` is the layout currently mounted.
@@ -501,15 +501,29 @@ const esc = s => String(s??'').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;',
 const $ = id => document.getElementById(id);
 const base = () => `seahelm/${S.mac}`;
 
+// Same-origin Host Gateway WSS. Prefer this whenever the page is served by
+// Host Gateway (any host/port), so plain HTTP Tailscale URLs work.
+function gatewayWsURL(){
+  const scheme = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${scheme}//${location.host}/ws`;
+}
 // Edge stack (https://gw.seahelm.dev/): same-origin Host Gateway WSS.
-// Pair links may still carry a legacy MQTT `b=`; ignore that on the gateway host.
 function edgeBroker() {
   if (location.protocol === 'https:' && /\.(seahelm\.dev|ucar\.cc)$/i.test(location.hostname)) {
-    return `wss://${location.host}/ws`;
+    return gatewayWsURL();
   }
   return null;
 }
-if ($('broker') && edgeBroker()) $('broker').value = edgeBroker();
+function defaultBroker(){
+  if (new URLSearchParams(location.search).get('mqtt') === '1') return null;
+  // Served from Host Gateway (not file://, not mqtt-only): use same-origin /ws.
+  if (location.protocol === 'http:' || location.protocol === 'https:') {
+    if (location.port === '28083') return null; // local MQTT devbroker
+    return gatewayWsURL();
+  }
+  return edgeBroker();
+}
+if ($('broker') && defaultBroker()) $('broker').value = defaultBroker();
 
 // Host Gateway (WSS /ws) vs MQTT devbroker. Force MQTT with ?mqtt=1 or localhost:28083.
 function useGatewayTransport(url) {
@@ -573,29 +587,42 @@ function setStatus(on, txt){
 // ── connect ───────────────────────────────────────────────────────────────
 function connect(){
   disconnectAll();
-  S.mac = $('mac').value.trim() || 'testmac';
-  const edge = edgeBroker();
+  S.mac = $('mac').value.trim() || S.mac || 'testmac';
+  const edge = defaultBroker();
   if (edge) $('broker').value = edge;
-  const url = $('broker').value.trim();
+  const url = $('broker').value.trim() || gatewayWsURL();
   if (useGatewayTransport(url)) connectGateway(url);
   else connectMqtt(url);
 }
 
 function connectGateway(url){
-  if (!S.authPass) return alert('Host Gateway 需要先配对(seahelm://pair?…)');
+  if (!S.authPass && !S.pendingCode) {
+    setStatus(false, '需要配对码');
+    return;
+  }
+  const wsURL = (url && url.includes('/ws')) ? url : gatewayWsURL();
   S.transport = 'gateway';
-  log('sys', '(connect)', url + ' [Gateway]');
-  const ws = new WebSocket(url);
+  log('sys', '(connect)', wsURL + ' [Gateway]');
+  const ws = new WebSocket(wsURL);
   ws.binaryType = 'arraybuffer';
   S.gw = { ws, ready: false, req: new Map(), n: 0, binary: false, deflate: false };
   ws.onopen = () => {
-    // Opt in to the binary VT frame. An older Mac ignores these and keeps
-    // sending JSON, which the message handler still understands.
-    gwSend('auth', {
-      mac_id: S.mac, token: S.authPass,
-      vt_binary: true, vt_deflate: typeof DecompressionStream === 'function',
-    }, (r, err) => {
+    const params = {
+      vt_binary: true,
+      vt_deflate: typeof DecompressionStream === 'function',
+    };
+    if (S.pendingCode) params.code = S.pendingCode;
+    else { params.mac_id = S.mac; params.token = S.authPass; }
+    gwSend('auth', params, (r, err) => {
+      if (err && err.code === -32029) {
+        S.pendingCode = null;
+        setStatus(false, '尝试过多,稍后再试');
+        log('sys', '(auth-rate)', JSON.stringify(err));
+        ws.close();
+        return;
+      }
       if (err || !r || r.ok === false) {
+        S.pendingCode = null;
         setStatus(false, '认证失败');
         log('sys', '(auth-fail)', err ? JSON.stringify(err) : JSON.stringify(r));
         ws.close();
@@ -604,6 +631,13 @@ function connectGateway(url){
       S.gw.ready = true;
       S.gw.binary = !!(r && r.vt_binary);
       S.gw.deflate = !!(r && r.vt_deflate);
+      if (r.mac_id) S.mac = r.mac_id;
+      if (r.token) S.authPass = r.token;
+      S.pendingCode = null;
+      try {
+        localStorage.setItem(CREDS_KEY, JSON.stringify({ m: S.mac, t: S.authPass }));
+      } catch (e) {}
+      if ($('mac')) $('mac').value = S.mac;
       log('sys', '(vt format)', S.gw.binary ? (S.gw.deflate ? 'binary+deflate' : 'binary') : 'json+base64');
       setStatus(true, '已连接');
       gwSend('session.snapshot', {}, (snap) => {
@@ -833,18 +867,21 @@ function restoreCreds(){
   let c;
   try { c = JSON.parse(localStorage.getItem(CREDS_KEY) || 'null'); } catch (e) { c = null; }
   if (!c || !c.t || !c.m) return false;
-  S.authPass = c.t; S.mac = c.m; S.encKey = null;
-  $('broker').value = edgeBroker() || c.b || ''; $('mac').value = c.m;
+  S.authPass = c.t; S.mac = c.m; S.encKey = null; S.pendingCode = null;
+  const edge = defaultBroker();
+  $('broker').value = edge || c.b || gatewayWsURL();
+  $('mac').value = c.m;
   $('user').value = c.m; $('pass').value = '';
   return true;
 }
 function pairPrompt(){
+  // Legacy MQTT-only helper; Gateway uses the gate's 8-digit input.
   const link = prompt('粘贴 macOS 配对界面的长链接(seahelm://pair?…):', '');
   if (!link) return;
   applyPair(link.trim()).catch(e => alert('配对失败:' + e.message));
 }
 function clearPair(){
-  S.encKey = null; S.authPass = null;
+  S.encKey = null; S.authPass = null; S.pendingCode = null;
   localStorage.removeItem(CREDS_KEY);
   localStorage.removeItem('seahelm_pair');   // pre-migration installs
   log('sys', '(unpaired)', '回到明文/手填模式');
@@ -852,10 +889,7 @@ function clearPair(){
 }
 // Reflect pairing state in the header: chip when paired, 配对 button when not.
 /**
- * Connection gate. Pairing and connecting used to be two buttons in a corner,
- * which asked the user to know they were two steps — the first one exactly once,
- * and never again. Now the page has three states and shows only the one you are
- * in: paste a link, or press connect, or get out of the way entirely.
+ * Connection gate. Three states: enter code, press connect, or get out of the way.
  */
 function renderGate(){
   const gate = $('gate');
@@ -871,7 +905,7 @@ function renderGate(){
   if (S.authPass){                       // paired, disconnected
     gate.innerHTML = `
       <div class="gate-card">
-        <div class="gate-mac"><span class="lock">🔒</span><b>${esc(S.mac)}</b><span class="e2ee">E2EE</span></div>
+        <div class="gate-mac"><span class="lock">🔒</span><b>${esc(S.mac)}</b></div>
         <button class="gate-primary" id="gateConnect">连接</button>
         <button class="gate-link" id="gateUnpair">解除配对</button>
       </div>`;
@@ -883,33 +917,25 @@ function renderGate(){
   gate.innerHTML = `
     <div class="gate-card">
       <div class="gate-title">配对这台 Mac</div>
-      <div class="gate-hint">粘贴 Seahelm 设置里的配对链接(seahelm://pair?…)</div>
-      <textarea class="gate-input" id="gateLink" rows="3" spellcheck="false"
-                placeholder="seahelm://pair?b=…&amp;m=…&amp;k=…"></textarea>
+      <div class="gate-hint">在 Seahelm 设置里查看 8 位配对码，输入后连接</div>
+      <input class="gate-input" id="gateCode" inputmode="numeric" autocomplete="one-time-code"
+             maxlength="9" placeholder="1234 5678" />
       <button class="gate-primary" id="gatePair">配对并连接</button>
       <div class="gate-error" id="gateError" hidden></div>
     </div>`;
-  const input = $('gateLink'), err = $('gateError');
+  const input = $('gateCode'), err = $('gateError');
   const fail = (m) => { err.textContent = m; err.hidden = false; };
 
-  const go = async () => {
-    const link = (input.value || '').trim();
-    if (!link) return fail('请先粘贴配对链接');
+  const go = () => {
+    const digits = String(input.value || '').replace(/\D/g, '');
+    if (digits.length !== 8) return fail('请输入 8 位配对码');
     err.hidden = true;
-    try {
-      await applyPair(link);
-      connect();                         // one action, not two
-      renderGate();
-    } catch (e) {
-      // The usual cause is a page served without a secure context, where
-      // SubtleCrypto does not exist and e2ee.js never finished loading.
-      fail(typeof E2EE === 'undefined'
-        ? '此页面不在安全上下文中,无法计算配对密钥 —— 请用 https:// 或 http://127.0.0.1 打开'
-        : '配对失败:' + (e && e.message));
-    }
+    S.pendingCode = digits;
+    connect();
+    renderGate();
   };
   $('gatePair').onclick = go;
-  input.onkeydown = (e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) go(); };
+  input.onkeydown = (e) => { if (e.key === 'Enter') go(); };
   setTimeout(() => input.focus(), 0);
 }
 

--- a/docs/superpowers/plans/2026-08-28-short-pair-code.md
+++ b/docs/superpowers/plans/2026-08-28-short-pair-code.md
@@ -1,0 +1,676 @@
+# Short Numeric Pair Code Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a browser pair to Host Gateway by entering an 8-digit code on any reachable page (HTTP or HTTPS), with no URL or root secret in the pairing payload, and remember a Mac-issued token for reconnect.
+
+**Architecture:** Mac Settings shows a persisted 8-digit code. The browser opens same-origin `/ws`, sends `auth { code }`, and the Mac verifies the code (rate-limited by IP), then returns the existing HKDF auth token + `mac_id`. The browser stores `{ m, t }` in `localStorage` and never runs WebCrypto for Gateway pairing. Refreshing the code invalidates only the code; rotating `root_secret` revokes all tokens.
+
+**Tech Stack:** Swift 5.10 / AppKit / Network.framework, existing `HostGatewaySession` / `HostGatewayAuth` / `MqttCrypto`, `clients/seahelm-web` static page, XCTest.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-short-pair-code-design.md`
+
+## Global Constraints
+
+- Code is exactly **8 digits**, zero-padded; display may group as `4829 1736`.
+- Code lifetime: until Mac **Refresh code** (no auto TTL).
+- Refresh code: invalidate old code only; **do not** revoke stored browser tokens.
+- Revoke all remotes: rotate `mqtt.root_secret` → all tokens + force new code.
+- Rate limit failed **code** auth: **5 failures / 60 s / client IP** → error `-32029 rate_limited`.
+- Browser Gateway path must not depend on `crypto.subtle` / `e2ee.js`.
+- WebSocket URL is always same-origin `ws(s)://<location.host>/ws` — never from a pair payload.
+- Settings / web **fully replace** `seahelm://pair` QR and long link (Watch/MQTT pairing deferred).
+- macOS 14+, Swift 5.10, `@testable import seahelm`, XCTest only.
+- Persist new fields with `decodeIfPresent` / optional keys for backward compat.
+- After modifying Swift sources that XcodeGen tracks by folder, no `project.yml` change is required (`Sources/` is a path group).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `Sources/Core/PairingCodeStore.swift` | Generate / persist / verify 8-digit code |
+| `Sources/Core/PairRateLimiter.swift` | Per-IP failed code attempt window |
+| `Sources/Core/HostGatewayConfig.swift` | Add `pairCode` field + preserve through `edited` |
+| `Sources/Core/HostGatewayAuth.swift` | Optional helper to normalize code (or keep on store only) |
+| `Sources/Core/HostGatewaySession.swift` | Auth branch: token **or** code; return `mac_id` + `token` on code success |
+| `Sources/Core/HostGatewayServer.swift` | Pass code store + limiter; extract client IP into session |
+| `Sources/App/TabCoordinator.swift` | Construct store/limiter when starting Gateway |
+| `Sources/UI/Settings/PairingWindowController.swift` | Replace QR/link pane with code UI |
+| `Sources/UI/Settings/SettingsViewController.swift` | Wire refresh / revoke; update Host Gateway copy |
+| `Sources/App/MainWindowController.swift` | Pairing context / revoke if menu window still used |
+| `clients/seahelm-web/index.html` | Gate: 8-digit input; same-origin WS; no E2EE for Gateway |
+| `Tests/PairingCodeStoreTests.swift` | Store unit tests |
+| `Tests/PairRateLimiterTests.swift` | Limiter unit tests |
+| `Tests/HostGatewaySessionTests.swift` | Code auth success / fail / rate limit |
+
+---
+
+### Task 1: `PairingCodeStore`
+
+**Files:**
+- Create: `Sources/Core/PairingCodeStore.swift`
+- Modify: `Sources/Core/HostGatewayConfig.swift` — add `pairCode: String?`, CodingKey `pair_code`, pass through `edited(...)`
+- Test: `Tests/PairingCodeStoreTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `struct PairingCodeStore` with:
+    - `static func generate() -> String` — 8 digits, zero-padded, from `SecRandomCopyBytes`
+    - `static func normalize(_ raw: String) -> String` — strip spaces/dashes, keep digits only
+    - `static func isValidFormat(_ code: String) -> Bool` — exactly 8 digits after normalize
+    - `mutating func ensureCode() -> String` — if missing/invalid, generate and set
+    - `mutating func refresh() -> String` — always new code
+    - `func verify(_ raw: String) -> Bool` — normalize + constant-time compare to stored
+  - `HostGatewayConfig.pairCode: String?` with `CodingKeys.pairCode = "pair_code"`
+  - `HostGatewayConfig.edited(..., pairCode: String?)` **or** preserve `existing?.pairCode` inside current `edited` so Settings edits do not wipe the code
+- Consumes: none
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import XCTest
+@testable import seahelm
+
+final class PairingCodeStoreTests: XCTestCase {
+    func testGenerateIsEightDigits() {
+        for _ in 0..<20 {
+            let code = PairingCodeStore.generate()
+            XCTAssertEqual(code.count, 8)
+            XCTAssertTrue(code.allSatisfy(\.isNumber))
+        }
+    }
+
+    func testNormalizeStripsSpaces() {
+        XCTAssertEqual(PairingCodeStore.normalize("4829 1736"), "48291736")
+    }
+
+    func testVerifyAcceptsGroupedInput() {
+        var store = PairingCodeStore(code: "48291736")
+        XCTAssertTrue(store.verify("4829 1736"))
+        XCTAssertFalse(store.verify("00000000"))
+    }
+
+    func testRefreshInvalidatesOld() {
+        var store = PairingCodeStore(code: "11111111")
+        let next = store.refresh()
+        XCTAssertNotEqual(next, "11111111")
+        XCTAssertFalse(store.verify("11111111"))
+        XCTAssertTrue(store.verify(next))
+    }
+
+    func testEnsureCodeFillsMissing() {
+        var store = PairingCodeStore(code: nil)
+        let code = store.ensureCode()
+        XCTAssertEqual(code.count, 8)
+        XCTAssertEqual(store.code, code)
+    }
+
+    func testConfigRoundTripsPairCode() throws {
+        var hg = HostGatewayConfig(enabled: true, port: 2783, pairCode: "12345678")
+        let data = try JSONEncoder().encode(hg)
+        let decoded = try JSONDecoder().decode(HostGatewayConfig.self, from: data)
+        XCTAssertEqual(decoded.pairCode, "12345678")
+        // edited must keep pair code when UI does not touch it
+        let kept = HostGatewayConfig.edited(
+            enabled: true, portText: "2783", publicURLText: "", from: hg)
+        XCTAssertEqual(kept.pairCode, "12345678")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug \
+  -skipPackagePluginValidation -skipMacroValidation \
+  -only-testing:seahelmTests/PairingCodeStoreTests test
+```
+Expected: FAIL — `PairingCodeStore` / `pairCode` not found.
+
+- [ ] **Step 3: Implement store + config field**
+
+`Sources/Core/PairingCodeStore.swift`:
+
+```swift
+import Foundation
+import Security
+
+struct PairingCodeStore: Equatable {
+    var code: String?
+
+    static func generate() -> String {
+        var bytes = [UInt8](repeating: 0, count: 8)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        precondition(status == errSecSuccess)
+        // Map each byte into 0...9 without bias that matters at this size.
+        return bytes.map { String($0 % 10) }.joined()
+    }
+
+    static func normalize(_ raw: String) -> String {
+        String(raw.filter(\.isNumber))
+    }
+
+    static func isValidFormat(_ code: String) -> Bool {
+        let n = normalize(code)
+        return n.count == 8 && n.allSatisfy(\.isNumber)
+    }
+
+    mutating func ensureCode() -> String {
+        if let code, Self.isValidFormat(code) { return Self.normalize(code) }
+        let next = Self.generate()
+        code = next
+        return next
+    }
+
+    @discardableResult
+    mutating func refresh() -> String {
+        let next = Self.generate()
+        code = next
+        return next
+    }
+
+    func verify(_ raw: String) -> Bool {
+        guard let code, Self.isValidFormat(code) else { return false }
+        let expected = Array(Self.normalize(code).utf8)
+        let got = Array(Self.normalize(raw).utf8)
+        guard expected.count == got.count, got.count == 8 else { return false }
+        var diff: UInt8 = 0
+        for (a, b) in zip(expected, got) { diff |= a ^ b }
+        return diff == 0
+    }
+}
+```
+
+In `HostGatewayConfig`:
+- Add `var pairCode: String?`
+- Init param `pairCode: String? = nil`
+- `CodingKeys.pairCode = "pair_code"`
+- In `edited(...)`, set `pairCode: existing?.pairCode` so Settings port/URL edits do not erase it
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Same `xcodebuild … PairingCodeStoreTests` command. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Core/PairingCodeStore.swift Sources/Core/HostGatewayConfig.swift \
+  Tests/PairingCodeStoreTests.swift Tests/HostGatewayConfigTests.swift
+git commit -m "$(cat <<'EOF'
+feat: persist Host Gateway 8-digit pairing code
+
+EOF
+)"
+```
+
+---
+
+### Task 2: `PairRateLimiter`
+
+**Files:**
+- Create: `Sources/Core/PairRateLimiter.swift`
+- Test: `Tests/PairRateLimiterTests.swift`
+
+**Interfaces:**
+- Produces: `final class PairRateLimiter` with:
+  - `init(maxFailures: Int = 5, window: TimeInterval = 60)`
+  - `func allow(ip: String, now: Date = Date()) -> Bool` — false if locked out
+  - `func recordFailure(ip: String, now: Date = Date())`
+  - `func recordSuccess(ip: String)` — clear window for that IP
+- Consumes: none
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import XCTest
+@testable import seahelm
+
+final class PairRateLimiterTests: XCTestCase {
+    func testAllowsUnderCap() {
+        let lim = PairRateLimiter(maxFailures: 5, window: 60)
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        for _ in 0..<4 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        XCTAssertTrue(lim.allow(ip: "1.1.1.1", now: t0))
+    }
+
+    func testBlocksAfterCap() {
+        let lim = PairRateLimiter(maxFailures: 5, window: 60)
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        for _ in 0..<5 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        XCTAssertFalse(lim.allow(ip: "1.1.1.1", now: t0))
+        XCTAssertTrue(lim.allow(ip: "2.2.2.2", now: t0)) // other IP free
+    }
+
+    func testWindowExpiryUnlocks() {
+        let lim = PairRateLimiter(maxFailures: 5, window: 60)
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        for _ in 0..<5 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        XCTAssertFalse(lim.allow(ip: "1.1.1.1", now: t0))
+        XCTAssertTrue(lim.allow(ip: "1.1.1.1", now: t0.addingTimeInterval(61)))
+    }
+
+    func testSuccessClearsFailures() {
+        let lim = PairRateLimiter(maxFailures: 5, window: 60)
+        let t0 = Date(timeIntervalSince1970: 1_000)
+        for _ in 0..<4 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        lim.recordSuccess(ip: "1.1.1.1")
+        for _ in 0..<4 { lim.recordFailure(ip: "1.1.1.1", now: t0) }
+        XCTAssertTrue(lim.allow(ip: "1.1.1.1", now: t0))
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`PairRateLimiter` missing)
+
+- [ ] **Step 3: Implement**
+
+```swift
+import Foundation
+
+final class PairRateLimiter {
+    private let maxFailures: Int
+    private let window: TimeInterval
+    private let lock = NSLock()
+    private var failures: [String: [Date]] = [:]
+
+    init(maxFailures: Int = 5, window: TimeInterval = 60) {
+        self.maxFailures = maxFailures
+        self.window = window
+    }
+
+    func allow(ip: String, now: Date = Date()) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        prune(ip: ip, now: now)
+        return (failures[ip] ?? []).count < maxFailures
+    }
+
+    func recordFailure(ip: String, now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        prune(ip: ip, now: now)
+        failures[ip, default: []].append(now)
+    }
+
+    func recordSuccess(ip: String) {
+        lock.lock(); defer { lock.unlock() }
+        failures.removeValue(forKey: ip)
+    }
+
+    private func prune(ip: String, now: Date) {
+        guard let list = failures[ip] else { return }
+        let kept = list.filter { now.timeIntervalSince($0) < window }
+        if kept.isEmpty { failures.removeValue(forKey: ip) }
+        else { failures[ip] = kept }
+    }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug \
+  -skipPackagePluginValidation -skipMacroValidation \
+  -only-testing:seahelmTests/PairRateLimiterTests test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Core/PairRateLimiter.swift Tests/PairRateLimiterTests.swift
+git commit -m "$(cat <<'EOF'
+feat: rate-limit Host Gateway pairing code attempts
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Code auth on `HostGatewaySession`
+
+**Files:**
+- Modify: `Sources/Core/HostGatewaySession.swift` — inject code store + rate limiter + client IP; extend `handleAuth`
+- Modify: `Sources/Core/HostGatewayServer.swift` — pass dependencies; set client IP from `NWConnection`
+- Modify: `Sources/App/TabCoordinator.swift` `setupHostGateway` — create store from config, persist on refresh if needed at start via `ensureCode`
+- Test: `Tests/HostGatewaySessionTests.swift` — add code-auth cases
+
+**Interfaces:**
+- Consumes: `PairingCodeStore.verify`, `PairRateLimiter.allow/recordFailure/recordSuccess`, `HostGatewayAuth.expectedToken`
+- Produces: `auth` success with `code` returns `result: { ok, mac_id, token, vt_binary, vt_deflate }`; rate limit returns `error: { code: -32029, message: "rate_limited" }`; bad code returns `result: { ok: false, … }` **or** `-32001` — pick **`result.ok = false` for wrong code** (matches today's token failure style) and **`error -32029` only for rate limit**
+- `HostGatewaySession` init gains:
+  - `pairingCode: PairingCodeStore` (value copy at session start is fine if server holds the live store and passes a closure — prefer **`codeVerifier: () -> PairingCodeStore`** or **`codeStore: PairingCodeProviding`** protocol so refresh on Settings is seen by live sessions)
+
+Prefer a small protocol so the server owns the mutable store:
+
+```swift
+protocol PairingCodeVerifying: AnyObject {
+    func verify(_ raw: String) -> Bool
+}
+protocol PairingCodeIssuing: AnyObject {
+    // token issuance uses root secret already on the session
+}
+```
+
+Simplest workable shape for this codebase:
+
+```swift
+// On HostGatewayServer / TabCoordinator:
+final class LivePairingCode: PairingCodeVerifying {
+    private let lock = NSLock()
+    private var store: PairingCodeStore
+    var onChange: ((PairingCodeStore) -> Void)?  // persist to config
+    init(store: PairingCodeStore) { self.store = store }
+    func current() -> String { lock.lock(); defer { lock.unlock() }; return store.ensureCode() }
+    func refresh() -> String { /* lock; refresh; onChange?; return */ }
+    func verify(_ raw: String) -> Bool { lock.lock(); defer { lock.unlock() }; return store.verify(raw) }
+}
+```
+
+Session init:
+
+```swift
+init(..., pairingCode: PairingCodeVerifying?, rateLimiter: PairRateLimiter?, clientIP: String?)
+```
+
+`handleAuth` algorithm:
+
+1. If `token` non-empty: existing verify; on success set authenticated; response **without requiring** `mac_id`/`token` echo (keep current fields; **also include `mac_id` + `token` when ok** so web can unify handling).
+2. Else if `code` non-empty:
+   - If `rateLimiter?.allow(ip:) == false` → encode error `-32029`.
+   - Else if `pairingCode?.verify(code) != true` → `recordFailure`; return `ok: false`.
+   - Else → `recordSuccess`; authenticate; return `ok: true, mac_id: expectedMacId, token: HostGatewayAuth.expectedToken(...)!, vt_*`.
+3. Else → `ok: false`.
+
+- [ ] **Step 1: Write failing session tests**
+
+```swift
+func testAuthWithCodeSucceedsAndReturnsToken() {
+    let (s, _, _) = sessionWithCode("48291736")
+    let frames = s.handle(#"{"id":"a","method":"auth","params":{"code":"4829 1736","vt_binary":true,"vt_deflate":true}}"#)
+    let text = frames.compactMap { if case .text(let t) = $0 { return t } else { return nil } }.joined()
+    XCTAssertTrue(text.contains(#""ok":true"#) || text.contains(#""ok": true"#))
+    XCTAssertTrue(text.contains("mac_id"))
+    XCTAssertTrue(text.contains("token"))
+    // follow-up business call must work
+    let snap = s.handle(#"{"id":"2","method":"session.snapshot","params":{}}"#)
+    XCTAssertFalse(snap.map(asText).joined().contains("unauthorized"))
+}
+
+func testAuthWithWrongCodeFails() { /* ok false; snapshot unauthorized */ }
+
+func testAuthCodeRateLimited() {
+    // inject limiter with maxFailures: 2, record 2 failures, third returns -32029
+}
+```
+
+Helper `sessionWithCode` must construct `LivePairingCode` / fake verifier.
+
+- [ ] **Step 2: Run — expect FAIL**
+
+- [ ] **Step 3: Implement session + server wiring**
+
+Extract client IP in `HostGatewayServer.accept`:
+
+```swift
+let ip: String
+if case .hostPort(let host, _) = connection.endpoint {
+    ip = "\(host)"
+} else {
+    ip = "unknown"
+}
+```
+
+Pass `pairingCode` and `rateLimiter` from `TabCoordinator.setupHostGateway`:
+
+```swift
+var store = PairingCodeStore(code: hgConfig.pairCode)
+_ = store.ensureCode()
+if store.code != hgConfig.pairCode {
+    config.hostGateway?.pairCode = store.code
+    // save config the same way mintPairingContext / applyChanges does
+}
+let live = LivePairingCode(store: store)
+live.onChange = { [weak self] updated in
+    self?.config.hostGateway?.pairCode = updated.code
+    self?.saveConfigIfNeeded() // use existing persist path
+}
+```
+
+Keep a strong reference on `TabCoordinator` (`pairingCodeLive`) so Settings refresh can call it.
+
+- [ ] **Step 4: Run session + auth tests — expect PASS**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug \
+  -skipPackagePluginValidation -skipMacroValidation \
+  -only-testing:seahelmTests/HostGatewaySessionTests \
+  -only-testing:seahelmTests/HostGatewayAuthTests test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Core/HostGatewaySession.swift Sources/Core/HostGatewayServer.swift \
+  Sources/Core/LivePairingCode.swift Sources/App/TabCoordinator.swift \
+  Tests/HostGatewaySessionTests.swift
+git commit -m "$(cat <<'EOF'
+feat: authenticate Host Gateway clients with an 8-digit code
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Settings UI — code pane + revoke
+
+**Files:**
+- Rewrite: `Sources/UI/Settings/PairingWindowController.swift` (`PairingPaneView`)
+- Modify: `Sources/UI/Settings/SettingsViewController.swift` — `buildPairingGroups`, Host Gateway subtitle copy, refresh/revoke actions
+- Modify: `Sources/App/MainWindowController.swift` — menu “Pair remote client” if it still opens QR window; either show new pane or open Settings Remote tab
+
+**Interfaces:**
+- Consumes: `LivePairingCode.current()` / `refresh()`, `HostGatewayConfig.resolvedPageURL`
+- Produces: UI showing code + access URL; no QR; no `seahelm://pair`
+
+- [ ] **Step 1: Replace `PairingPaneView`**
+
+New API:
+
+```swift
+final class PairingPaneView: NSView {
+    var accessURL: String { didSet { urlField.stringValue = accessURL } }
+    private let codeLabel = NSTextField(labelWithString: "")
+    private let urlField = NSTextField(labelWithString: "")
+    var onRefresh: (() -> String)?
+    var onRevokeAll: (() -> Void)?
+
+    func setCode(_ code: String) {
+        // display as "XXXX XXXX"
+        let n = PairingCodeStore.normalize(code)
+        guard n.count == 8 else { codeLabel.stringValue = n; return }
+        let i = n.index(n.startIndex, offsetBy: 4)
+        codeLabel.stringValue = "\(n[..<i]) \(n[i...])"
+    }
+}
+```
+
+Buttons: Copy code, Refresh code, Revoke all remotes.  
+Caption: “Open the access URL in a browser, then enter this code.”  
+Remove QR image, long link field, `brokerURL`, `rootSecret`, `pairURI`.
+
+- [ ] **Step 2: Wire Settings**
+
+In `buildPairingGroups`:
+- Build pane with `accessURL = (config.hostGateway ?? .init()).resolvedPageURL`
+- `setCode` from live store / config.pairCode
+- `onRefresh` → live.refresh(); persist; update label
+- `onRevokeAll` → generate new `mqtt.root_secret`, persist, restart Host Gateway (existing setup/teardown), refresh code, drop sessions
+
+Update Host Gateway **Public URL** subtitle: remove SubtleCrypto / HTTPS-only warning; say it is the address shown under Browser access / used for `resolvedPageURL`, not embedded in a pair secret.
+
+Remove `refreshPairingLink` QR updates; replace with `refreshPairingCodeDisplay()` updating access URL + code.
+
+- [ ] **Step 3: Manual build**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelm -configuration Debug \
+  -skipPackagePluginValidation -skipMacroValidation build
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/UI/Settings/PairingWindowController.swift \
+  Sources/UI/Settings/SettingsViewController.swift \
+  Sources/App/MainWindowController.swift
+git commit -m "$(cat <<'EOF'
+feat: show 8-digit pairing code in Settings instead of QR
+
+EOF
+)"
+```
+
+---
+
+### Task 5: Web gate — code input, no E2EE
+
+**Files:**
+- Modify: `clients/seahelm-web/index.html` — `renderGate`, `connectGateway`, creds storage, remove `applyPair` for Gateway path
+- Do **not** remove `e2ee.js` file (MQTT `?mqtt=1` may still need it); stop requiring it for Gateway
+
+**Interfaces:**
+- Consumes: `auth` response fields `mac_id`, `token`
+- Produces: localStorage `{ m, t }` only
+
+- [ ] **Step 1: Replace gate UI**
+
+Unpaired gate:
+
+```html
+<div class="gate-card">
+  <div class="gate-title">配对这台 Mac</div>
+  <div class="gate-hint">在 Seahelm 设置里查看 8 位配对码，输入后连接</div>
+  <input class="gate-input" id="gateCode" inputmode="numeric" autocomplete="one-time-code"
+         maxlength="9" placeholder="1234 5678" />
+  <button class="gate-primary" id="gatePair">配对并连接</button>
+  <div class="gate-error" id="gateError" hidden></div>
+</div>
+```
+
+`go()`:
+1. Normalize code (digits only); if length !== 8 → fail.
+2. Set `S.pendingCode = code` (temporary; cleared after auth).
+3. `connect()` → Gateway.
+
+- [ ] **Step 2: Change `connectGateway`**
+
+```javascript
+function connectGateway(_ignoredUrl){
+  const scheme = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const url = `${scheme}//${location.host}/ws`;
+  // ...
+  ws.onopen = () => {
+    const params = { vt_binary: true, vt_deflate: typeof DecompressionStream === 'function' };
+    if (S.pendingCode) { params.code = S.pendingCode; }
+    else if (S.authPass) { params.mac_id = S.mac; params.token = S.authPass; }
+    else { setStatus(false, '需要配对码'); ws.close(); return; }
+    gwSend('auth', params, (r, err) => {
+      if (err && err.code === -32029) { /* rate limited */ ...; return; }
+      if (err || !r || r.ok === false) { /* unauthorized */ clear pending; ...; return; }
+      S.mac = r.mac_id || S.mac;
+      S.authPass = r.token || S.authPass;
+      S.pendingCode = null;
+      localStorage.setItem(CREDS_KEY, JSON.stringify({ m: S.mac, t: S.authPass }));
+      // negotiate vt flags as today
+      ...
+    });
+  };
+}
+```
+
+Remove alert “需要先配对(seahelm://pair…)”.  
+`useGatewayTransport`: when on Gateway-served page (path `/` with Host Gateway), default Gateway — already true when URL ends with `/ws` after connect; ensure Connect without broker field still uses Gateway when `location.port` is gateway or `?transport=gateway` / served from Host Gateway (same as today’s `/ws` heuristic after setting broker to same-origin `/ws` in `edgeBroker`-like helper):
+
+```javascript
+function gatewayWsURL(){
+  const scheme = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${scheme}//${location.host}/ws`;
+}
+// On load, if not ?mqtt=1, set broker field to gatewayWsURL() so Connect uses Gateway.
+```
+
+- [ ] **Step 3: Remove Gateway `applyPair` path**
+
+Delete or gate behind `?mqtt=1` only: paste long link flow.  
+`loadCreds` must tolerate missing `b`.
+
+- [ ] **Step 4: Manual check**
+
+With Gateway enabled: open `http://127.0.0.1:2783/`, enter code, confirm log shows `(vt format) binary+deflate` and First Mate fills. Reload page — auto-connect without code.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/seahelm-web/index.html
+git commit -m "$(cat <<'EOF'
+feat: pair seahelm-web with an 8-digit code over plain HTTP
+
+EOF
+)"
+```
+
+---
+
+### Task 6: Spec status + smoke checklist
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-28-short-pair-code-design.md` — Status → Implemented (or “Ready for QA”)
+- Optional note in `clients/seahelm-web/README.md` one-liner: production pairing is 8-digit code on Host Gateway page
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug \
+  -skipPackagePluginValidation -skipMacroValidation \
+  -only-testing:seahelmTests/PairingCodeStoreTests \
+  -only-testing:seahelmTests/PairRateLimiterTests \
+  -only-testing:seahelmTests/HostGatewaySessionTests \
+  -only-testing:seahelmTests/HostGatewayConfigTests test
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Update spec status line**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-28-short-pair-code-design.md clients/seahelm-web/README.md
+git commit -m "$(cat <<'EOF'
+docs: mark short pair-code design implemented
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage (self-review)
+
+| Spec requirement | Task |
+|---|---|
+| 8-digit code, refresh until manual | Task 1 + 4 |
+| Remember token in localStorage | Task 5 |
+| Full replace QR/long link in Settings + web | Task 4 + 5 |
+| `auth { code }` → `mac_id` + `token` | Task 3 |
+| Same-origin WS, HTTP works | Task 5 |
+| Rate limit 5/60s/IP | Task 2 + 3 |
+| Refresh code ≠ revoke tokens | Task 1 + 4 (revoke is separate) |
+| Revoke all = rotate root | Task 4 |
+| Unit tests store/limiter/session | Tasks 1–3 |
+| Manual HTTP Tailscale | Task 5 Step 4 / Task 6 |
+
+No TBD placeholders. Types: `PairingCodeStore`, `PairRateLimiter`, `LivePairingCode`, `HostGatewayConfig.pairCode` used consistently.

--- a/docs/superpowers/specs/2026-08-28-short-pair-code-design.md
+++ b/docs/superpowers/specs/2026-08-28-short-pair-code-design.md
@@ -1,0 +1,215 @@
+# Short numeric pairing code for Host Gateway
+
+> **Status:** Draft for review (2026-08-28 brainstorm)  
+> **Goal:** Pair a browser to a Mac Host Gateway by entering an 8-digit code on the page you already opened — works on plain HTTP and HTTPS, with no URL or secret in the pairing payload.  
+> **Replaces for web:** `seahelm://pair?b=…&m=…&k=…` QR / long-link pairing in Settings and the web gate UI.
+
+---
+
+## 0. Decisions locked in brainstorm
+
+| Question | Choice |
+|---|---|
+| Code shape | **8-digit numeric** (Settings shows grouped, e.g. `4829 1736`) |
+| Code lifetime | **Until manual refresh** on the Mac (no auto TTL) |
+| After success | **Remember** — browser stores long-lived `token` in `localStorage`, auto-reconnect |
+| Legacy pair URI | **Full replace** in Settings / web — no QR, no long link (Watch/MQTT pairing deferred) |
+| Approach | **Short code + server-issued token** — browser never runs HKDF / WebCrypto for Gateway auth |
+
+---
+
+## 1. User flows
+
+### 1.1 Mac — Settings → Remote pairing
+
+- Large **8-digit code** (monospaced, copy button).
+- **Refresh code** — new random code; previous code rejected immediately.
+- **Revoke all remotes** — rotate `mqtt.root_secret`; invalidates every stored browser token and forces a new code.
+- Helper text: *Open the access URL shown below in a browser, then enter this code.*  
+  Access URL comes from `HostGatewayConfig.resolvedPageURL` (e.g. `http://100.103.37.3:2783/`, `http://127.0.0.1:2783/`).
+- **Removed:** QR, `seahelm://pair` long link, copy-link for pair URI.
+
+### 1.2 Browser — any reachable Gateway origin
+
+1. User navigates to the Gateway page (`http` or `https`).
+2. Gate shows 8-digit input + **Pair & connect**.
+3. Client opens **same-origin** WebSocket: `ws(s)://<host>/ws` (path from current page, not from any pairing payload).
+4. `auth` with `{ code, vt_binary, vt_deflate }`.
+5. On success, store `{ m: mac_id, t: token }` in `localStorage`; render fleet.
+6. Next visit: if creds present, `auth` with `{ mac_id, token, vt_binary, vt_deflate }` only.
+
+**Plain HTTP works** because the Mac derives `token` server-side; the browser never touches `crypto.subtle` or `e2ee.js` on the Gateway path.
+
+---
+
+## 2. Wire protocol
+
+Single WSS connection; extend existing `auth` method.
+
+### 2.1 First-time pairing (code)
+
+**Request**
+
+```json
+{
+  "id": "1",
+  "method": "auth",
+  "params": {
+    "code": "48291736",
+    "vt_binary": true,
+    "vt_deflate": true
+  }
+}
+```
+
+**Success**
+
+```json
+{
+  "id": "1",
+  "result": {
+    "ok": true,
+    "mac_id": "m3e530892",
+    "token": "<64-char hex, HostGatewayAuth token>",
+    "vt_binary": true,
+    "vt_deflate": true
+  }
+}
+```
+
+**Failure**
+
+```json
+{
+  "id": "1",
+  "error": { "code": -32001, "message": "unauthorized" }
+}
+```
+
+Or rate limit:
+
+```json
+{
+  "id": "1",
+  "error": { "code": -32029, "message": "rate_limited" }
+}
+```
+
+### 2.2 Return visit (stored token)
+
+Unchanged from today:
+
+```json
+{
+  "id": "2",
+  "method": "auth",
+  "params": {
+    "mac_id": "m3e530892",
+    "token": "<hex>",
+    "vt_binary": true,
+    "vt_deflate": true
+  }
+}
+```
+
+### 2.3 Precedence
+
+- If `token` + `mac_id` present and valid → authenticate (skip code).
+- Else if `code` present → verify against current `PairingCodeStore` code.
+- Else → `unauthorized`.
+
+Negotiation flags (`vt_binary`, `vt_deflate`) behave as today.
+
+---
+
+## 3. Mac components
+
+### 3.1 `PairingCodeStore`
+
+- Field: `host_gateway.pair_code` (string, exactly 8 digits, zero-padded).
+- On first launch / missing code: generate and persist.
+- `refresh()` → new `SecRandom`-backed code, persist, return display string.
+- `verify(_ code: String) -> Bool` — normalize input (strip spaces), constant-time compare against stored code.
+
+### 3.2 `PairRateLimiter`
+
+- Tracks failed **code** attempts per client IP (from `HostGatewayServer` front listener).
+- Policy: **5 failures / 60 s / IP** → reject with `-32029` for 60 s.
+- Successful code auth resets or does not increment (implementation choice; must not lock out legitimate user after one typo if under cap).
+- Token-based auth failures use existing path; optional separate counter (same IP cap).
+
+### 3.3 `HostGatewaySession.handleAuth`
+
+Extend to branch:
+
+1. Token path — existing `HostGatewayAuth.verify`.
+2. Code path — `PairingCodeStore.verify` + `PairRateLimiter` allow/check + on success issue same `token` as token path would expect.
+
+### 3.4 Settings UI — `PairingPaneView`
+
+Replace QR/link pane with:
+
+- Code label (large type)
+- Copy code
+- Refresh code (calls store + updates label)
+- Access URL label (read-only, copy)
+- Revoke all remotes (existing root rotation if present; wire if missing)
+
+Remove `brokerURL` property and QR generation.
+
+---
+
+## 4. Web client (`clients/seahelm-web/index.html`)
+
+- Gate: 8-digit numeric input; remove textarea for `seahelm://pair`.
+- Remove `applyPair`, `E2EE` dependency for Gateway connect path.
+- `connectGateway()`: always `new WebSocket(\`${wsScheme}//${location.host}/ws\`)`.
+- `localStorage` key unchanged in spirit; shape `{ m, t }` without `b`.
+- Disconnect / unpair clears stored creds.
+- Error copy for wrong code vs rate limit vs offline.
+
+MQTT debug mode (`?mqtt=1`) unchanged; may still use `e2ee.js` for broker creds.
+
+---
+
+## 5. Security
+
+| Topic | Decision |
+|---|---|
+| Code entropy | 10⁸ values; **rate limiting is mandatory** because there is no TTL |
+| Refresh code | Invalidates old code only; **does not** revoke existing browser tokens |
+| Revoke all | Rotates `root_secret` → all tokens dead, new code required for new browsers |
+| Attacker model | Must reach Gateway URL (Tailscale, LAN, or exposed port) **and** guess/brute code |
+| Token storage | Same as today — scoped hex in `localStorage`; not extractable goal, convenience default |
+
+---
+
+## 6. Scope & breaking changes
+
+| In scope | Out of scope (this spec) |
+|---|---|
+| Host Gateway web pairing | Watch short-code PAKE (deferred) |
+| Settings pairing pane rewrite | MQTT client pairing via 8-digit code |
+| Remove web long-link gate | `seahelm-stack` / EMQX pairing UX |
+| Unit tests for store, auth, limiter | E2EE envelope for Gateway (still TLS/code/token) |
+
+**Breaking:** Settings no longer shows `seahelm://pair` or QR. Users with bookmarked long links must use code flow. Document in release notes.
+
+---
+
+## 7. Testing
+
+- `PairingCodeStoreTests` — generate, refresh invalidates old, verify normalizes spaces.
+- `HostGatewaySessionTests` — code auth ok, bad code, refreshed code rejects old.
+- `PairRateLimiterTests` — 6th failure in window → rate_limited.
+- Manual — `http://<tailscale-ip>:2783/` pair without HTTPS; reconnect after reload.
+
+---
+
+## 8. Success criteria
+
+1. Plain `http://100.x.x.x:2783/` pairs with 8-digit code, no console crypto errors.
+2. Pair payload contains **no URL** and **no root secret**.
+3. Reload page auto-connects with stored token.
+4. Refresh code on Mac blocks new pairings with old code; existing session stays up.
+5. Revoke all remotes forces re-pair on every browser.

--- a/docs/superpowers/specs/2026-08-28-short-pair-code-design.md
+++ b/docs/superpowers/specs/2026-08-28-short-pair-code-design.md
@@ -1,6 +1,6 @@
 # Short numeric pairing code for Host Gateway
 
-> **Status:** Draft for review (2026-08-28 brainstorm)  
+> **Status:** Implemented (2026-08-29) — ready for QA  
 > **Goal:** Pair a browser to a Mac Host Gateway by entering an 8-digit code on the page you already opened — works on plain HTTP and HTTPS, with no URL or secret in the pairing payload.  
 > **Replaces for web:** `seahelm://pair?b=…&m=…&k=…` QR / long-link pairing in Settings and the web gate UI.
 

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		12B626905E1B75F6419CD452 /* ChromeLayoutMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4890F1362CCDACF15E685662 /* ChromeLayoutMetricsTests.swift */; };
 		13005279CEAF281DCBE08040 /* NotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D0B8A444B60E3445EC7977 /* NotificationManagerTests.swift */; };
 		132C344775FE1F50E1CD4C2B /* OpenedSurfaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBEC0B8D9CEC4A93075C660 /* OpenedSurfaceView.swift */; };
+		13CBA3871CB3BCEC3F77646F /* PairingCodeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A6FB3297AF50CA9C3A298D /* PairingCodeStore.swift */; };
 		15883F7CBE3B47E89DF0637E /* NormalizedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB9C63D8B4C22ACE7671274 /* NormalizedEvent.swift */; };
 		161353FA0DCF4D6A3505490D /* GmailOutboundMail.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99782104F7A320C332326AC /* GmailOutboundMail.swift */; };
 		16F8BAF43220432D8AEC04BD /* Aptabase in Frameworks */ = {isa = PBXBuildFile; productRef = 7EA0376D0607F1CA3B3D97ED /* Aptabase */; };
@@ -187,6 +188,7 @@
 		6EC6FB1CFEB5BB2802C4376B /* IMessageRuleCoalescer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B383B7D494355714192C928 /* IMessageRuleCoalescer.swift */; };
 		6EF47CD1C02411BA3C719E90 /* SettingsChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD8616FF9AAEF5CCCA0A710C /* SettingsChrome.swift */; };
 		6F46B38545D8EA067171AF5B /* EditorTheme+Seahelm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A09155A1FFCC67267E9F246 /* EditorTheme+Seahelm.swift */; };
+		707F6BEF7FED22391823BAAD /* PairingCodeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DCFDDC4C498DF9532ABDBE4 /* PairingCodeStoreTests.swift */; };
 		708FA82605788117E6142639 /* NotificationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B96BFA805FFD64725FFB924 /* NotificationHistory.swift */; };
 		709880C8E3C9BA504468A7E6 /* OnboardingKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4BADCEEC41DBC2915014A1B /* OnboardingKit.swift */; };
 		71206C48591B67FF56E51E8E /* HostGatewaySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D9E5FDD907FFB3D57373A8A /* HostGatewaySessionTests.swift */; };
@@ -505,6 +507,7 @@
 		148C3573E73EB0680BE0D550 /* HostGatewayPairingURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayPairingURLTests.swift; sourceTree = "<group>"; };
 		14DEB2B3541ED551726C6C96 /* ProcessRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessRunnerTests.swift; sourceTree = "<group>"; };
 		159B10196D13B333CFC76E1D /* SuggestGuidanceWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestGuidanceWriter.swift; sourceTree = "<group>"; };
+		15A6FB3297AF50CA9C3A298D /* PairingCodeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeStore.swift; sourceTree = "<group>"; };
 		16AC3A2325B391B90BFD6175 /* HostGatewayVTFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayVTFrameTests.swift; sourceTree = "<group>"; };
 		16C8F047AD222C44B3E5DD1A /* HostGatewayAuthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayAuthTests.swift; sourceTree = "<group>"; };
 		16F923AC4CC69AE72ABE17C5 /* ProcessProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessProbe.swift; sourceTree = "<group>"; };
@@ -515,6 +518,7 @@
 		1C0F7D7F30A3F031DC191AFF /* StationHealthCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationHealthCheckTests.swift; sourceTree = "<group>"; };
 		1D9E5FDD907FFB3D57373A8A /* HostGatewaySessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewaySessionTests.swift; sourceTree = "<group>"; };
 		1DB77CC892E8D4F3F9285B90 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
+		1DCFDDC4C498DF9532ABDBE4 /* PairingCodeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeStoreTests.swift; sourceTree = "<group>"; };
 		1EA61698D1160080DD9E900B /* HostGatewayPairing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayPairing.swift; sourceTree = "<group>"; };
 		201D21B0CA40F70C2EDF3073 /* CursorSessionTitleLookupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CursorSessionTitleLookupTests.swift; sourceTree = "<group>"; };
 		20388FC5D9797A091BADCF95 /* MqttCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MqttCryptoTests.swift; sourceTree = "<group>"; };
@@ -1048,6 +1052,7 @@
 				4F6248F858A60E04AAC76E22 /* OnboardingAgentDetector.swift */,
 				215354472FB165AA55E27D9C /* OnboardingHookInstaller.swift */,
 				E0A70D4315E684DAEAFF18A8 /* OpenCodePluginInstaller.swift */,
+				15A6FB3297AF50CA9C3A298D /* PairingCodeStore.swift */,
 				A07E3B53FF30705F3C18D603 /* PaneHistoryBuffer.swift */,
 				7C3D3984EB87D6ED65A3312A /* PaneInfo.swift */,
 				280B84339A7AE83C77426D07 /* PaneReducer.swift */,
@@ -1434,6 +1439,7 @@
 				826B5E1EB796AA82415B329F /* OSC133ParserTests.swift */,
 				FF833BDB434AB8F30EE6D6AF /* OSCProgressTests.swift */,
 				376AB999E829F6B1298D7B05 /* OverviewFocusModelTests.swift */,
+				1DCFDDC4C498DF9532ABDBE4 /* PairingCodeStoreTests.swift */,
 				8E895D84F1DB6343D08BAB30 /* PaneInfoDisplayStatusTests.swift */,
 				529E3EDAF8D57902FD901649 /* PanelCoordinatorTests.swift */,
 				73FDA109B06DD6B1F279D87A /* PaneReducerTests.swift */,
@@ -1982,6 +1988,7 @@
 				C98FA9225C36EA1C59E1A67E /* OpenCodePluginInstallerTests.swift in Sources */,
 				E7AB85089D6CD9A1AF14B3CF /* OverviewFocusModelTests.swift in Sources */,
 				D4ABC34B40C85BDA5145EAAC /* PRURLParsingTests.swift in Sources */,
+				707F6BEF7FED22391823BAAD /* PairingCodeStoreTests.swift in Sources */,
 				A7FBE343E9691CDA24404E84 /* PaneInfoDisplayStatusTests.swift in Sources */,
 				EA9AE25E1B7C668B9DEE38D4 /* PaneReducerTests.swift in Sources */,
 				371A789DDD991B083F733DB8 /* PaneStatusTests.swift in Sources */,
@@ -2244,6 +2251,7 @@
 				36A3C27B63B14CBA52BC3A4D /* OverviewFocusModel.swift in Sources */,
 				F822A1F30137CB7940F82296 /* PRListView.swift in Sources */,
 				DF7E8C735153B1DD42FFDC8C /* PRReviewCoordinator.swift in Sources */,
+				13CBA3871CB3BCEC3F77646F /* PairingCodeStore.swift in Sources */,
 				55C5B0B646137831DCA9D1E9 /* PairingWindowController.swift in Sources */,
 				A8E20664CBC80AC29F9ED31F /* PaneHistoryBuffer.swift in Sources */,
 				73AD1B9CB4727CC7D40DB028 /* PaneInfo.swift in Sources */,

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		9C35BEC65A084B6F21FF11DB /* TerminalHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 472ACEFBD0F23747FC60EB0D /* TerminalHeaderViewTests.swift */; };
 		9C55DE7AD6C3DCE23F18B842 /* PendingOrdersQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD6CAE97113B8F2314759D70 /* PendingOrdersQueue.swift */; };
 		9CB20225E63262D49B89EFFB /* WorktreeSnapshotter.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6EF9DDF33CD3FBC2155391 /* WorktreeSnapshotter.swift */; };
+		9E5E4D337C396152FFF5EFEC /* LivePairingCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECD4814056E1D419262B278 /* LivePairingCode.swift */; };
 		9E6B89CACF0F49A0029E3BD1 /* GitDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = B032E95F9035447EBF27883B /* GitDiff.swift */; };
 		9E70B1DBD63DBC4873DC38EB /* QuickSwitcherViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DA513259B19E55E2FB46C9F /* QuickSwitcherViewController.swift */; };
 		9E7373708FBA84B5A512E671 /* IMessageRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B97EA2AD344FB22E7B40CA /* IMessageRule.swift */; };
@@ -586,6 +587,7 @@
 		3CD049D511655E149E38EA48 /* PairingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingWindowController.swift; sourceTree = "<group>"; };
 		3D002748AEBEA4297919DC48 /* FocusPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusPanelView.swift; sourceTree = "<group>"; };
 		3D90518E8BFCA59E2D344513 /* TerminalEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalEnvironment.swift; sourceTree = "<group>"; };
+		3ECD4814056E1D419262B278 /* LivePairingCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePairingCode.swift; sourceTree = "<group>"; };
 		3F4CB69B94BFFAB30A5D430C /* ChromeHeaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeHeaderDelegate.swift; sourceTree = "<group>"; };
 		3F67CBC84404085C3483C910 /* TestViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewHelpers.swift; sourceTree = "<group>"; };
 		3FA6E78D00BFAF395356B892 /* IMessageRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMessageRuleTests.swift; sourceTree = "<group>"; };
@@ -1047,6 +1049,7 @@
 				C8F1B159E50F3F6CDA6466BE /* IntegrationRunner.swift */,
 				811DF1463E1F5D6EFC56F68A /* IntegrationStatusStore.swift */,
 				AAC3559992F8B4562068B449 /* IntegrationWorktreeStore.swift */,
+				3ECD4814056E1D419262B278 /* LivePairingCode.swift */,
 				B4A702B5B856603AEC1DAAFA /* MailBody.swift */,
 				366D03974E15A858BE536AE1 /* MailHTML.swift */,
 				93F4FC4D61D58DD56DB8E9FE /* MailPaneRouter.swift */,
@@ -2224,6 +2227,7 @@
 				4344E9AEB5D00D092883F299 /* KeyboardMode.swift in Sources */,
 				8080334C2591CD6DAEE35749 /* KeyboardSubstateController.swift in Sources */,
 				D5E1195B106F29ACCB59D516 /* LayoutNode.swift in Sources */,
+				9E5E4D337C396152FFF5EFEC /* LivePairingCode.swift in Sources */,
 				3DB03858C29C479B5A8E7885 /* MailBody.swift in Sources */,
 				5B7C12A03AE9A5017FA79E62 /* MailHTML.swift in Sources */,
 				010013ADD3241CB34AD1A70C /* MailPaneRouter.swift in Sources */,

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		C3E90FF67663F4290485E940 /* FileSystemProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF6E8352A4B0C1AE47D7B49A /* FileSystemProbe.swift */; };
 		C444DD64D874C76934185DD6 /* WorktreeStatusAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517E6B353B84EA6AE224E0C1 /* WorktreeStatusAggregatorTests.swift */; };
 		C44DA54E0C66DC612DB80D80 /* StatusBarPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FF4E0C39BAB48A48179246 /* StatusBarPage.swift */; };
+		C48C6B37BDE6D3B07283626C /* PairRateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C798752B1147F8BA20E3C29 /* PairRateLimiter.swift */; };
 		C4F0F2B38AE80B7645DCA217 /* AddWorktreePopoverController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599AEE9969A8C01373011303 /* AddWorktreePopoverController.swift */; };
 		C52C3A952FCD9CA7B5DCD013 /* ProcessCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5468EE88AD5D27E7AC0F95AA /* ProcessCaptureTests.swift */; };
 		C603CC2D9529DAB53223D97E /* OnboardingWelcomeStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E08BEAA55278BCB719905234 /* OnboardingWelcomeStepView.swift */; };
@@ -454,6 +455,7 @@
 		FA7FE7F8722B6916762E68E3 /* TestViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F67CBC84404085C3483C910 /* TestViewHelpers.swift */; };
 		FAA6371DC6AF759AC571414B /* StatusPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EF78A5043DF5162290DDE4 /* StatusPublisher.swift */; };
 		FAF2ABF4372E190D0A42EE2A /* HostGatewayConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8548571F540C914ACA11E /* HostGatewayConfigTests.swift */; };
+		FB0F579F23F5FBCAEE4FB294 /* PairRateLimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9D36C4513804B095CBABA5 /* PairRateLimiterTests.swift */; };
 		FB6A28074D9ADC1B5DB97F53 /* StationHealthCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0F7D7F30A3F031DC191AFF /* StationHealthCheckTests.swift */; };
 		FC3680C2E8486D8066CCEE37 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB77CC892E8D4F3F9285B90 /* OnboardingViewController.swift */; };
 		FC6620AFE070216CBEDBEB30 /* UsageSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22314B62F8F244CAE44DE94D /* UsageSummaryFormatterTests.swift */; };
@@ -513,6 +515,7 @@
 		16F923AC4CC69AE72ABE17C5 /* ProcessProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessProbe.swift; sourceTree = "<group>"; };
 		176DD9C40844C7ECA03950E6 /* StatusBarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarViewTests.swift; sourceTree = "<group>"; };
 		17703086C94D05EDA9B85B21 /* GmailMailConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GmailMailConfigTests.swift; sourceTree = "<group>"; };
+		1A9D36C4513804B095CBABA5 /* PairRateLimiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairRateLimiterTests.swift; sourceTree = "<group>"; };
 		1AB9B880E783FE26BA01DA38 /* GatewayStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayStateTests.swift; sourceTree = "<group>"; };
 		1B08FEEAC5D86CEE353749EA /* FirstMateConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateConfigTests.swift; sourceTree = "<group>"; };
 		1C0F7D7F30A3F031DC191AFF /* StationHealthCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationHealthCheckTests.swift; sourceTree = "<group>"; };
@@ -609,6 +612,7 @@
 		49AB93A5F8C2A6D49CA1AA79 /* UpdateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateCoordinator.swift; sourceTree = "<group>"; };
 		4AC1BAD4A2F2FD577B157E07 /* ControlRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlRouterTests.swift; sourceTree = "<group>"; };
 		4C5477C17977F4C27B7B01CB /* PiExtensionInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiExtensionInstallerTests.swift; sourceTree = "<group>"; };
+		4C798752B1147F8BA20E3C29 /* PairRateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairRateLimiter.swift; sourceTree = "<group>"; };
 		4C97F6C22C29552377720F4D /* WorktreePathNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathNavigationTests.swift; sourceTree = "<group>"; };
 		4DA513259B19E55E2FB46C9F /* QuickSwitcherViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSwitcherViewController.swift; sourceTree = "<group>"; };
 		4E3492399099DDDAE527C6CA /* GitHubDiffAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubDiffAdapter.swift; sourceTree = "<group>"; };
@@ -1053,6 +1057,7 @@
 				215354472FB165AA55E27D9C /* OnboardingHookInstaller.swift */,
 				E0A70D4315E684DAEAFF18A8 /* OpenCodePluginInstaller.swift */,
 				15A6FB3297AF50CA9C3A298D /* PairingCodeStore.swift */,
+				4C798752B1147F8BA20E3C29 /* PairRateLimiter.swift */,
 				A07E3B53FF30705F3C18D603 /* PaneHistoryBuffer.swift */,
 				7C3D3984EB87D6ED65A3312A /* PaneInfo.swift */,
 				280B84339A7AE83C77426D07 /* PaneReducer.swift */,
@@ -1440,6 +1445,7 @@
 				FF833BDB434AB8F30EE6D6AF /* OSCProgressTests.swift */,
 				376AB999E829F6B1298D7B05 /* OverviewFocusModelTests.swift */,
 				1DCFDDC4C498DF9532ABDBE4 /* PairingCodeStoreTests.swift */,
+				1A9D36C4513804B095CBABA5 /* PairRateLimiterTests.swift */,
 				8E895D84F1DB6343D08BAB30 /* PaneInfoDisplayStatusTests.swift */,
 				529E3EDAF8D57902FD901649 /* PanelCoordinatorTests.swift */,
 				73FDA109B06DD6B1F279D87A /* PaneReducerTests.swift */,
@@ -1988,6 +1994,7 @@
 				C98FA9225C36EA1C59E1A67E /* OpenCodePluginInstallerTests.swift in Sources */,
 				E7AB85089D6CD9A1AF14B3CF /* OverviewFocusModelTests.swift in Sources */,
 				D4ABC34B40C85BDA5145EAAC /* PRURLParsingTests.swift in Sources */,
+				FB0F579F23F5FBCAEE4FB294 /* PairRateLimiterTests.swift in Sources */,
 				707F6BEF7FED22391823BAAD /* PairingCodeStoreTests.swift in Sources */,
 				A7FBE343E9691CDA24404E84 /* PaneInfoDisplayStatusTests.swift in Sources */,
 				EA9AE25E1B7C668B9DEE38D4 /* PaneReducerTests.swift in Sources */,
@@ -2251,6 +2258,7 @@
 				36A3C27B63B14CBA52BC3A4D /* OverviewFocusModel.swift in Sources */,
 				F822A1F30137CB7940F82296 /* PRListView.swift in Sources */,
 				DF7E8C735153B1DD42FFDC8C /* PRReviewCoordinator.swift in Sources */,
+				C48C6B37BDE6D3B07283626C /* PairRateLimiter.swift in Sources */,
 				13CBA3871CB3BCEC3F77646F /* PairingCodeStore.swift in Sources */,
 				55C5B0B646137831DCA9D1E9 /* PairingWindowController.swift in Sources */,
 				A8E20664CBC80AC29F9ED31F /* PaneHistoryBuffer.swift in Sources */,


### PR DESCRIPTION
## Summary
- Replace QR / `seahelm://pair` long-link pairing with an 8-digit code shown in Settings; browsers open the Gateway page and enter the code (works on plain HTTP and HTTPS).
- Host Gateway `auth` accepts `{ code }` (rate-limited) and returns a long-lived `{ mac_id, token }`; web stores credentials and reconnects without WebCrypto.
- Refresh code invalidates only the code; Revoke all remotes rotates `root_secret` and forces every browser to re-pair.

## Test plan
- [ ] Enable Host Gateway in Settings; confirm 8-digit code + access URL appear (no QR/long link)
- [ ] Open `http://127.0.0.1:<port>/` (or Tailscale IP); enter code → connect; confirm `(vt format) binary+deflate` and fleet list
- [ ] Reload page → auto-reconnect without re-entering code
- [ ] Refresh code on Mac → new browser pairing with old code fails; existing session stays up
- [ ] Revoke all remotes → stored browsers fail auth until re-pair
- [ ] Wrong code / rapid failures → unauthorized / rate_limited
- [ ] Unit: `PairingCodeStoreTests`, `PairRateLimiterTests`, `HostGatewaySessionTests`, `HostGatewayConfigTests`


Made with [Cursor](https://cursor.com)