### PR TITLE
build: bump bundled zmx to 0.7.1

### DIFF
--- a/Vendor/zmx.pin
+++ b/Vendor/zmx.pin
@@ -1,3 +1,3 @@
-VERSION=0.7.0
-URL=https://zmx.sh/a/zmx-0.7.0-macos-aarch64.tar.gz
-SHA256=a63d6f3edd6d4b38240f8f81513e60e35a898ca520211112d7bc67f610f1f3eb
+VERSION=0.7.1
+URL=https://zmx.sh/a/zmx-0.7.1-macos-aarch64.tar.gz
+SHA256=86ce4c0eeb6b8448d058390fabe4a5aff323c4fc1e64ed578d48ab75a0f59a79


### PR DESCRIPTION
## What

Moves `Vendor/zmx.pin` from 0.7.0 to 0.7.1. One file, three lines.

`scripts/bump-zmx.sh 0.7.1` also re-fetches the MIT license into `Resources/licenses/zmx-LICENSE`, but it came back byte-identical to the vendored copy, so there is nothing to commit there.

## Upstream changes

`neurosnap/zmx` v0.7.0...v0.7.1 — the release notes are empty; the log is:

```
- fix: attach hang against pre-0.7.0 daemons
- chore: prep v0.7.1
```

So: one client-side fix for `attach` hanging against a daemon older than 0.7.0.

## Verification

- `scripts/fetch-zmx.sh <dest>` — asset downloads, SHA-256 matches the new pin, extracted binary reports `zmx 0.7.1` (Mach-O arm64).
- `scripts/check-zmx.sh` — now exits 0, "up to date (pinned 0.7.1 is the latest release)".

## Note for whoever merges

The pin is a build-time input. Already-running daemons stay on 0.7.0 until they are restarted, and a local checkout needs a `./run.sh` before the new binary is actually bundled. Since the fix only concerns attaching to *pre*-0.7.0 daemons, live 0.7.0 daemons are unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)