### PR TITLE
fix: ask every pane whether a worktree is busy, not just the first

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -1327,7 +1327,7 @@ dashboard.stationManager = terminalCoordinator.stationManager
 
         case .removeWorktree(let path):
             let branch = tabCoordinator.allWorktrees.first { $0.info.path == path }?.info.branch ?? ""
-            if AgentRegistry.shared.pane(forWorktree: path)?.status == .running {
+            if AgentRegistry.shared.hasRunningPane(inWorktree: path) {
                 reply("**\(branch)** has an agent running — leaving it alone.")
                 return
             }
@@ -1507,7 +1507,9 @@ dashboard.stationManager = terminalCoordinator.stationManager
 
         // A worktree with a live agent must never be reaped by /remove: neither
         // deleted outright nor carded for "Force remove". Leave it untouched.
-        if pane?.status == .running {
+        // Asked across every pane, not just `pane`: that one is the worktree's
+        // first, and a split whose second pane is working is just as live.
+        if AgentRegistry.shared.hasRunningPane(inWorktree: path) {
             onDone?()
             return
         }
@@ -3035,7 +3037,7 @@ extension MainWindowController {
         if order.action.kind == .returnToPort {
             // Guard against a stale card: if the agent started running after the
             // card was enqueued, refuse the reap and drop the card.
-            if AgentRegistry.shared.pane(forWorktree: order.action.worktreePath)?.status == .running {
+            if AgentRegistry.shared.hasRunningPane(inWorktree: order.action.worktreePath) {
                 NSSound.beep()
                 tabCoordinator.pendingOrders.resolve(id: order.id)
                 return
@@ -3104,7 +3106,7 @@ extension MainWindowController {
             AgentRegistry.shared.sendCommand(to: terminalID, command: task)
         case .returnToPort:
             // Never reap a worktree whose agent is now running.
-            if AgentRegistry.shared.pane(forWorktree: order.action.worktreePath)?.status == .running {
+            if AgentRegistry.shared.hasRunningPane(inWorktree: order.action.worktreePath) {
                 NSSound.beep()
                 break
             }

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -130,8 +130,8 @@ class TabCoordinator {
                     .filter { WorktreeDiscovery.findRepoRoot(from: $0.path) == repo } ?? []
             },
             integrationPath: { IntegrationWorktreeStore.shared.worktreePath(forRepo: $0) },
-            isCheckoutBusy: { AgentRegistry.shared.pane(forWorktree: $0)?.status == .running },
-            isWorktreeBusy: { AgentRegistry.shared.pane(forWorktree: $0)?.status == .running },
+            isCheckoutBusy: { AgentRegistry.shared.hasRunningPane(inWorktree: $0) },
+            isWorktreeBusy: { AgentRegistry.shared.hasRunningPane(inWorktree: $0) },
             onReport: { [weak self] report, _ in
                 IntegrationStatusStore.shared.set(report.panelState, forWorktree: report.integrationWorktreePath)
                 guard report.needsAttention else { return }

--- a/Sources/Core/AgentRegistry.swift
+++ b/Sources/Core/AgentRegistry.swift
@@ -981,6 +981,20 @@ class AgentRegistry {
         return (worktreeIndex[worktreePath] ?? []).compactMap { agents[$0] }
     }
 
+    /// Whether *any* pane in a worktree has an agent mid-turn.
+    ///
+    /// Deliberately not `pane(forWorktree:)?.status == .running`: that reads
+    /// only the first registered pane, so a split whose second pane is working
+    /// reports idle. Every caller asking this is really asking "is it safe to
+    /// touch this worktree's files?", and for that question one busy pane is
+    /// enough to say no.
+    func hasRunningPane(inWorktree worktreePath: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return (worktreeIndex[worktreePath] ?? []).contains { agents[$0]?.status == .running }
+    }
+
     func panesForProject(_ project: String) -> [PaneInfo] {
         lock.lock()
         defer { lock.unlock() }

--- a/Tests/AgentRegistryTests.swift
+++ b/Tests/AgentRegistryTests.swift
@@ -193,6 +193,34 @@ final class AgentRegistryTests: XCTestCase {
         XCTAssertNil(AgentRegistry.shared.pane(forWorktree: "/nonexistent"))
     }
 
+    /// The guard that decides whether it is safe to touch a worktree's files —
+    /// reaping it, or resetting an integration checkout onto a fresh fold — used
+    /// to read `pane(forWorktree:)`, i.e. only the *first* registered pane. A
+    /// split whose second pane was mid-turn therefore reported idle.
+    func testHasRunningPaneSeesANonFirstPane() {
+        registerTestPane(path: "/tmp/repo/split", branch: "feature")
+        let second = registerTestPane(path: "/tmp/repo/split", branch: "feature")
+
+        AgentRegistry.shared.updateStatus(terminalID: second, status: .running,
+                                          lastMessage: "", roundDuration: 0)
+
+        XCTAssertNotEqual(AgentRegistry.shared.pane(forWorktree: "/tmp/repo/split")?.status, .running,
+                          "precondition: the first pane is the idle one")
+        XCTAssertTrue(AgentRegistry.shared.hasRunningPane(inWorktree: "/tmp/repo/split"))
+    }
+
+    func testHasRunningPaneIsFalseWhenEveryPaneIsIdle() {
+        let first = registerTestPane(path: "/tmp/repo/quiet")
+        let second = registerTestPane(path: "/tmp/repo/quiet")
+        AgentRegistry.shared.updateStatus(terminalID: first, status: .idle,
+                                          lastMessage: "", roundDuration: 0)
+        AgentRegistry.shared.updateStatus(terminalID: second, status: .idle,
+                                          lastMessage: "", roundDuration: 0)
+
+        XCTAssertFalse(AgentRegistry.shared.hasRunningPane(inWorktree: "/tmp/repo/quiet"))
+        XCTAssertFalse(AgentRegistry.shared.hasRunningPane(inWorktree: "/nonexistent"))
+    }
+
     // MARK: - Ordering
 
     func testAllAgentsPreservesInsertionOrder() {


### PR DESCRIPTION
## What

`AgentRegistry.pane(forWorktree:)` returns `worktreeIndex[path]?.first` — the worktree's **first registered pane**. Every "is this worktree busy?" guard was built on it, so a split whose *second* pane was mid-turn reported idle.

Adds `AgentRegistry.hasRunningPane(inWorktree:)` and moves all five call sites onto it.

## Why it matters

| Call site | Consequence of the first-pane read |
|---|---|
| `IntegrationCoordinator.isCheckoutBusy` | A dev server in the checkout's second pane looks idle → the round `reset --hard`s the files out from under it. In the first pane, the opposite: every round is silently skipped and auto-integrate quietly stops. |
| `IntegrationCoordinator.isWorktreeBusy` | A busy worktree contributes a live snapshot instead of its HEAD — exactly the torn, half-written state that guard exists to keep out of a fold. |
| `/remove` over chat (`MainWindowController:1330`) | A worktree with a running agent is deleted anyway. |
| `enqueueReturnCard` (`:1512`) | Same, and its comment promises "a worktree with a live agent must never be reaped". |
| returnToPort card (`:3040`, `:3109`) | Tapping the red-zone chip reaps a worktree whose agent is working. |

The three reap guards are the more dangerous half — they delete worktrees.

## How it was found

Auto-integrate on a repo stopped publishing for ~54 minutes while agents kept finishing turns. The integration checkout's reflog showed the last seahelm publish (`reset: moving to …`) at 13:39:52 and nothing after; the checkout had two panes, one running `pnpm tauri dev`.

## Tests

`Tests/AgentRegistryTests.swift`:
- `testHasRunningPaneSeesANonFirstPane` — asserts the first pane really is the idle one, then that `hasRunningPane` still reports true.
- `testHasRunningPaneIsFalseWhenEveryPaneIsIdle`

`AgentRegistryTests` (24) and `IntegrationCoordinatorTests` (8) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)