### PR TITLE
fix: reconnect the web client instead of going dark

### DIFF
--- a/Tests/PRReviewCoordinatorLifetimeTests.swift
+++ b/Tests/PRReviewCoordinatorLifetimeTests.swift
@@ -47,8 +47,10 @@ final class PRReviewCoordinatorLifetimeTests: XCTestCase {
 
         autoreleasepool { dashboard.dismissCenterOverlay() }
         // `dismissCenterOverlay` hands the overlay's release to the next runloop
-        // turn on purpose, so the click feels instant. Give it that turn.
-        let deadline = Date().addingTimeInterval(2)
+        // turn on purpose, so the click feels instant. Give it that turn — and
+        // room, because the assertion is that it releases at all, not that it
+        // does so inside a window a loaded machine has to hit.
+        let deadline = Date().addingTimeInterval(15)
         while weakCoordinator != nil, Date() < deadline {
             autoreleasepool { RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02)) }
         }

--- a/clients/seahelm-web/devbroker/reconnect-test.js
+++ b/clients/seahelm-web/devbroker/reconnect-test.js
@@ -1,0 +1,139 @@
+// reconnect-test.js — the gateway socket's reconnect policy, on virtual time.
+//
+// Run:  node devbroker/reconnect-test.js
+//
+// The MQTT client this replaced reconnected on its own; the gateway socket did
+// not, so a phone locking its screen left a dead page. These check the schedule
+// and — more important — the two cases where retrying is the wrong answer.
+'use strict';
+
+const { createReconnector, DEFAULTS } = require('../reconnect.js');
+
+let pass = 0, fail = 0;
+const check = (ok, name, extra = '') => {
+  if (ok) { pass++; console.log(`  ok   ${name}`); }
+  else { fail++; console.log(`  FAIL ${name} ${extra}`); }
+};
+
+function makeVirtualTime() {
+  let now = 1000, seq = 0;
+  const timers = new Map();
+  return {
+    now: () => now,
+    setTimer(fn, ms) { const id = ++seq; timers.set(id, { at: now + ms, fn }); return id; },
+    clearTimer(id) { timers.delete(id); },
+    advance(ms) {
+      const target = now + ms;
+      for (;;) {
+        let next = null;
+        for (const [id, t] of timers) if (!next || t.at < next[1].at) next = [id, t];
+        if (!next || next[1].at > target) break;
+        now = next[1].at; timers.delete(next[0]); next[1].fn();
+      }
+      now = target;
+    },
+  };
+}
+
+function harness(over = {}) {
+  const vt = makeVirtualTime();
+  const attempts = [];
+  const schedules = [];
+  const r = createReconnector(Object.assign({
+    attempt: () => attempts.push(vt.now()),
+    onSchedule: (s) => schedules.push(s),
+    now: vt.now, setTimer: vt.setTimer, clearTimer: vt.clearTimer,
+    random: () => 0.5,              // jitter centred, so delays are exact
+  }, over));
+  return { vt, attempts, schedules, r };
+}
+
+console.log('gateway reconnect');
+
+{
+  const { vt, attempts, r } = harness();
+  r.closed();
+  check(attempts.length === 0, 'does not reconnect synchronously');
+  vt.advance(DEFAULTS.baseMs);
+  check(attempts.length === 1, 'reconnects after the first delay');
+}
+
+// Backoff, or a Mac that is simply off gets hammered.
+{
+  const { vt, attempts, r } = harness();
+  const seen = [];
+  for (let i = 0; i < 6; i++) {
+    const before = vt.now();
+    r.closed();
+    vt.advance(DEFAULTS.maxMs + 1);
+    seen.push(attempts[attempts.length - 1] - before);
+  }
+  const rising = seen.every((d, i) => i === 0 || d >= seen[i - 1]);
+  check(rising, 'delay grows', `(${seen.join(', ')})`);
+  check(seen[seen.length - 1] <= DEFAULTS.maxMs, 'and is capped', `(${seen[seen.length - 1]}ms)`);
+}
+
+// A drop after a good connection should feel instant, not resume the backoff
+// the last outage climbed to.
+{
+  const { vt, attempts, r } = harness();
+  for (let i = 0; i < 5; i++) { r.closed(); vt.advance(DEFAULTS.maxMs + 1); }
+  r.succeeded();
+  const before = vt.now();
+  r.closed();
+  vt.advance(DEFAULTS.baseMs);
+  check(attempts[attempts.length - 1] - before === DEFAULTS.baseMs,
+        'a successful connect resets the backoff');
+}
+
+// The two cases where retrying is wrong.
+{
+  const { vt, attempts, r } = harness();
+  r.stop();                       // credential rejected, or user disconnected
+  r.closed();
+  vt.advance(60000);
+  check(attempts.length === 0, 'stopped means stopped');
+  check(r.isStopped, 'and says so');
+}
+{
+  const { vt, attempts, r } = harness();
+  r.closed();                     // one in flight
+  r.stop();                       // user hits 断开 while it is pending
+  vt.advance(60000);
+  check(attempts.length === 0, 'stop cancels a pending retry');
+}
+{
+  const { vt, attempts, r } = harness();
+  r.stop();
+  r.resume();                     // new code entered, or page came back
+  r.closed();
+  vt.advance(DEFAULTS.baseMs);
+  check(attempts.length === 1, 'resume starts over from the short delay');
+}
+
+// One close should not queue several timers.
+{
+  const { vt, attempts, r } = harness();
+  r.closed(); r.closed(); r.closed();
+  vt.advance(DEFAULTS.maxMs + 1);
+  check(attempts.length === 1, 'repeated closes schedule one attempt', `(${attempts.length})`);
+}
+
+// Phones come back together — after a train tunnel, after a WiFi drop. Without
+// jitter they would all hit the gateway on the same tick.
+{
+  const { r } = harness({ random: Math.random });
+  const seen = new Set();
+  for (let i = 0; i < 40; i++) seen.add(r.delayFor(3));
+  check(seen.size > 1, 'delays are jittered', `(${seen.size} distinct of 40)`);
+}
+
+console.log('\nschedule (jitter centred)');
+{
+  const { r } = harness();
+  const row = [0, 1, 2, 3, 4, 5, 6].map((n) => `${r.delayFor(n)}ms`);
+  console.log('  ' + row.join('  →  '));
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -387,6 +387,7 @@
 <script src="./xterm.js"></script>
 <script src="./xterm-addon-webgl.js"></script>
 <script src="./input-coalescer.js"></script>
+<script src="./reconnect.js"></script>
 <script>
 // ── state ─────────────────────────────────────────────────────────────────
 const GEOM_KEY = 'seahelm_pane_geometry';
@@ -552,18 +553,33 @@ function setStatus(on, txt){
 }
 
 // ── connect ───────────────────────────────────────────────────────────────
+// Remembered across a drop so the page can put itself back: which worktree was
+// mounted, and which pane had focus. The panes themselves are torn down — their
+// attach leases died with the socket — and rebuilt on the way back.
+let lastMount = null;
+
+const reconnector = SeahelmReconnect.createReconnector({
+  attempt: () => openGatewaySocket(),
+  onSchedule: ({ retrying, attempt, delayMs }) => {
+    if (retrying) setStatus(false, `\u91cd\u8fde\u4e2d\u2026 (${attempt})`);
+  },
+});
+
 function connect(){
   disconnectAll();
   S.mac = $('mac').value.trim() || S.mac || 'testmac';
-  connectGateway(gatewayWsURL());
+  reconnector.resume();
+  openGatewaySocket();
 }
 
-function connectGateway(url){
+function openGatewaySocket(){
+  const url = gatewayWsURL();
   if (!S.authPass && !S.pendingCode) {
+    reconnector.stop();            // nothing to authenticate with
     setStatus(false, '需要配对码');
     return;
   }
-  const wsURL = (url && url.includes('/ws')) ? url : gatewayWsURL();
+  const wsURL = url;
   S.transport = 'gateway';
   log('sys', '(connect)', wsURL + ' [Gateway]');
   const ws = new WebSocket(wsURL);
@@ -579,6 +595,7 @@ function connectGateway(url){
     gwSend('auth', params, (r, err) => {
       if (err && err.code === -32029) {
         S.pendingCode = null;
+        reconnector.stop();        // retrying would only burn the rate limit
         setStatus(false, '尝试过多,稍后再试');
         log('sys', '(auth-rate)', JSON.stringify(err));
         ws.close();
@@ -586,6 +603,7 @@ function connectGateway(url){
       }
       if (err || !r || r.ok === false) {
         S.pendingCode = null;
+        reconnector.stop();        // a rejected credential stays rejected
         setStatus(false, '认证失败');
         log('sys', '(auth-fail)', err ? JSON.stringify(err) : JSON.stringify(r));
         ws.close();
@@ -602,9 +620,11 @@ function connectGateway(url){
       } catch (e) {}
       if ($('mac')) $('mac').value = S.mac;
       log('sys', '(vt format)', S.gw.binary ? (S.gw.deflate ? 'binary+deflate' : 'binary') : 'json+base64');
+      reconnector.succeeded();
       setStatus(true, '已连接');
       gwSend('session.snapshot', {}, (snap) => {
         if (snap && snap.panes) applySessionSnapshot(snap);
+        restoreMount();
       });
     });
   };
@@ -612,8 +632,27 @@ function connectGateway(url){
     if (ev.data instanceof ArrayBuffer) { onGatewayBinaryFrame(new Uint8Array(ev.data)); return; }
     try { onGatewayFrame(JSON.parse(ev.data)); } catch {}
   };
-  ws.onclose = () => { setStatus(false, '离线'); S.gw = null; S.transport = null; };
-  ws.onerror = () => setStatus(false, '错误');
+  ws.onclose = () => {
+    S.gw = null; S.transport = null;
+    // The panes' attach leases went with the socket; keep where we were so
+    // the reconnect can put it back rather than landing on an empty page.
+    if (S.vt.worktree) lastMount = { path: S.vt.worktree, focus: S.vt.focus };
+    unmountPanes();
+    if (reconnector.isStopped) setStatus(false, '离线');
+    reconnector.closed();
+  };
+  ws.onerror = () => { if (reconnector.isStopped) setStatus(false, '错误'); };
+}
+
+/** Put back the worktree that was on screen before the drop. */
+function restoreMount(){
+  if (!lastMount) return;
+  const { path, focus } = lastMount;
+  lastMount = null;
+  // Addressed by path, because the row objects are rebuilt from the fresh
+  // snapshot — the ones we held before the drop are stale.
+  const row = buildFleet().find(r => r.path === path);
+  if (row) selectWorktree(row, focus);
 }
 
 function gwSend(method, params, onReply){
@@ -1732,7 +1771,23 @@ function updateToBottom(){
 // not harmless — and mirroring a layout opens one per pane, which multiplies the
 // cost of getting this wrong. vt_close covers the tidy exits; pagehide covers
 // closing the tab; the bridge's lease sweep covers a crash, where neither runs.
-window.addEventListener('pagehide', unmountPanes);
+window.addEventListener('pagehide', () => {
+  // Keep where we were: on a phone this fires on every app switch, and the page
+  // that comes back is the same one — nothing re-runs to rebuild it.
+  if (S.vt.worktree) lastMount = { path: S.vt.worktree, focus: S.vt.focus };
+  unmountPanes();
+});
+
+// The other half. Without it, switching apps and back left a page that had torn
+// down its panes and had nothing to put them back — the panes are gone either
+// way, since their attach leases do not survive the socket.
+window.addEventListener('pageshow', () => {
+  if (reconnector.isStopped) return;          // disconnected on purpose
+  if (isLinked()) { restoreMount(); return; } // socket outlived the trip
+  if (!S.authPass && !S.pendingCode) return;  // never paired
+  reconnector.resume();
+  openGatewaySocket();
+});
 setInterval(() => {
   if (!isLinked()) return;
   for (const key of S.vt.panes.keys()) sendCommand('pane.vt_keepalive', { pane_session_key: key });
@@ -1741,15 +1796,18 @@ setInterval(() => {
 let corrN=0;
 const cmdReq = new Map();    // corr → onReply, for commands whose result we need
 function sendCommand(method, params, onReply){
-  if (S.transport === 'gateway') {
-    if (!isLinked()) { alert('未连接'); return; }
-    gwSend(method, params, (result, error) => {
-      if (!onReply) return;
-      onReply(error ? { ok: false, error } : { ok: true, result: result ?? {} });
-    });
+  // Not an alert. A dropped socket now reconnects on its own, so this is a
+  // transient state a tap can land in — a modal the user has to dismiss, on
+  // a phone, for something about to fix itself, is the wrong shape.
+  if (!isLinked()) {
+    setStatus(false, reconnector.isPending ? '重连中…' : '未连接');
+    log('sys', '(dropped)', method);
     return;
   }
-  alert('未连接');
+  gwSend(method, params, (result, error) => {
+    if (!onReply) return;
+    onReply(error ? { ok: false, error } : { ok: true, result: result ?? {} });
+  });
 }
 
 // ── wire ─────────────────────────────────────────────────────────────────────
@@ -1788,6 +1846,10 @@ function applyLogVisibility(){
   setTimeout(fitAllPanes, 200);   // the panes just got wider
 }
 $('disconnectBtn').onclick = () => {
+  // Before disconnectAll: closing the socket fires onclose, which would
+  // otherwise schedule the reconnect the user just asked us not to make.
+  reconnector.stop();
+  lastMount = null;
   disconnectAll();
   unmountPanes();
   setStatus(false, '离线');

--- a/clients/seahelm-web/reconnect.js
+++ b/clients/seahelm-web/reconnect.js
@@ -1,0 +1,84 @@
+// Reconnect policy for the Host Gateway socket.
+//
+// The MQTT client this replaced reconnected on its own (mqtt.js, every 2s). The
+// gateway socket did not: `onclose` set the status to offline and stopped, so a
+// phone locking its screen, handing off WiFi→cellular, or simply being switched
+// away from left a dead page that only a manual tap could revive. That is not an
+// edge case for this client; it is the normal way a phone behaves.
+//
+// Two things it must not do:
+//   • retry a credential the gateway rejected — a wrong or expired code will be
+//     wrong forever, and hammering it burns the pairing rate limit
+//   • retry after the user pressed 断开
+//
+// Pure, with its clock and timers injected, so the schedule can be asserted.
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.SeahelmReconnect = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  const DEFAULTS = { baseMs: 500, maxMs: 15000, factor: 2, jitter: 0.25 };
+
+  /**
+   * @param {object} o
+   * @param {()=>void} o.attempt        open a fresh socket
+   * @param {(state:{retrying:boolean, attempt:number, delayMs:number})=>void} [o.onSchedule]
+   */
+  function createReconnector(o) {
+    const cfg = Object.assign({}, DEFAULTS, o);
+    const now = cfg.now || (() => Date.now());
+    const setTimer = cfg.setTimer || ((fn, ms) => setTimeout(fn, ms));
+    const clearTimer = cfg.clearTimer || ((h) => clearTimeout(h));
+    const random = cfg.random || Math.random;
+
+    let attempts = 0;
+    let timer = null;
+    let stopped = false;
+
+    /** Exponential with full-width jitter, so N phones do not return in lockstep. */
+    function delayFor(n) {
+      const raw = Math.min(cfg.maxMs, cfg.baseMs * Math.pow(cfg.factor, n));
+      const spread = raw * cfg.jitter;
+      return Math.round(raw - spread + random() * 2 * spread);
+    }
+
+    return {
+      /** The socket closed on its own. Schedule another try. */
+      closed() {
+        if (stopped || timer !== null) return;
+        const delayMs = delayFor(attempts);
+        attempts += 1;
+        if (cfg.onSchedule) cfg.onSchedule({ retrying: true, attempt: attempts, delayMs });
+        timer = setTimer(() => { timer = null; if (!stopped) cfg.attempt(); }, delayMs);
+      },
+      /** Authenticated. The next drop starts from the short delay again. */
+      succeeded() {
+        attempts = 0;
+        stopped = false;
+        if (cfg.onSchedule) cfg.onSchedule({ retrying: false, attempt: 0, delayMs: 0 });
+      },
+      /**
+       * Give up until something changes: a rejected credential, or the user
+       * pressing disconnect. `resume()` is the only way back.
+       */
+      stop() {
+        stopped = true;
+        if (timer !== null) { clearTimer(timer); timer = null; }
+      },
+      /** A new code was entered, or the page came back — try again now. */
+      resume() {
+        stopped = false;
+        attempts = 0;
+        if (timer !== null) { clearTimer(timer); timer = null; }
+      },
+      get isStopped() { return stopped; },
+      get isPending() { return timer !== null; },
+      get attempts() { return attempts; },
+      delayFor,
+    };
+  }
+
+  return { createReconnector, DEFAULTS };
+});


### PR DESCRIPTION
## The gap

The gateway socket had no reconnect:

```js
ws.onclose = () => { setStatus(false, '离线'); S.gw = null; S.transport = null; };
```

A phone locking its screen, handing off WiFi→cellular, or simply being switched away from left a page only a manual tap could revive. That is not an edge case for this client — it is how a phone behaves.

The MQTT client this transport replaced reconnected on its own (mqtt.js, `reconnectPeriod: 2000`, with a "重连中…" status). So the newer, preferred path had regressed on reliability against the one it superseded.

And `pagehide` had no `pageshow`. On mobile the first fires on every app switch and tears the panes down; nothing put them back. Together: switch away, come back, find a blank disconnected page — and every tap raised a native `alert('未连接')`.

## Backoff

500ms → 15s, jittered. Phones come back *together* — after a tunnel, after an AP drop — and without jitter they would all hit the gateway on the same tick.

```
500ms  →  1000ms  →  2000ms  →  4000ms  →  8000ms  →  15000ms  →  15000ms
```

A successful connect resets it, so a drop after a good session feels immediate instead of resuming where the last outage climbed to.

## Two cases where retrying is wrong

- **A rejected credential stays rejected.** An expired or mistyped code will be wrong forever, and retrying only burns the pairing rate limit the Mac just started enforcing.
- **断开 must stop it** — which means stopping the reconnector *before* closing the socket, or `onclose` schedules the attempt the user just declined. That ordering has a test.

## Coming back

`pagehide` and `pageshow` both go through `lastMount`, which remembers the worktree and focused pane, so a reconnect lands where the page was. The panes themselves cannot be kept — their attach leases die with the socket — so they are rebuilt, addressed **by path**, because the row objects are recreated from the fresh snapshot and the ones held across the drop are stale.

`sendCommand` no longer raises a modal. With reconnect in place a down socket is a transient state a tap can land in, and a blocking alert on a phone, for something about to fix itself, is the wrong shape. It sets the status line and logs the dropped call.

## Tests

`node devbroker/reconnect-test.js` — virtual time, no browser, no gateway. 11 checks: the schedule grows and caps, success resets it, stop cancels a pending retry, resume starts over, repeated closes schedule one attempt, delays are jittered.

Against a no-op `closed()` — the old behaviour — **6 of the 11 fail**. I put it back and ran it, rather than trusting a green suite to mean anything.

1783 Swift tests. This also widens the deadline in `PRReviewCoordinatorLifetimeTests`: it waits on a deferred main-runloop release and gave it two seconds, which held in isolation and not under a full suite. The assertion is that the coordinator releases at all, not that it does so inside a window a loaded machine has to hit. `ChromeCollapseAnimationTests` and `HostGatewayServerTests.testStoppingReleasesThePortForTheNextServer` still flake on timing and port reuse — pre-existing, and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
