### PR TITLE
perf: send the first keystroke of a burst without waiting

### DIFF
--- a/clients/seahelm-web/devbroker/input-coalescer-test.js
+++ b/clients/seahelm-web/devbroker/input-coalescer-test.js
@@ -1,0 +1,142 @@
+// input-coalescer-test.js — the keystroke path, on virtual time.
+//
+// Run:  node devbroker/input-coalescer-test.js
+//
+// No broker and no browser: the coalescer takes its clock and its timers as
+// arguments precisely so the latency it adds can be measured directly. That
+// matters because the Swift benchmark next door, testKeystrokeEchoRoundTripLatency,
+// drives HostGatewayServer straight — the browser is not in its loop, so the
+// delay this file measures was invisible to it. That is why an unconditional
+// 10ms wait on every burst survived a round of latency work.
+'use strict';
+
+const { createKeystrokeCoalescer } = require('../input-coalescer.js');
+
+let pass = 0, fail = 0;
+const check = (ok, name, extra = '') => {
+  if (ok) { pass++; console.log(`  ok   ${name}`); }
+  else { fail++; console.log(`  FAIL ${name} ${extra}`); }
+};
+
+/** A clock and timer queue we drive by hand. */
+function makeVirtualTime() {
+  let now = 1000;                 // not 0: catches "measured from the epoch" bugs
+  let seq = 0;
+  const timers = new Map();
+  return {
+    now: () => now,
+    setTimer(fn, ms) { const id = ++seq; timers.set(id, { at: now + ms, fn }); return id; },
+    clearTimer(id) { timers.delete(id); },
+    /** Advance, firing timers in due order. */
+    advance(ms) {
+      const target = now + ms;
+      for (;;) {
+        let next = null;
+        for (const [id, t] of timers) if (!next || t.at < next[1].at) next = [id, t];
+        if (!next || next[1].at > target) break;
+        now = next[1].at;
+        timers.delete(next[0]);
+        next[1].fn();
+      }
+      now = target;
+    },
+  };
+}
+
+function harness(windowMs = 10) {
+  const vt = makeVirtualTime();
+  const sends = [];
+  const c = createKeystrokeCoalescer({
+    windowMs,
+    send: (payload) => sends.push({ at: vt.now(), payload }),
+    now: vt.now,
+    setTimer: vt.setTimer,
+    clearTimer: vt.clearTimer,
+  });
+  return { vt, sends, c };
+}
+
+console.log('keystroke coalescer');
+
+// The whole point: a keystroke into an idle pane must not wait for a window
+// that has nothing to coalesce it with.
+{
+  const { vt, sends, c } = harness();
+  const t0 = vt.now();
+  c.push('a');
+  check(sends.length === 1, 'idle keystroke sends immediately');
+  check(sends[0] && sends[0].at - t0 === 0, 'with zero added latency',
+        sends[0] ? `(waited ${sends[0].at - t0}ms)` : '(never sent)');
+}
+
+// …including the very first of the session, which a lastSent of 0 would have
+// made wait out a window measured from the epoch.
+{
+  const { sends, c } = harness();
+  c.push('x');
+  check(sends.length === 1, 'the first keystroke of a session is idle too');
+}
+
+// A burst is what the window is for.
+{
+  const { vt, sends, c } = harness();
+  c.push('a');                       // leading edge, out at once
+  c.push('b'); c.push('c');          // inside the window
+  check(sends.length === 1, 'burst does not send per keystroke');
+  vt.advance(10);
+  check(sends.length === 2, 'burst flushes when the window closes');
+  check(sends[1] && sends[1].payload === 'bc', 'coalesced in order',
+        sends[1] ? `(got ${JSON.stringify(sends[1].payload)})` : '');
+}
+
+// Typing steadily must not degrade into one message per keystroke.
+{
+  const { vt, sends, c } = harness();
+  for (let i = 0; i < 30; i++) { c.push('k'); vt.advance(4); }   // ~250 wpm
+  check(sends.length < 30, 'sustained typing still coalesces', `(${sends.length} sends for 30 keys)`);
+  check(sends.length > 1, 'and still gets there', `(${sends.length})`);
+}
+
+// Going idle re-arms the fast path, or the win lasts one burst.
+{
+  const { vt, sends, c } = harness();
+  c.push('a'); vt.advance(50);
+  const before = vt.now();
+  c.push('b');
+  check(sends.length === 2 && sends[1].at === before, 'idle again → immediate again');
+}
+
+{
+  const { vt, sends, c } = harness();
+  c.push('a'); c.push('b');
+  c.cancel();
+  vt.advance(50);
+  check(sends.length === 1, 'cancel drops buffered input and its timer');
+  check(!c.hasPending, 'and reports nothing pending');
+}
+
+{
+  const { sends, c } = harness();
+  c.push('a'); c.push('b');
+  c.flushNow();
+  check(sends.length === 2 && sends[1].payload === 'b', 'flushNow sends without waiting');
+}
+
+// ── the measurement ───────────────────────────────────────────────────────
+// What the old policy cost, in the units a person feels.
+console.log('\nadded latency on the first keystroke of a burst');
+{
+  const windowMs = 10;
+  const { vt, sends, c } = harness(windowMs);
+  const t0 = vt.now();
+  c.push('a');
+  vt.advance(windowMs);
+  const leading = sends[0].at - t0;
+  console.log(`  leading-edge (now):  ${leading}ms`);
+  console.log(`  trailing-edge (was): ${windowMs}ms`);
+  console.log(`  saved per burst:     ${windowMs - leading}ms`);
+  check(leading === 0, 'the fix removes the whole window');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -392,6 +392,7 @@
 <script src="./xterm.js"></script>
 <script src="./xterm-addon-webgl.js"></script>
 <script src="./e2ee.js"></script>
+<script src="./input-coalescer.js"></script>
 <script>
 // ── state ─────────────────────────────────────────────────────────────────
 const GEOM_KEY = 'seahelm_pane_geometry';
@@ -413,6 +414,9 @@ function saveGeom(){
 //
 // Depth is not a speed knob: paint moves 4% between 1000 and 5000. This buys
 // memory on multi-pane mirrors and nothing else.
+// Matches the Mac's own flush window in spirit, not in number: this one only
+// applies to a burst, never to the keystroke that starts it.
+const VT_INPUT_WINDOW_MS = 10;
 const VT_SCROLLBACK_DEEP = 5000;
 const VT_SCROLLBACK_SHALLOW = 1000;
 const VT_SHALLOW_FROM_LEAVES = 3;
@@ -667,13 +671,15 @@ function gwSend(method, params, onReply){
 //   u8 version | u8 flags (bit0 = deflate-raw) | u8 kind (1 data, 2 snapshot)
 //   u8 keyLen  | key… | [snapshot only] u16 cols, u16 rows | payload
 const VT_FRAME_VERSION = 1;
+// Hoisted: parseVTFrame runs per keystroke and per screen update.
+const VT_KEY_DECODER = new TextDecoder();
 
 function parseVTFrame(buf){
   if (buf.length < 4 || buf[0] !== VT_FRAME_VERSION) return null;
   const flags = buf[1], kind = buf[2], keyLen = buf[3];
   let off = 4;
   if (buf.length < off + keyLen) return null;
-  const key = new TextDecoder().decode(buf.subarray(off, off + keyLen));
+  const key = VT_KEY_DECODER.decode(buf.subarray(off, off + keyLen));
   off += keyLen;
   let cols, rows;
   if (kind === 2){
@@ -699,6 +705,11 @@ async function inflateRaw(bytes){
 // corrupted — not slow, corrupted. Every frame for a pane is therefore threaded
 // through one promise chain, so decode can overlap but application cannot.
 const vtWriteChains = new Map();
+
+/// A pane that goes away takes its chain with it — the map is keyed by pane and
+/// nothing else ever removed an entry, so worktree churn grew it for the life of
+/// the page.
+function releaseVTChain(key){ vtWriteChains.delete(key); }
 
 function onGatewayBinaryFrame(buf){
   const f = parseVTFrame(buf);
@@ -1607,7 +1618,8 @@ function mountSinglePane(key){
   // Drop the previous terminal first — its attach client goes with it.
   for (const [k, entry] of S.vt.panes){
     if (isLinked()) sendCommand('pane.vt_close', { pane_session_key: k });
-    if (entry.flushT) clearTimeout(entry.flushT);
+    if (entry.keys) entry.keys.cancel();
+    releaseVTChain(k);
     try { entry.term.dispose(); } catch (e) {}
   }
   S.vt.panes.clear();
@@ -1646,7 +1658,8 @@ function renderPaneStrip(activeKey){
 function unmountPanes(){
   for (const [key, entry] of S.vt.panes){
     if (isLinked()) sendCommand('pane.vt_close', { pane_session_key: key });
-    if (entry.flushT) clearTimeout(entry.flushT);
+    if (entry.keys) entry.keys.cancel();
+    releaseVTChain(key);
     try { entry.term.dispose(); } catch (e) {}
   }
   S.vt.panes.clear();
@@ -1696,22 +1709,20 @@ function buildLayoutLeaf(node){
   });
   t.open(host);
   attachWebglRenderer(t);
-  const entry = { term:t, el, host, pending:'', flushT:null };
+  const entry = { term:t, el, host, keys:null };
+  entry.keys = SeahelmInput.createKeystrokeCoalescer({
+    windowMs: VT_INPUT_WINDOW_MS,
+    send: (buf) => {
+      if (!isLinked()) return;
+      sendCommand('pane.send_keys',
+        { pane_session_key: key, b64: bytesToB64(new TextEncoder().encode(buf)) });
+    },
+  });
   S.vt.panes.set(key, entry);
 
   // xterm only fires onData for the terminal that actually holds focus, so each
   // pane can own its own outbound path — no routing table, no focus bookkeeping.
-  t.onData((data) => {
-    entry.pending += data;
-    if (entry.flushT) return;
-    entry.flushT = setTimeout(() => {
-      entry.flushT = null;
-      const buf = entry.pending; entry.pending = '';
-      if (!buf || !isLinked()) return;
-      sendCommand('pane.send_keys',
-        { pane_session_key: key, b64: bytesToB64(new TextEncoder().encode(buf)) });
-    }, 10);
-  });
+  t.onData((data) => entry.keys.push(data));
   t.onScroll(() => { if (S.vt.focus === key) updateToBottom(); });
   el.addEventListener('mousedown', () => focusPane(key));
 

--- a/clients/seahelm-web/input-coalescer.js
+++ b/clients/seahelm-web/input-coalescer.js
@@ -1,0 +1,77 @@
+// Keystroke coalescing for the pane → Mac direction.
+//
+// The naive version arms a timer on the first keystroke and sends when it
+// fires, which makes every burst start with a full window of latency for no
+// gain: there was nothing to coalesce it with. The Mac already avoids that in
+// the other direction — ZmxVTAttachManager tracks time since its last flush so
+// an idle pane answers immediately — and this is the same policy pointing the
+// other way, which is the direction a person actually feels.
+//
+// Leading edge, then trailing: an idle pane sends at once; a second keystroke
+// inside the window is what starts coalescing, and it goes out when the window
+// closes.
+//
+// Pure, with time and timers injected, so the latency it produces can be
+// measured without a browser.
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.SeahelmInput = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  /**
+   * @param {object} o
+   * @param {number} o.windowMs      coalescing window
+   * @param {(payload:string)=>void} o.send
+   * @param {()=>number} [o.now]
+   * @param {(fn:Function, ms:number)=>any} [o.setTimer]
+   * @param {(handle:any)=>void} [o.clearTimer]
+   */
+  function createKeystrokeCoalescer(o) {
+    const windowMs = o.windowMs;
+    const send = o.send;
+    const now = o.now || (() => Date.now());
+    const setTimer = o.setTimer || ((fn, ms) => setTimeout(fn, ms));
+    const clearTimer = o.clearTimer || ((h) => clearTimeout(h));
+
+    let pending = '';
+    let timer = null;
+    // -Infinity, not 0: the very first keystroke of a session is idle by
+    // definition and must not wait out a window measured from the epoch.
+    let lastSentAt = -Infinity;
+
+    function flush() {
+      timer = null;
+      if (!pending) return;
+      const payload = pending;
+      pending = '';
+      lastSentAt = now();
+      send(payload);
+    }
+
+    return {
+      push(data) {
+        if (!data) return;
+        pending += data;
+        if (timer !== null) return;             // a flush is already scheduled
+        const since = now() - lastSentAt;
+        if (since >= windowMs) { flush(); return; }
+        timer = setTimer(flush, windowMs - since);
+      },
+      /** Send whatever is buffered right now (pane teardown, blur). */
+      flushNow() {
+        if (timer !== null) { clearTimer(timer); timer = null; }
+        flush();
+      },
+      /** Drop buffered input and any pending timer. */
+      cancel() {
+        if (timer !== null) { clearTimer(timer); timer = null; }
+        pending = '';
+      },
+      get hasPending() { return pending.length > 0 || timer !== null; },
+    };
+  }
+
+  return { createKeystrokeCoalescer };
+});


### PR DESCRIPTION
Reading the VT work in #58 and #70. The measurement discipline there is the good part — a real captured corpus, wire-amplification numbers, an echo-latency benchmark — and this is one thing that discipline could not reach, plus two smaller things found on the same path.

## The asymmetry

`ZmxVTAttachManager` already avoids paying a coalescing window it has nothing to fill:

> When this stream last emitted, so an idle pane can answer immediately instead of serving out a coalescing window nothing is filling.

The browser did not. `t.onData` armed a 10ms timer on the first keystroke and sent when it fired:

```js
entry.pending += data;
if (entry.flushT) return;
entry.flushT = setTimeout(() => { …send… }, 10);
```

So every burst began with a full window of latency bought against nothing — there was no second keystroke to coalesce with yet. And it is the one direction a person feels: keystroke echo.

**It survived a round of latency work because the benchmark could not see it.** `testKeystrokeEchoRoundTripLatency` drives `HostGatewayServer` directly; the browser is not in that loop. The benchmark's boundary was exactly where the remaining delay sat.

## What changed

The policy moves into `input-coalescer.js` with its clock and timers injected, so the latency it adds is measurable without a browser. Leading edge, then trailing: an idle pane sends at once; a second keystroke inside the window starts coalescing; sustained typing still batches.

`lastSentAt` starts at `-Infinity`, not `0` — otherwise the first keystroke of a session waits out a window measured from the epoch. There is a test for exactly that.

## The benchmark

`node devbroker/input-coalescer-test.js` — no broker, no browser, virtual time.

```
added latency on the first keystroke of a burst
  leading-edge (now):  0ms
  trailing-edge (was): 10ms
  saved per burst:     10ms
```

13 checks. Against the old trailing-edge policy **10 of them fail** and it exits non-zero — I put the old policy back and ran it, rather than assuming a passing test proves anything.

## Two more on the same path

**`vtWriteChains` only ever grew.** Keyed by pane, `get`/`set` and no `delete` anywhere; `unmountPanes` cleared `S.vt.panes` but not this. Worktree churn accumulated entries for the life of the page. Both teardown paths now release the chain alongside the terminal.

**`parseVTFrame` built a `TextDecoder` per frame**, on a path that runs per keystroke and per screen update. Hoisted to a module constant.

## Not changed, after checking

Two things I suspected and dropped once I looked:

- `inflateRaw` builds a Blob → stream → Response per frame, which is heavy for small payloads — but `HostGatewayVTFrame` only deflates above `minimumCompressedPayload` and only when it actually shrinks, so small frames never take that path.
- `buildLayoutLeaf` always constructs a fresh `Terminal`, which looked like leaked WebGL contexts — but `mountPanes` calls `unmountPanes()` first and that disposes each terminal and its addon.

1788 Swift tests pass; nothing on the Mac side changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
