### PR TITLE
feat: seahelm-web poor-network optimizations

### DIFF
--- a/Sources/Core/HostGatewayKeyFrame.swift
+++ b/Sources/Core/HostGatewayKeyFrame.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Binary inbound frame for `pane.send_keys` (negotiated via `keys_binary` on auth).
+///
+/// ```
+///   u8  version (1)
+///   u8  kind        1 = keys
+///   u8  keyLength
+///   ..  key         UTF-8 pane session key
+///   ..  payload     raw UTF-8 keystrokes
+/// ```
+enum HostGatewayKeyFrame {
+    static let version: UInt8 = 1
+    static let kindKeys: UInt8 = 1
+    static let maxKeyLength = 255
+
+    static func encode(paneSessionKey: String, utf8: Data) -> Data? {
+        let keyBytes = Array(paneSessionKey.utf8)
+        guard keyBytes.count <= maxKeyLength else { return nil }
+        var out = Data()
+        out.reserveCapacity(3 + keyBytes.count + utf8.count)
+        out.append(version)
+        out.append(kindKeys)
+        out.append(UInt8(keyBytes.count))
+        out.append(contentsOf: keyBytes)
+        out.append(utf8)
+        return out
+    }
+
+    static func decode(_ frame: Data) -> (paneSessionKey: String, utf8: Data)? {
+        var index = frame.startIndex
+        func byte() -> UInt8? {
+            guard index < frame.endIndex else { return nil }
+            defer { index = frame.index(after: index) }
+            return frame[index]
+        }
+        guard let v = byte(), v == version,
+              let kind = byte(), kind == kindKeys,
+              let keyLength = byte() else { return nil }
+        guard let keyEnd = frame.index(index, offsetBy: Int(keyLength), limitedBy: frame.endIndex),
+              let key = String(data: frame[index..<keyEnd], encoding: .utf8) else { return nil }
+        index = keyEnd
+        return (key, Data(frame[index...]))
+    }
+}

--- a/Sources/Core/HostGatewayServer.swift
+++ b/Sources/Core/HostGatewayServer.swift
@@ -479,15 +479,21 @@ final class HostGatewayServer {
 
             let wsMeta = context?.protocolMetadata(definition: NWProtocolWebSocket.definition)
                 as? NWProtocolWebSocket.Metadata
-            if let data,
-               let metadata = wsMeta,
-               metadata.opcode == .text,
-               let text = String(data: data, encoding: .utf8) {
-                let outbound = session.handle(text: text)
-                for frame in outbound {
-                    self.send(frame, on: connection)
+            if let data, let metadata = wsMeta {
+                if metadata.opcode == .text,
+                   let text = String(data: data, encoding: .utf8) {
+                    let outbound = session.handle(text: text)
+                    for frame in outbound {
+                        self.send(frame, on: connection)
+                    }
+                    self.sendPendingNotifications(for: connection, session: session)
+                } else if metadata.opcode == .binary {
+                    let outbound = session.handle(binary: data)
+                    for frame in outbound {
+                        self.send(frame, on: connection)
+                    }
+                    self.sendPendingNotifications(for: connection, session: session)
                 }
-                self.sendPendingNotifications(for: connection, session: session)
             }
 
             if connection.state != .cancelled {

--- a/Sources/Core/HostGatewayServer.swift
+++ b/Sources/Core/HostGatewayServer.swift
@@ -276,10 +276,18 @@ final class HostGatewayServer {
             return
         }
         let (method, target) = Self.requestLine(head: head)
-        let response = staticFiles.response(method: method, target: target)
-        let payload = HostGatewayStaticFiles.serialize(response, includeBody: method != "HEAD")
-        connection.send(content: payload, isComplete: true, completion: .contentProcessed { _ in
-            connection.cancel()
+        let headers = Self.parseRequestHeaders(head: head)
+        let response = staticFiles.response(method: method, target: target, headers: headers)
+        let close = Self.clientRequestsClose(head: head)
+        let payload = HostGatewayStaticFiles.serialize(
+            response, includeBody: method != "HEAD", connectionClose: close)
+        connection.send(content: payload, isComplete: close, completion: .contentProcessed { [weak self] error in
+            guard let self else { return }
+            if error != nil || close {
+                connection.cancel()
+                return
+            }
+            self.readRequestHead(on: connection, buffered: Data())
         })
     }
 
@@ -375,6 +383,46 @@ final class HostGatewayServer {
             return String(target[target.startIndex..<cut])
         }
         return target
+    }
+
+    static func parseRequestHeaders(head: String) -> HostGatewayStaticFiles.RequestHeaders {
+        var acceptEncoding: String?
+        var ifNoneMatch: String?
+        for line in head.split(separator: "\r\n", omittingEmptySubsequences: true).dropFirst() {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = line[line.startIndex..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+            switch name {
+            case "accept-encoding":
+                acceptEncoding = value
+            case "if-none-match":
+                ifNoneMatch = value
+            default:
+                break
+            }
+        }
+        return HostGatewayStaticFiles.RequestHeaders(
+            acceptEncoding: acceptEncoding, ifNoneMatch: ifNoneMatch)
+    }
+
+    /// HTTP/1.0 defaults to close; HTTP/1.1 defaults to keep-alive unless `Connection: close`.
+    static func clientRequestsClose(head: String) -> Bool {
+        guard let first = head.split(separator: "\r\n", omittingEmptySubsequences: true).first else {
+            return true
+        }
+        let parts = first.split(separator: " ", omittingEmptySubsequences: true)
+        let version = parts.count > 2 ? String(parts[2]).uppercased() : "HTTP/1.0"
+        let isHTTP11 = version.hasPrefix("HTTP/1.1")
+        if !isHTTP11 { return true }
+
+        for line in head.split(separator: "\r\n", omittingEmptySubsequences: true).dropFirst() {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let name = line[line.startIndex..<colon].trimmingCharacters(in: .whitespaces).lowercased()
+            guard name == "connection" else { continue }
+            let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces).lowercased()
+            if value.contains("close") { return true }
+        }
+        return false
     }
 
     // MARK: - WebSocket sessions (internal listener)

--- a/Sources/Core/HostGatewaySession.swift
+++ b/Sources/Core/HostGatewaySession.swift
@@ -215,6 +215,10 @@ final class HostGatewaySession {
     }
 
     private func maybeScheduleResync(pane: String) {
+        // A still-queued real snapshot *is* the resync. An empty synthetic after
+        // it would make the client term.reset() to a blank screen and undo it.
+        if restackRealSnapshot(pane: pane) { return }
+
         let now = Date()
         let allowed = needsResync[pane].map { now.timeIntervalSince($0) >= Self.resyncMinInterval } ?? true
         let existing = pending.lastIndex {
@@ -233,6 +237,34 @@ final class HostGatewaySession {
         guard allowed else { return }
         needsResync[pane] = now
         pending.append(.vt(VTEvent(kind: .snapshot, paneSessionKey: pane, payload: Data())))
+    }
+
+    /// If a non-empty snapshot for `pane` survived trim, drop later `.data` for
+    /// that pane and restack the snapshot last so drain ends on a consistent
+    /// screen. Returns true when that happened (caller must not append empty).
+    private func restackRealSnapshot(pane: String) -> Bool {
+        let snapIdx = pending.lastIndex {
+            if case .vt(let e) = $0,
+               e.kind == .snapshot,
+               e.paneSessionKey == pane,
+               !e.payload.isEmpty { return true }
+            return false
+        }
+        guard let snapIdx else { return false }
+        var i = pending.count - 1
+        while i > snapIdx {
+            if case .vt(let e) = pending[i],
+               e.paneSessionKey == pane,
+               e.kind == .data {
+                pendingVTBytes -= e.payload.count
+                pending.remove(at: i)
+            }
+            i -= 1
+        }
+        if pendingVTBytes < 0 { pendingVTBytes = 0 }
+        let item = pending.remove(at: snapIdx)
+        pending.append(item)
+        return true
     }
 
     /// Server → session: an event that opened or closed a decision.

--- a/Sources/Core/HostGatewaySession.swift
+++ b/Sources/Core/HostGatewaySession.swift
@@ -24,8 +24,16 @@ final class HostGatewaySession {
     private let rateLimiter: PairRateLimiter?
     private let clientIP: String
 
+    /// Caps on queued VT payload (uncompressed). Overflow drops oldest `.vt`
+    /// for the overflowing pane (or globally, if the session total is over)
+    /// and rate-limits a synthetic empty snapshot so the client can reset.
+    static let maxPendingVTBytes = 256 * 1024
+    static let maxPendingVTBytesPerPane = 128 * 1024
+    static let resyncMinInterval: TimeInterval = 1.0
+
     /// A queued outbound frame.
     ///
+    /// High-priority frames (decisions / control notifies) drain before VT.
     /// VT events are queued as events and encoded at drain time. `emit` runs on
     /// the VT manager's serial queue — the same one that has to drain the PTY —
     /// so deflating a 48KB chunk there stalls reading for every pane, and does it
@@ -33,12 +41,12 @@ final class HostGatewaySession {
     /// encoded.
     ///
     /// The trade is that a queued VT frame is held uncompressed, so a client that
-    /// stalls holds more memory than it used to. That is bounded: the manager
-    /// coalesces to one frame per pane per flush window, capped at 48KB, only
-    /// panes this client opened are queued at all, and every enqueue wakes a
-    /// drain.
+    /// stalls holds more memory than it used to. That is bounded: drop-old keeps
+    /// pending VT at `maxPendingVTBytes` (and `maxPendingVTBytesPerPane` per
+    /// pane), only panes this client opened are queued at all, and every enqueue
+    /// wakes a drain.
     private enum Pending {
-        case ready(HostGatewayWireFrame)
+        case high(HostGatewayWireFrame)
         case vt(VTEvent)
     }
 
@@ -54,6 +62,9 @@ final class HostGatewaySession {
     private var authenticated = false
     private var openVTKeys: Set<String> = []
     private var pending: [Pending] = []
+    /// pane → last forced-resync time. Also the rate-limit clock.
+    private var needsResync: [String: Date] = [:]
+    private var pendingVTBytes: Int = 0
     private var vtObserverToken: Int?
     /// Negotiated at auth. Absent means a client from before binary VT, which
     /// still gets base64 inside a JSON notify.
@@ -94,6 +105,8 @@ final class HostGatewaySession {
         vtObserverToken = nil
         pendingOutbound = nil
         pending.removeAll()
+        pendingVTBytes = 0
+        needsResync.removeAll()
         lock.unlock()
         if let token { vt.removeObserver(token) }
     }
@@ -137,7 +150,11 @@ final class HostGatewaySession {
     private func enqueueVT(_ event: VTEvent) {
         lock.lock()
         let wanted = authenticated && openVTKeys.contains(event.paneSessionKey)
-        if wanted { pending.append(.vt(event)) }
+        if wanted {
+            pending.append(.vt(event))
+            pendingVTBytes += event.payload.count
+            trimVTIfNeeded(pane: event.paneSessionKey)
+        }
         let notify = wanted ? pendingOutbound : nil
         lock.unlock()
         notify?(self)
@@ -145,10 +162,77 @@ final class HostGatewaySession {
 
     private func enqueue(_ frame: HostGatewayWireFrame) {
         lock.lock()
-        pending.append(.ready(frame))
+        pending.append(.high(frame))
         let notify = pendingOutbound
         lock.unlock()
         notify?(self)
+    }
+
+    /// Must run while `lock` is held.
+    private func trimVTIfNeeded(pane: String) {
+        var dropped = Set<String>()
+        while panePendingVTBytes(pane) > Self.maxPendingVTBytesPerPane {
+            guard let key = dropOldestVT(pane: pane) else { break }
+            dropped.insert(key)
+        }
+        while pendingVTBytes > Self.maxPendingVTBytes {
+            guard let key = dropOldestVT(pane: nil) else { break }
+            dropped.insert(key)
+        }
+        for key in dropped {
+            maybeScheduleResync(pane: key)
+        }
+    }
+
+    private func panePendingVTBytes(_ pane: String) -> Int {
+        var n = 0
+        for item in pending {
+            if case .vt(let e) = item, e.paneSessionKey == pane {
+                n += e.payload.count
+            }
+        }
+        return n
+    }
+
+    /// Drops the oldest `vt.data` for `pane` (or any pane if `pane` is nil).
+    /// Falls back to any `.vt` so a huge snapshot cannot pin the budget over cap.
+    private func dropOldestVT(pane: String?) -> String? {
+        func matches(_ event: VTEvent) -> Bool {
+            pane.map { event.paneSessionKey == $0 } ?? true
+        }
+        let dataIdx = pending.firstIndex {
+            if case .vt(let e) = $0, e.kind == .data, matches(e) { return true }
+            return false
+        }
+        let idx = dataIdx ?? pending.firstIndex {
+            if case .vt(let e) = $0, matches(e) { return true }
+            return false
+        }
+        guard let idx, case .vt(let event) = pending.remove(at: idx) else { return nil }
+        pendingVTBytes -= event.payload.count
+        if pendingVTBytes < 0 { pendingVTBytes = 0 }
+        return event.paneSessionKey
+    }
+
+    private func maybeScheduleResync(pane: String) {
+        let now = Date()
+        let allowed = needsResync[pane].map { now.timeIntervalSince($0) >= Self.resyncMinInterval } ?? true
+        let existing = pending.lastIndex {
+            if case .vt(let e) = $0,
+               e.kind == .snapshot,
+               e.paneSessionKey == pane,
+               e.payload.isEmpty { return true }
+            return false
+        }
+        if let existing {
+            let item = pending.remove(at: existing)
+            pending.append(item)
+            if allowed { needsResync[pane] = now }
+            return
+        }
+        guard allowed else { return }
+        needsResync[pane] = now
+        pending.append(.vt(VTEvent(kind: .snapshot, paneSessionKey: pane, payload: Data())))
     }
 
     /// Server → session: an event that opened or closed a decision.
@@ -181,17 +265,22 @@ final class HostGatewaySession {
         lock.lock()
         let queued = pending
         pending.removeAll()
+        pendingVTBytes = 0
         let binary = vtBinary
         let deflate = vtDeflate
         lock.unlock()
         // Encoding happens here — on the gateway's queue, outside the lock, and
-        // off the queue that reads the PTY.
-        return queued.map { item in
-            switch item {
-            case .ready(let frame): return frame
-            case .vt(let event): return encodeVT(event, binary: binary, deflate: deflate)
-            }
+        // off the queue that reads the PTY. High-priority control always
+        // precedes VT, even if the VT was enqueued first.
+        let high = queued.compactMap { item -> HostGatewayWireFrame? in
+            if case .high(let frame) = item { return frame }
+            return nil
         }
+        let vts = queued.compactMap { item -> VTEvent? in
+            if case .vt(let event) = item { return event }
+            return nil
+        }
+        return high + vts.map { encodeVT($0, binary: binary, deflate: deflate) }
     }
 
     func handle(text: String) -> [HostGatewayWireFrame] {

--- a/Sources/Core/HostGatewaySession.swift
+++ b/Sources/Core/HostGatewaySession.swift
@@ -70,6 +70,7 @@ final class HostGatewaySession {
     /// still gets base64 inside a JSON notify.
     private var vtBinary = false
     private var vtDeflate = false
+    private var keysBinary = false
     private var pendingOutbound: ((HostGatewaySession) -> Void)?
 
     init(router: ControlRouter,
@@ -333,6 +334,19 @@ final class HostGatewaySession {
         }
     }
 
+    /// Negotiated binary `send_keys` — fire-and-forget, no RPC id.
+    func handle(binary: Data) -> [HostGatewayWireFrame] {
+        lock.lock()
+        let ready = authenticated
+        let allowKeys = keysBinary
+        lock.unlock()
+        guard ready, allowKeys,
+              let decoded = HostGatewayKeyFrame.decode(binary) else { return [] }
+        guard isVTOpen(decoded.paneSessionKey) else { return [] }
+        _ = vt.sendKeys(paneSessionKey: decoded.paneSessionKey, utf8: decoded.utf8)
+        return []
+    }
+
     private func handleAuth(id: String, params: [String: Any]) -> [String] {
         let macId = params["mac_id"] as? String ?? ""
         let token = params["token"] as? String ?? ""
@@ -368,17 +382,20 @@ final class HostGatewaySession {
         // against a new Mac rather than rendering nothing.
         let binary = ok && (params["vt_binary"] as? Bool ?? false)
         let deflate = binary && (params["vt_deflate"] as? Bool ?? false)
+        let keysBin = ok && (params["keys_binary"] as? Bool ?? false)
         if ok {
             lock.lock()
             authenticated = true
             vtBinary = binary
             vtDeflate = deflate
+            keysBinary = keysBin
             lock.unlock()
         }
         var result: [String: Any] = [
             "ok": ok,
             "vt_binary": binary,
             "vt_deflate": deflate,
+            "keys_binary": keysBin,
         ]
         if ok {
             result["mac_id"] = expectedMacId

--- a/Sources/Core/HostGatewayStaticFiles.swift
+++ b/Sources/Core/HostGatewayStaticFiles.swift
@@ -1,3 +1,5 @@
+import Compression
+import CryptoKit
 import Foundation
 
 /// Static hosting for the browser client, served from the Host Gateway's own port.
@@ -26,15 +28,28 @@ struct HostGatewayStaticFiles {
         return Bundle.main.resourceURL?.appendingPathComponent("seahelm-web")
     }
 
+    struct RequestHeaders: Equatable {
+        var acceptEncoding: String?
+        var ifNoneMatch: String?
+    }
+
     struct Response: Equatable {
         let status: Int
         let reason: String
         let contentType: String
         let body: Data
+        let cacheControl: String
+        let contentEncoding: String?
+        let etag: String?
+        let vary: String?
     }
 
     /// Resolve an HTTP request target (`/`, `/e2ee.js`, `/x?v=1`) to a response.
     func response(method: String, target: String) -> Response {
+        response(method: method, target: target, headers: .init())
+    }
+
+    func response(method: String, target: String, headers: RequestHeaders) -> Response {
         guard method == "GET" || method == "HEAD" else {
             return Self.plain(405, "Method Not Allowed", "method not allowed\n")
         }
@@ -47,10 +62,36 @@ struct HostGatewayStaticFiles {
         guard let data = try? Data(contentsOf: file) else {
             return Self.plain(404, "Not Found", "not found\n")
         }
-        return Response(status: 200,
-                        reason: "OK",
-                        contentType: Self.contentType(for: file.pathExtension.lowercased()),
-                        body: data)
+
+        let ext = file.pathExtension.lowercased()
+        let contentType = Self.contentType(for: ext)
+        let cache = Self.cacheControl(for: target, pathExtension: ext)
+        let etag = Self.etag(for: data)
+
+        if let inm = headers.ifNoneMatch, inm == etag {
+            return Response(status: 304, reason: "Not Modified",
+                            contentType: contentType, body: Data(),
+                            cacheControl: cache,
+                            contentEncoding: nil, etag: etag, vary: nil)
+        }
+
+        let wantGzip = Self.acceptsGzip(headers.acceptEncoding) && Self.gzipable(ext)
+        var body = data
+        var encoding: String?
+        var vary: String?
+        if wantGzip, let gz = Self.gzip(data), gz.count < data.count {
+            body = gz
+            encoding = "gzip"
+            vary = "Accept-Encoding"
+        }
+
+        return Response(status: 200, reason: "OK",
+                        contentType: contentType,
+                        body: body,
+                        cacheControl: cache,
+                        contentEncoding: encoding,
+                        etag: etag,
+                        vary: vary)
     }
 
     /// Map a request target onto a file inside `root`, refusing to escape it.
@@ -94,11 +135,112 @@ struct HostGatewayStaticFiles {
         }
     }
 
+    static func cacheControl(for target: String, pathExtension: String) -> String {
+        switch pathExtension {
+        case "html", "htm":
+            return "no-cache"
+        default:
+            if target.contains("?v=") || target.contains("?v&") {
+                return "public, max-age=31536000, immutable"
+            }
+            return "public, max-age=86400"
+        }
+    }
+
+    static func etag(for data: Data) -> String {
+        let digest = SHA256.hash(data: data)
+        let hex = digest.map { String(format: "%02x", $0) }.joined()
+        return "\"\(hex)\""
+    }
+
+    static func acceptsGzip(_ acceptEncoding: String?) -> Bool {
+        guard let acceptEncoding else { return false }
+        let tokens = acceptEncoding.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        for token in tokens {
+            let parts = token.split(separator: ";", maxSplits: 1).map { $0.trimmingCharacters(in: .whitespaces) }
+            guard let name = parts.first?.lowercased(), name == "gzip" else { continue }
+            if parts.count > 1 {
+                let qPart = parts[1].trimmingCharacters(in: .whitespaces).lowercased()
+                if qPart.hasPrefix("q="), let q = Double(qPart.dropFirst(2)), q == 0 {
+                    continue
+                }
+            }
+            return true
+        }
+        return false
+    }
+
+    static func gzipable(_ pathExtension: String) -> Bool {
+        switch pathExtension {
+        case "html", "htm", "js", "mjs", "css", "svg", "json", "map", "txt", "md":
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func gzip(_ input: Data) -> Data? {
+        guard !input.isEmpty else { return nil }
+        guard let deflated = deflateRaw(input) else { return nil }
+
+        var out = Data()
+        // RFC 1952 gzip header
+        out.append(contentsOf: [0x1f, 0x8b, 0x08, 0x00])
+        out.append(contentsOf: [0, 0, 0, 0]) // mtime
+        out.append(contentsOf: [0x00, 0x03]) // xfl + OS (Unix)
+        out.append(deflated)
+        out.append(contentsOf: crc32(input).littleEndianBytes)
+        out.append(contentsOf: UInt32(truncatingIfNeeded: input.count).littleEndianBytes)
+        return out
+    }
+
+    private static func deflateRaw(_ input: Data) -> Data? {
+        var output = Data(count: max(input.count, 64))
+        var capacity = output.count
+        for _ in 0..<8 {
+            let written = output.withUnsafeMutableBytes { dst -> Int in
+                input.withUnsafeBytes { src -> Int in
+                    guard let dstBase = dst.bindMemory(to: UInt8.self).baseAddress,
+                          let srcBase = src.bindMemory(to: UInt8.self).baseAddress else { return 0 }
+                    return compression_encode_buffer(dstBase, capacity,
+                                                     srcBase, input.count,
+                                                     nil, COMPRESSION_ZLIB)
+                }
+            }
+            if written > 0 {
+                output.removeSubrange(written...)
+                return output
+            }
+            capacity *= 2
+            output = Data(count: capacity)
+        }
+        return nil
+    }
+
+    private static func crc32(_ input: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in input {
+            crc ^= UInt32(byte)
+            for _ in 0..<8 {
+                if crc & 1 != 0 {
+                    crc = (crc >> 1) ^ 0xEDB8_8320
+                } else {
+                    crc >>= 1
+                }
+            }
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+
     private static func plain(_ status: Int, _ reason: String, _ body: String) -> Response {
         Response(status: status,
                  reason: reason,
                  contentType: "text/plain; charset=utf-8",
-                 body: Data(body.utf8))
+                 body: Data(body.utf8),
+                 cacheControl: "no-cache",
+                 contentEncoding: nil,
+                 etag: nil,
+                 vary: nil)
     }
 
     /// Serialize to the wire. HEAD keeps the headers and drops the body.
@@ -106,12 +248,25 @@ struct HostGatewayStaticFiles {
         var head = "HTTP/1.1 \(response.status) \(response.reason)\r\n"
         head += "Content-Type: \(response.contentType)\r\n"
         head += "Content-Length: \(response.body.count)\r\n"
-        // The gateway is a live view of the machine; a stale cached shell is worse
-        // than a re-fetch of a few hundred KB over the loopback or a tunnel.
-        head += "Cache-Control: no-cache\r\n"
-        head += "Connection: close\r\n\r\n"
+        head += "Cache-Control: \(response.cacheControl)\r\n"
+        if let encoding = response.contentEncoding {
+            head += "Content-Encoding: \(encoding)\r\n"
+        }
+        if let etag = response.etag {
+            head += "ETag: \(etag)\r\n"
+        }
+        if let vary = response.vary {
+            head += "Vary: \(vary)\r\n"
+        }
+        head += "Connection: keep-alive\r\n\r\n"
         var data = Data(head.utf8)
         if includeBody { data.append(response.body) }
         return data
+    }
+}
+
+private extension FixedWidthInteger {
+    var littleEndianBytes: [UInt8] {
+        withUnsafeBytes(of: littleEndian) { Array($0) }
     }
 }

--- a/Sources/Core/HostGatewayStaticFiles.swift
+++ b/Sources/Core/HostGatewayStaticFiles.swift
@@ -244,7 +244,7 @@ struct HostGatewayStaticFiles {
     }
 
     /// Serialize to the wire. HEAD keeps the headers and drops the body.
-    static func serialize(_ response: Response, includeBody: Bool) -> Data {
+    static func serialize(_ response: Response, includeBody: Bool, connectionClose: Bool = false) -> Data {
         var head = "HTTP/1.1 \(response.status) \(response.reason)\r\n"
         head += "Content-Type: \(response.contentType)\r\n"
         head += "Content-Length: \(response.body.count)\r\n"
@@ -258,7 +258,7 @@ struct HostGatewayStaticFiles {
         if let vary = response.vary {
             head += "Vary: \(vary)\r\n"
         }
-        head += "Connection: keep-alive\r\n\r\n"
+        head += "Connection: \(connectionClose ? "close" : "keep-alive")\r\n\r\n"
         var data = Data(head.utf8)
         if includeBody { data.append(response.body) }
         return data

--- a/Tests/HostGatewayKeyFrameTests.swift
+++ b/Tests/HostGatewayKeyFrameTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import seahelm
+
+final class HostGatewayKeyFrameTests: XCTestCase {
+    func testRoundTrip() {
+        let key = "seahelm-main-p1"
+        let utf8 = Data("hello".utf8)
+        let frame = try! XCTUnwrap(HostGatewayKeyFrame.encode(paneSessionKey: key, utf8: utf8))
+        let decoded = try! XCTUnwrap(HostGatewayKeyFrame.decode(frame))
+        XCTAssertEqual(decoded.paneSessionKey, key)
+        XCTAssertEqual(decoded.utf8, utf8)
+    }
+
+    func testRejectsOversizedKey() {
+        let key = String(repeating: "a", count: 300)
+        XCTAssertNil(HostGatewayKeyFrame.encode(paneSessionKey: key, utf8: Data()))
+    }
+
+    func testRejectsWrongVersion() {
+        var frame = try! XCTUnwrap(HostGatewayKeyFrame.encode(paneSessionKey: "k", utf8: Data("x".utf8)))
+        frame[0] = 2
+        XCTAssertNil(HostGatewayKeyFrame.decode(frame))
+    }
+}

--- a/Tests/HostGatewayServerTests.swift
+++ b/Tests/HostGatewayServerTests.swift
@@ -144,10 +144,15 @@ final class HostGatewayServerTests: XCTestCase {
         waitUntilListening(second)
 
         // Not just bound — actually answering, since a half-dead listener can
-        // hold the port without serving.
+        // hold the port without serving. Use an ephemeral session: keep-alive
+        // would otherwise reuse a pooled connection to the stopped first server.
         let exp = expectation(description: "page")
         var status = 0
-        URLSession.shared.dataTask(with: URL(string: "http://127.0.0.1:\(testPort)/")!) { _, response, _ in
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(testPort)/")!)
+        request.setValue("close", forHTTPHeaderField: "Connection")
+        session.dataTask(with: request) { _, response, _ in
             status = (response as? HTTPURLResponse)?.statusCode ?? 0
             exp.fulfill()
         }.resume()

--- a/Tests/HostGatewayServerTests.swift
+++ b/Tests/HostGatewayServerTests.swift
@@ -79,6 +79,31 @@ final class HostGatewayServerTests: XCTestCase {
         wait(for: [exp], timeout: timeout)
     }
 
+    /// Fresh session + `Connection: close` so keep-alive cannot reuse a socket to a
+    /// stopped previous server on the same `testPort`.
+    private func httpGet(_ path: String, timeout: TimeInterval = 10)
+        -> (status: Int, body: String, contentType: String) {
+        let exp = expectation(description: "http \(path)")
+        var status = -1
+        var body = ""
+        var contentType = ""
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.invalidateAndCancel() }
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(testPort)\(path)")!)
+        request.setValue("close", forHTTPHeaderField: "Connection")
+        session.dataTask(with: request) { data, response, error in
+            if let error { XCTFail("GET failed: \(error)") }
+            if let http = response as? HTTPURLResponse {
+                status = http.statusCode
+                contentType = http.value(forHTTPHeaderField: "Content-Type") ?? ""
+            }
+            body = String(decoding: data ?? Data(), as: UTF8.self)
+            exp.fulfill()
+        }.resume()
+        wait(for: [exp], timeout: timeout)
+        return (status, body, contentType)
+    }
+
     func testWebSocketAuthAndSnapshot() {
         let ds = ServerFakeDataSource()
         ds.panes = [PaneSnapshot(
@@ -144,20 +169,9 @@ final class HostGatewayServerTests: XCTestCase {
         waitUntilListening(second)
 
         // Not just bound — actually answering, since a half-dead listener can
-        // hold the port without serving. Use an ephemeral session: keep-alive
-        // would otherwise reuse a pooled connection to the stopped first server.
-        let exp = expectation(description: "page")
-        var status = 0
-        let session = URLSession(configuration: .ephemeral)
-        defer { session.invalidateAndCancel() }
-        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(testPort)/")!)
-        request.setValue("close", forHTTPHeaderField: "Connection")
-        session.dataTask(with: request) { _, response, _ in
-            status = (response as? HTTPURLResponse)?.statusCode ?? 0
-            exp.fulfill()
-        }.resume()
-        wait(for: [exp], timeout: 5)
-        XCTAssertEqual(status, 200, "rebound server should serve the page again")
+        // hold the port without serving.
+        let page = httpGet("/")
+        XCTAssertEqual(page.status, 200, "rebound server should serve the page again")
     }
 
     /// The binary path end to end: negotiated at auth, framed by the server,
@@ -272,27 +286,10 @@ final class HostGatewayServerTests: XCTestCase {
 
         waitUntilListening(server)
 
-        let exp = expectation(description: "http get")
-        var status = -1
-        var body = ""
-        var contentType = ""
-        let task = URLSession.shared.dataTask(
-            with: URL(string: "http://127.0.0.1:\(testPort)/")!
-        ) { data, response, error in
-            if let error { XCTFail("GET failed: \(error)") }
-            if let http = response as? HTTPURLResponse {
-                status = http.statusCode
-                contentType = http.value(forHTTPHeaderField: "Content-Type") ?? ""
-            }
-            body = String(decoding: data ?? Data(), as: UTF8.self)
-            exp.fulfill()
-        }
-        task.resume()
-        wait(for: [exp], timeout: 10)
-
-        XCTAssertEqual(status, 200)
-        XCTAssertEqual(body, "<html>cockpit</html>")
-        XCTAssertTrue(contentType.hasPrefix("text/html"), "got \(contentType)")
+        let page = httpGet("/")
+        XCTAssertEqual(page.status, 200)
+        XCTAssertEqual(page.body, "<html>cockpit</html>")
+        XCTAssertTrue(page.contentType.hasPrefix("text/html"), "got \(page.contentType)")
     }
 
     func testKeepAliveDefaultHttp11() {
@@ -323,17 +320,7 @@ final class HostGatewayServerTests: XCTestCase {
 
         waitUntilListening(server)
 
-        let exp = expectation(description: "http 404")
-        var status = -1
-        let task = URLSession.shared.dataTask(
-            with: URL(string: "http://127.0.0.1:\(testPort)/definitely-not-here.js")!
-        ) { _, response, _ in
-            status = (response as? HTTPURLResponse)?.statusCode ?? -1
-            exp.fulfill()
-        }
-        task.resume()
-        wait(for: [exp], timeout: 10)
-
-        XCTAssertEqual(status, 404)
+        let page = httpGet("/definitely-not-here.js")
+        XCTAssertEqual(page.status, 404)
     }
 }

--- a/Tests/HostGatewayServerTests.swift
+++ b/Tests/HostGatewayServerTests.swift
@@ -290,6 +290,22 @@ final class HostGatewayServerTests: XCTestCase {
         XCTAssertTrue(contentType.hasPrefix("text/html"), "got \(contentType)")
     }
 
+    func testKeepAliveDefaultHttp11() {
+        XCTAssertFalse(HostGatewayServer.clientRequestsClose(
+            head: "GET / HTTP/1.1\r\nHost: x\r\n"))
+        XCTAssertTrue(HostGatewayServer.clientRequestsClose(
+            head: "GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n"))
+        XCTAssertTrue(HostGatewayServer.clientRequestsClose(
+            head: "GET / HTTP/1.0\r\nHost: x\r\n"))
+    }
+
+    func testParseRequestHeaders() {
+        let headers = HostGatewayServer.parseRequestHeaders(
+            head: "GET /e2ee.js HTTP/1.1\r\nHost: x\r\nAccept-Encoding: gzip, deflate\r\nIf-None-Match: \"abc\"\r\n")
+        XCTAssertEqual(headers.acceptEncoding, "gzip, deflate")
+        XCTAssertEqual(headers.ifNoneMatch, "\"abc\"")
+    }
+
     /// Static hosting must not become a file server for the rest of the disk.
     func testUnknownPathIs404() throws {
         let server = HostGatewayServer(

--- a/Tests/HostGatewaySessionBackpressureTests.swift
+++ b/Tests/HostGatewaySessionBackpressureTests.swift
@@ -70,7 +70,7 @@ final class HostGatewaySessionBackpressureTests: XCTestCase {
     private func session() -> (HostGatewaySession, SessionFakeDataSource, FakeVT) {
         let ds = SessionFakeDataSource()
         let vt = FakeVT()
-        let b64 = MqttCrypto.base64url(root)
+        let b64 = PairingCrypto.base64url(root)
         let s = HostGatewaySession(
             router: ControlRouter(dataSource: ds),
             expectedMacId: macId,
@@ -80,7 +80,7 @@ final class HostGatewaySessionBackpressureTests: XCTestCase {
     }
 
     private func token() -> String {
-        MqttCrypto(rootSecret: root).authPassword
+        PairingCrypto(rootSecret: root).authPassword
     }
 
     private func authFrame(id: String = "auth1") -> String {

--- a/Tests/HostGatewaySessionBackpressureTests.swift
+++ b/Tests/HostGatewaySessionBackpressureTests.swift
@@ -1,0 +1,163 @@
+import XCTest
+@testable import seahelm
+
+final class HostGatewaySessionBackpressureTests: XCTestCase {
+    private final class SessionFakeDataSource: ControlDataSource {
+        var panes: [PaneSnapshot] = []
+        var knownPanes: Set<String> = []
+        var sentKeys: [(pane: String, keys: [String])] = []
+
+        func snapshotPanes() -> [PaneSnapshot] { panes }
+        func readPane(paneId: String, source: String, lines: Int) -> String? { nil }
+        func ingestHook(json: [String: Any]) -> String? { nil }
+        func sendKeys(paneId: String, keys: [String]) -> Bool {
+            guard knownPanes.contains(paneId) else { return false }
+            sentKeys.append((paneId, keys))
+            return true
+        }
+    }
+
+    final class FakeVT: HostGatewayVTAttaching {
+        var openKeys: Set<String> = []
+        var opened: [String] = []
+        var closed: [String] = []
+        var keepalives: [String] = []
+        var sentKeys: [(key: String, utf8: Data)] = []
+        var openResult: [String: Any] = ["ok": true]
+        private var observers: [Int: (VTEvent) -> Void] = [:]
+        private var nextToken = 1
+
+        @discardableResult
+        func addObserver(_ observer: @escaping (VTEvent) -> Void) -> Int {
+            defer { nextToken += 1 }
+            observers[nextToken] = observer
+            return nextToken
+        }
+
+        func removeObserver(_ token: Int) { observers.removeValue(forKey: token) }
+
+        func emit(_ event: VTEvent) {
+            for observer in observers.values { observer(event) }
+        }
+
+        func open(paneSessionKey: String) -> [String: Any] {
+            opened.append(paneSessionKey)
+            if (openResult["ok"] as? Bool) != false {
+                openKeys.insert(paneSessionKey)
+            }
+            return openResult
+        }
+
+        func close(paneSessionKey: String) {
+            closed.append(paneSessionKey)
+            openKeys.remove(paneSessionKey)
+        }
+
+        func keepalive(paneSessionKey: String) {
+            keepalives.append(paneSessionKey)
+        }
+
+        func sendKeys(paneSessionKey: String, utf8: Data) -> Bool {
+            guard openKeys.contains(paneSessionKey) else { return false }
+            sentKeys.append((paneSessionKey, utf8))
+            return true
+        }
+    }
+
+    private let root = Data((0..<32).map { UInt8($0) })
+    private let macId = "live"
+
+    private func session() -> (HostGatewaySession, SessionFakeDataSource, FakeVT) {
+        let ds = SessionFakeDataSource()
+        let vt = FakeVT()
+        let b64 = MqttCrypto.base64url(root)
+        let s = HostGatewaySession(
+            router: ControlRouter(dataSource: ds),
+            expectedMacId: macId,
+            rootSecretBase64url: b64,
+            vt: vt)
+        return (s, ds, vt)
+    }
+
+    private func token() -> String {
+        MqttCrypto(rootSecret: root).authPassword
+    }
+
+    private func authFrame(id: String = "auth1") -> String {
+        #"{"id":"\#(id)","method":"auth","params":{"mac_id":"\#(macId)","token":"\#(token())"}}"#
+    }
+
+    private func decodeResponse(_ frame: HostGatewayWireFrame) -> [String: Any] {
+        guard case .text(let text) = frame else {
+            XCTFail("expected a text frame, got binary")
+            return [:]
+        }
+        return try! JSONSerialization.jsonObject(with: Data(text.utf8)) as! [String: Any]
+    }
+
+    private func openAuthenticated(_ s: HostGatewaySession, vtKey: String = "k1") {
+        _ = s.handle(text: authFrame())
+        _ = s.handle(text: #"{"id":"o","method":"pane.vt_open","params":{"pane_session_key":"\#(vtKey)"}}"#)
+    }
+
+    private func methods(of frames: [HostGatewayWireFrame]) -> [String] {
+        frames.compactMap { decodeResponse($0)["method"] as? String }
+    }
+
+    private func vtPayloadBytes(of frames: [HostGatewayWireFrame]) -> Int {
+        frames.reduce(0) { sum, frame in
+            let obj = decodeResponse(frame)
+            guard let method = obj["method"] as? String,
+                  method == "vt.data" || method == "vt.snapshot",
+                  let b64 = (obj["params"] as? [String: Any])?["b64"] as? String,
+                  let data = Data(base64Encoded: b64) else { return sum }
+            return sum + data.count
+        }
+    }
+
+    func testHighPriorityDrainsBeforeVT() {
+        let (s, _, vt) = session()
+        openAuthenticated(s)
+        vt.emit(VTEvent(kind: .data, paneSessionKey: "k1", payload: Data("a".utf8)))
+        s.pushDecision(.opened(HostGatewayDecisions.Decision(
+            paneSessionKey: "k1", paneId: "p1", kind: "question",
+            prompt: "ok?", options: ["yes"], seq: 1)))
+
+        let notes = s.drainNotifications()
+        let methods = methods(of: notes)
+        XCTAssertEqual(methods.first, "pane.event",
+                       "high-priority pane.event must drain before queued VT")
+        XCTAssertTrue(methods.contains("vt.data"))
+        let firstVT = methods.firstIndex { $0.hasPrefix("vt.") }
+        XCTAssertEqual(firstVT, 1)
+        XCTAssertEqual(methods, ["pane.event", "vt.data"])
+    }
+
+    func testDropsOldVTWhenOverBudget() {
+        let (s, _, vt) = session()
+        openAuthenticated(s)
+        let chunk = Data(repeating: 0x41, count: 32 * 1024)
+        for _ in 0..<8 {
+            vt.emit(VTEvent(kind: .data, paneSessionKey: "k1", payload: chunk))
+        }
+
+        let notes = s.drainNotifications()
+        let vtBytes = vtPayloadBytes(of: notes)
+        XCTAssertLessThanOrEqual(vtBytes, 256 * 1024)
+        XCTAssertLessThanOrEqual(vtBytes, 128 * 1024)
+        XCTAssertEqual(methods(of: notes).last, "vt.snapshot",
+                       "overflow must leave a resync snapshot at the end")
+    }
+
+    func testResyncRateLimited() {
+        let (s, _, vt) = session()
+        openAuthenticated(s)
+        let chunk = Data(repeating: 0x42, count: 64 * 1024)
+        for _ in 0..<5 {
+            vt.emit(VTEvent(kind: .data, paneSessionKey: "k1", payload: chunk))
+        }
+
+        let snapshots = methods(of: s.drainNotifications()).filter { $0 == "vt.snapshot" }
+        XCTAssertEqual(snapshots.count, 1, "two overflows within 1s must share one snapshot")
+    }
+}

--- a/Tests/HostGatewaySessionBackpressureTests.swift
+++ b/Tests/HostGatewaySessionBackpressureTests.swift
@@ -105,14 +105,30 @@ final class HostGatewaySessionBackpressureTests: XCTestCase {
     }
 
     private func vtPayloadBytes(of frames: [HostGatewayWireFrame]) -> Int {
-        frames.reduce(0) { sum, frame in
+        vtNotifies(of: frames).reduce(0) { $0 + $1.payload.count }
+    }
+
+    private func vtNotifies(of frames: [HostGatewayWireFrame]) -> [(method: String, payload: Data)] {
+        frames.compactMap { frame in
             let obj = decodeResponse(frame)
             guard let method = obj["method"] as? String,
                   method == "vt.data" || method == "vt.snapshot",
                   let b64 = (obj["params"] as? [String: Any])?["b64"] as? String,
-                  let data = Data(base64Encoded: b64) else { return sum }
-            return sum + data.count
+                  let data = Data(base64Encoded: b64) else { return nil }
+            return (method, data)
         }
+    }
+
+    private func taggedChunk(_ id: UInt8, count: Int = 32 * 1024) -> Data {
+        var data = Data(repeating: 0x41, count: count)
+        data[0] = id
+        return data
+    }
+
+    private func openedDecision() -> HostGatewayDecisions.Change {
+        .opened(HostGatewayDecisions.Decision(
+            paneSessionKey: "k1", paneId: "p1", kind: "question",
+            prompt: "ok?", options: ["yes"], seq: 1))
     }
 
     func testHighPriorityDrainsBeforeVT() {
@@ -136,17 +152,44 @@ final class HostGatewaySessionBackpressureTests: XCTestCase {
     func testDropsOldVTWhenOverBudget() {
         let (s, _, vt) = session()
         openAuthenticated(s)
-        let chunk = Data(repeating: 0x41, count: 32 * 1024)
-        for _ in 0..<8 {
-            vt.emit(VTEvent(kind: .data, paneSessionKey: "k1", payload: chunk))
+        s.pushDecision(openedDecision())
+        for i in 0..<8 {
+            vt.emit(VTEvent(kind: .data, paneSessionKey: "k1", payload: taggedChunk(UInt8(i))))
         }
 
         let notes = s.drainNotifications()
+        let names = methods(of: notes)
+        XCTAssertEqual(names.first, "pane.event",
+                       "high-priority frame must drain first and survive VT flood")
+        XCTAssertEqual(names.filter { $0 == "pane.event" }.count, 1)
+
+        let data = vtNotifies(of: notes).filter { $0.method == "vt.data" }
+        XCTAssertEqual(data.map { $0.payload.first }, [4, 5, 6, 7],
+                       "drop-old must keep the newest chunks, not the oldest")
+        XCTAssertFalse(data.contains { ($0.payload.first ?? 0) < 4 })
+
         let vtBytes = vtPayloadBytes(of: notes)
         XCTAssertLessThanOrEqual(vtBytes, 256 * 1024)
         XCTAssertLessThanOrEqual(vtBytes, 128 * 1024)
-        XCTAssertEqual(methods(of: notes).last, "vt.snapshot",
+        XCTAssertEqual(names.last, "vt.snapshot",
                        "overflow must leave a resync snapshot at the end")
+    }
+
+    func testKeepsQueuedSnapshotInsteadOfEmptyResync() {
+        let (s, _, vt) = session()
+        openAuthenticated(s)
+        let screen = Data("SCREEN".utf8)
+        vt.emit(VTEvent(kind: .snapshot, paneSessionKey: "k1", payload: screen))
+        for i in 0..<8 {
+            vt.emit(VTEvent(kind: .data, paneSessionKey: "k1", payload: taggedChunk(UInt8(i))))
+        }
+
+        let notes = s.drainNotifications()
+        let snaps = vtNotifies(of: notes).filter { $0.method == "vt.snapshot" }
+        XCTAssertEqual(snaps.count, 1, "must not append an empty synthetic over a real snapshot")
+        XCTAssertEqual(snaps.first?.payload, screen)
+        XCTAssertEqual(methods(of: notes).last, "vt.snapshot")
+        XCTAssertFalse(snaps.contains { $0.payload.isEmpty })
     }
 
     func testResyncRateLimited() {

--- a/Tests/HostGatewaySessionTests.swift
+++ b/Tests/HostGatewaySessionTests.swift
@@ -374,6 +374,27 @@ final class HostGatewaySessionTests: XCTestCase {
         XCTAssertEqual(decoded?.payload, Data(repeating: 0x41, count: 8))
     }
 
+    func testBinaryKeysOnlyWhenNegotiated() {
+        let frame = try! XCTUnwrap(HostGatewayKeyFrame.encode(
+            paneSessionKey: "k1", utf8: Data("x".utf8)))
+
+        let (s, _, vt) = session()
+        _ = s.handle(text: authFrame())
+        _ = s.handle(text: #"{"id":"o","method":"pane.vt_open","params":{"pane_session_key":"k1"}}"#)
+        _ = s.handle(binary: frame)
+        XCTAssertTrue(vt.sentKeys.isEmpty, "binary keys ignored without negotiation")
+
+        let (b, _, bvt) = session()
+        let authKeys = #"{"id":"a","method":"auth","params":{"mac_id":"\#(macId)","token":"\#(token())","keys_binary":true}}"#
+        let reply = decodeResponse(b.handle(text: authKeys)[0])
+        XCTAssertEqual((reply["result"] as? [String: Any])?["keys_binary"] as? Bool, true)
+        _ = b.handle(text: #"{"id":"o","method":"pane.vt_open","params":{"pane_session_key":"k1"}}"#)
+        _ = b.handle(binary: frame)
+        XCTAssertEqual(bvt.sentKeys.count, 1)
+        XCTAssertEqual(bvt.sentKeys[0].key, "k1")
+        XCTAssertEqual(bvt.sentKeys[0].utf8, Data("x".utf8))
+    }
+
     /// A closed connection must stop costing the manager encode work.
     ///
     /// Wired the way `HostGatewayServer.accept` wires it — with a pending-outbound

--- a/Tests/HostGatewayStaticFilesTests.swift
+++ b/Tests/HostGatewayStaticFilesTests.swift
@@ -142,7 +142,22 @@ final class HostGatewayStaticFilesTests: XCTestCase {
         XCTAssertTrue(wire.contains("Cache-Control: public, max-age=86400\r\n"))
         XCTAssertTrue(wire.contains("ETag: \"abc\"\r\n"))
         XCTAssertTrue(wire.contains("Vary: Accept-Encoding\r\n"))
+        XCTAssertTrue(wire.contains("Connection: keep-alive\r\n"))
         XCTAssertFalse(wire.contains("Connection: close\r\n"))
+    }
+
+    func testSerializeConnectionClose() {
+        let response = HostGatewayStaticFiles.Response(
+            status: 200, reason: "OK",
+            contentType: "text/plain; charset=utf-8",
+            body: Data("ok".utf8),
+            cacheControl: "no-cache",
+            contentEncoding: nil,
+            etag: nil,
+            vary: nil)
+        let wire = String(decoding: HostGatewayStaticFiles.serialize(
+            response, includeBody: true, connectionClose: true), as: UTF8.self)
+        XCTAssertTrue(wire.contains("Connection: close\r\n"))
     }
 
     func testRequestParsing() {

--- a/Tests/HostGatewayStaticFilesTests.swift
+++ b/Tests/HostGatewayStaticFilesTests.swift
@@ -19,20 +19,23 @@ final class HostGatewayStaticFilesTests: XCTestCase {
     private var files: HostGatewayStaticFiles { HostGatewayStaticFiles(root: root) }
 
     func testRootServesIndex() {
-        let response = files.response(method: "GET", target: "/")
+        let response = files.response(method: "GET", target: "/",
+                                      headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
         XCTAssertEqual(response.status, 200)
         XCTAssertEqual(String(decoding: response.body, as: UTF8.self), "<html>index</html>")
         XCTAssertEqual(response.contentType, "text/html; charset=utf-8")
     }
 
     func testAssetContentType() {
-        let response = files.response(method: "GET", target: "/e2ee.js")
+        let response = files.response(method: "GET", target: "/e2ee.js",
+                                      headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
         XCTAssertEqual(response.status, 200)
         XCTAssertEqual(response.contentType, "text/javascript; charset=utf-8")
     }
 
     func testQueryStringIsStripped() {
-        let response = files.response(method: "GET", target: "/e2ee.js?v=20260724")
+        let response = files.response(method: "GET", target: "/e2ee.js?v=20260724",
+                                      headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
         XCTAssertEqual(response.status, 200)
         XCTAssertEqual(String(decoding: response.body, as: UTF8.self), "var E2EE;")
     }
@@ -67,12 +70,79 @@ final class HostGatewayStaticFilesTests: XCTestCase {
     }
 
     func testSerializeHeadOmitsBodyButKeepsLength() {
-        let response = files.response(method: "HEAD", target: "/")
+        let response = files.response(method: "HEAD", target: "/",
+                                      headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
         let wire = String(decoding: HostGatewayStaticFiles.serialize(response, includeBody: false), as: UTF8.self)
         XCTAssertTrue(wire.hasPrefix("HTTP/1.1 200 OK\r\n"))
         XCTAssertTrue(wire.contains("Content-Length: 18\r\n"))
         XCTAssertTrue(wire.hasSuffix("\r\n\r\n"))
         XCTAssertFalse(wire.contains("<html>"))
+    }
+
+    func testGzipWhenAccepted() {
+        // Make body large enough that gzip shrinks it.
+        let raw = Data(repeating: 0x61, count: 4096) // "aaaa..."
+        try! raw.write(to: root.appendingPathComponent("big.js"))
+        let response = files.response(
+            method: "GET",
+            target: "/big.js",
+            headers: .init(acceptEncoding: "gzip, deflate", ifNoneMatch: nil))
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(response.contentEncoding, "gzip")
+        XCTAssertLessThan(response.body.count, raw.count)
+        XCTAssertEqual(response.cacheControl, "public, max-age=86400")
+        XCTAssertNotNil(response.etag)
+    }
+
+    func testNoGzipWithoutAcceptEncoding() {
+        let response = files.response(
+            method: "GET", target: "/e2ee.js",
+            headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
+        XCTAssertNil(response.contentEncoding)
+        XCTAssertEqual(String(decoding: response.body, as: UTF8.self), "var E2EE;")
+    }
+
+    func testHtmlIsNoCache() {
+        let response = files.response(
+            method: "GET", target: "/",
+            headers: .init(acceptEncoding: "gzip", ifNoneMatch: nil))
+        XCTAssertEqual(response.cacheControl, "no-cache")
+    }
+
+    func testVersionedAssetIsImmutable() {
+        let response = files.response(
+            method: "GET", target: "/e2ee.js?v=20260724",
+            headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
+        XCTAssertEqual(response.cacheControl, "public, max-age=31536000, immutable")
+    }
+
+    func testETagYields304() {
+        let first = files.response(
+            method: "GET", target: "/e2ee.js",
+            headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
+        let etag = try! XCTUnwrap(first.etag)
+        let again = files.response(
+            method: "GET", target: "/e2ee.js",
+            headers: .init(acceptEncoding: nil, ifNoneMatch: etag))
+        XCTAssertEqual(again.status, 304)
+        XCTAssertTrue(again.body.isEmpty)
+    }
+
+    func testSerializeIncludesEncodingAndCache() {
+        let response = HostGatewayStaticFiles.Response(
+            status: 200, reason: "OK",
+            contentType: "text/javascript; charset=utf-8",
+            body: Data([0x1f, 0x8b]),
+            cacheControl: "public, max-age=86400",
+            contentEncoding: "gzip",
+            etag: "\"abc\"",
+            vary: "Accept-Encoding")
+        let wire = String(decoding: HostGatewayStaticFiles.serialize(response, includeBody: true), as: UTF8.self)
+        XCTAssertTrue(wire.contains("Content-Encoding: gzip\r\n"))
+        XCTAssertTrue(wire.contains("Cache-Control: public, max-age=86400\r\n"))
+        XCTAssertTrue(wire.contains("ETag: \"abc\"\r\n"))
+        XCTAssertTrue(wire.contains("Vary: Accept-Encoding\r\n"))
+        XCTAssertFalse(wire.contains("Connection: close\r\n"))
     }
 
     func testRequestParsing() {

--- a/clients/seahelm-web/README.md
+++ b/clients/seahelm-web/README.md
@@ -99,6 +99,17 @@ MAC=live npm run mock:zmx # 终端 B: ZMX_PANES=1,真实 zmx session → MQTT pa
 
 窄窗口仍强制单屏(`layoutFitsMirror` 不满足时忽略镜像偏好)。
 
+## 弱网相关行为
+
+| 能力 | 说明 |
+|---|---|
+| **静态加速** | Gateway 对 js/css/html 等做 gzip；带 `?v=` 的资源可长期缓存；HTTP keep-alive 连拉多文件 |
+| **延后 WebGL** | `xterm-addon-webgl.js` 在首个终端打开后再加载 |
+| **默认单屏** | 见上「VT 订阅模式」— 默认只订阅焦点 pane，镜像需手动开 |
+| **背压** | Mac 侧 VT 发送队列有界；积压时丢旧 `vt.data` 并重 snapshot，画面可能短暂跳动 |
+| **浏览器丢帧** | 解压/写终端积压超过深度上限时丢中间 `vt.data` |
+| **binary keys** | `auth` 协商 `keys_binary` 后按键走二进制帧（无 JSON/base64）；旧 Mac 仍用 `pane.send_keys` |
+
 ## VT 终端
 
 Mac 侧经 **`zmx attach`** 保真 PTY 流;浏览器 xterm.js 渲染。
@@ -111,7 +122,7 @@ Gateway notify / MQTT topic 均携带 `{b64, cols?, rows?}`;客户端共用 `han
 | `pane.vt_open` | attach;首屏 `vt.snapshot`,其后 `vt.data` |
 | `pane.vt_keepalive` | 20s 心跳 |
 | `pane.vt_close` | 断开 attach 客户端 |
-| `pane.send_keys` | `{b64}` UTF-8 键序列 |
+| `pane.send_keys` | `{b64}` UTF-8 键序列；协商 `keys_binary` 后可走二进制帧 |
 
 ## 协议一致性测试(MQTT devbroker)
 

--- a/clients/seahelm-web/README.md
+++ b/clients/seahelm-web/README.md
@@ -44,6 +44,7 @@ Wire 格式:
 | `e2ee.js` | 配对 URI 解析 + HKDF auth/E2EE(与 Mac `MqttCrypto` 一致) |
 | `mqtt.min.js` | vendored MQTT.js — **仅 devbroker / 遗留 MQTT 调试** |
 | `xterm.js` / `xterm.css` | vendored xterm.js 5.5.0 |
+| `xterm-addon-webgl.js` | vendored WebGL renderer — loaded on first terminal open, not at page load |
 | `devbroker/` | 本地 MQTT 调试台(**非生产路径**) |
 
 ## 本地 MQTT 调试(dev-only)

--- a/clients/seahelm-web/README.md
+++ b/clients/seahelm-web/README.md
@@ -88,6 +88,17 @@ MAC=live npm run mock:zmx # 终端 B: ZMX_PANES=1,真实 zmx session → MQTT pa
 
 终端按宽度贴合;字号下限 9px;右下角「↓ 最新」在回看时出现。
 
+### VT 订阅模式
+
+终端标题栏 **单屏 / 镜像** 徽章切换 VT attach 策略(`localStorage seahelm_vt_mode`,默认 **`single`**):
+
+| 模式 | 行为 |
+|---|---|
+| **单屏** (默认) | 只 attach 当前焦点 pane — 弱网/小屏友好,多 pane 时靠顶栏 chip 切换 |
+| **镜像** | 每个 pane 一路 VT,按 Mac 侧 split 布局同屏渲染 |
+
+窄窗口仍强制单屏(`layoutFitsMirror` 不满足时忽略镜像偏好)。
+
 ## VT 终端
 
 Mac 侧经 **`zmx attach`** 保真 PTY 流;浏览器 xterm.js 渲染。

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -712,6 +712,28 @@ async function inflateRaw(bytes){
 // corrupted — not slow, corrupted. Every frame for a pane is therefore threaded
 // through one promise chain, so decode can overlap but application cannot.
 const vtWriteChains = new Map();
+// Under decode backlog, drop intermediate vt.data rather than growing forever.
+// Snapshots always enqueue (they reset the terminal).
+const VT_APPLY_MAX = 8;
+const vtApplyDepth = new Map();
+
+function enqueueVTApply(key, type, work){
+  const depth = vtApplyDepth.get(key) || 0;
+  if (type === 'vt.data' && depth >= VT_APPLY_MAX) {
+    log('sys', '(vt drop)', key);
+    return;
+  }
+  vtApplyDepth.set(key, depth + 1);
+  const prior = vtWriteChains.get(key) || Promise.resolve();
+  const next = prior.then(async () => {
+    try { await work(); }
+    finally { vtApplyDepth.set(key, Math.max(0, (vtApplyDepth.get(key) || 1) - 1)); }
+  }).catch((e) => {
+    vtApplyDepth.set(key, Math.max(0, (vtApplyDepth.get(key) || 1) - 1));
+    log('sys', '(vt)', `frame dropped: ${e && e.message}`);
+  });
+  vtWriteChains.set(key, next);
+}
 
 /// A pane that goes away takes its chain with it — the map is keyed by pane and
 /// nothing else ever removed an entry, so worktree churn grew it for the life of
@@ -723,12 +745,10 @@ function onGatewayBinaryFrame(buf){
   if (!f) { log('sys', '(vt)', `unparseable binary frame, ${buf.length}B`); return; }
   log('rx', f.type, `${f.type} ${f.body.length}B${f.deflated ? ' deflated' : ''} (payload elided)`);
 
-  const prior = vtWriteChains.get(f.key) || Promise.resolve();
-  const next = prior.then(async () => {
+  enqueueVTApply(f.key, f.type, async () => {
     const bytes = f.deflated ? await inflateRaw(f.body) : f.body;
     handleVT(f.key, { type: f.type, bytes, cols: f.cols, rows: f.rows });
-  }).catch((e) => log('sys', '(vt)', `frame dropped: ${e && e.message}`));
-  vtWriteChains.set(f.key, next);
+  });
 }
 
 function onGatewayFrame(msg){
@@ -753,8 +773,7 @@ function onGatewayFrame(msg){
 }
 
 function onGatewayNotify(method, params){
-  // Open questions / suggestions. MQTT delivered these as retained topics; over
-  // the socket the Mac pushes them and replays whatever is open on auth.
+  // Open questions / suggestions — pushed by the Mac and replayed on auth.
   if (method === 'pane.event') {
     const key = params.pane_session_key || params.pane_id;
     if (!key) return;
@@ -765,9 +784,11 @@ function onGatewayNotify(method, params){
   }
   if (method === 'vt.snapshot' || method === 'vt.data') {
     const key = params.pane_session_key || params.pane_id;
-    handleVT(key, {
-      type: method === 'vt.snapshot' ? 'vt.snapshot' : 'vt.data',
-      b64: params.b64, cols: params.cols, rows: params.rows,
+    const type = method === 'vt.snapshot' ? 'vt.snapshot' : 'vt.data';
+    enqueueVTApply(key, type, async () => {
+      handleVT(key, {
+        type, b64: params.b64, cols: params.cols, rows: params.rows,
+      });
     });
   }
 }

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -585,11 +585,12 @@ function openGatewaySocket(){
   log('sys', '(connect)', wsURL + ' [Gateway]');
   const ws = new WebSocket(wsURL);
   ws.binaryType = 'arraybuffer';
-  S.gw = { ws, ready: false, req: new Map(), n: 0, binary: false, deflate: false };
+  S.gw = { ws, ready: false, req: new Map(), n: 0, binary: false, deflate: false, keysBinary: false };
   ws.onopen = () => {
     const params = {
       vt_binary: true,
       vt_deflate: typeof DecompressionStream === 'function',
+      keys_binary: true,
     };
     if (S.pendingCode) params.code = S.pendingCode;
     else { params.mac_id = S.mac; params.token = S.authPass; }
@@ -613,6 +614,7 @@ function openGatewaySocket(){
       S.gw.ready = true;
       S.gw.binary = !!(r && r.vt_binary);
       S.gw.deflate = !!(r && r.vt_deflate);
+      S.gw.keysBinary = !!(r && r.keys_binary);
       if (r.mac_id) S.mac = r.mac_id;
       if (r.token) S.authPass = r.token;
       S.pendingCode = null;
@@ -726,11 +728,13 @@ function enqueueVTApply(key, type, work){
   vtApplyDepth.set(key, depth + 1);
   const prior = vtWriteChains.get(key) || Promise.resolve();
   const next = prior.then(async () => {
-    try { await work(); }
-    finally { vtApplyDepth.set(key, Math.max(0, (vtApplyDepth.get(key) || 1) - 1)); }
-  }).catch((e) => {
-    vtApplyDepth.set(key, Math.max(0, (vtApplyDepth.get(key) || 1) - 1));
-    log('sys', '(vt)', `frame dropped: ${e && e.message}`);
+    try {
+      await work();
+    } catch (e) {
+      log('sys', '(vt)', `frame dropped: ${e && e.message}`);
+    } finally {
+      vtApplyDepth.set(key, Math.max(0, (vtApplyDepth.get(key) || 1) - 1));
+    }
   });
   vtWriteChains.set(key, next);
 }
@@ -1376,8 +1380,7 @@ function copySelection(){
 function sendRawKey(bytes){
   const key = S.vt.focus;
   if (!key || !isLinked()) return;
-  sendCommand('pane.send_keys',
-    { pane_session_key: key, b64: bytesToB64(new TextEncoder().encode(bytes)) });
+  sendKeysPayload(key, new TextEncoder().encode(bytes));
   const entry = S.vt.panes.get(key);
   if (entry) { try { entry.term.focus(); } catch (e) {} }   // hand the keyboard back
 }
@@ -1669,8 +1672,7 @@ function buildLayoutLeaf(node){
     windowMs: VT_INPUT_WINDOW_MS,
     send: (buf) => {
       if (!isLinked()) return;
-      sendCommand('pane.send_keys',
-        { pane_session_key: key, b64: bytesToB64(new TextEncoder().encode(buf)) });
+      sendKeysPayload(key, new TextEncoder().encode(buf));
     },
   });
   S.vt.panes.set(key, entry);
@@ -1802,6 +1804,30 @@ function b64ToBytes(b64){
 function bytesToB64(bytes){
   let s=''; for (let i=0;i<bytes.length;i++) s+=String.fromCharCode(bytes[i]);
   return btoa(s);
+}
+
+/** Binary key frame — same layout as HostGatewayKeyFrame.swift. */
+function encodeKeyFrame(paneKey, utf8Bytes){
+  const keyBytes = new TextEncoder().encode(paneKey);
+  if (keyBytes.length > 255) return null;
+  const out = new Uint8Array(3 + keyBytes.length + utf8Bytes.length);
+  out[0] = 1; out[1] = 1; out[2] = keyBytes.length;
+  out.set(keyBytes, 3);
+  out.set(utf8Bytes, 3 + keyBytes.length);
+  return out.buffer;
+}
+
+function sendKeysPayload(paneKey, utf8Bytes){
+  if (S.gw && S.gw.keysBinary && S.gw.ws && S.gw.ws.readyState === WebSocket.OPEN) {
+    const frame = encodeKeyFrame(paneKey, utf8Bytes);
+    if (frame) {
+      S.gw.ws.send(frame);
+      log('tx', 'keys', `${paneKey} ${utf8Bytes.length}B`);
+      return;
+    }
+  }
+  sendCommand('pane.send_keys',
+    { pane_session_key: paneKey, b64: bytesToB64(utf8Bytes) });
 }
 
 /** Shared VT path for MQTT topic payloads and Gateway notify frames. */

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -363,6 +363,7 @@
     <div class="col" id="midcol">
       <div class="detail-head">
         <h2 id="detailHead">终端</h2>
+        <button class="renderer-badge" id="vtModeBadge" title="VT 订阅模式">单屏</button>
         <button class="renderer-badge" id="rendererBadge" title="终端渲染器">xterm.js</button>
         <span class="term-keys" id="termKeys"></span>
       </div>
@@ -1152,7 +1153,8 @@ window.addEventListener('resize', handleViewportResize);
 function handleViewportResize(){
   const wrap = $('termWrap');
   if (S.vt.tree && wrap){
-    const want = layoutFitsMirror(S.vt.tree, wrap.clientWidth) ? 'mirror' : 'single';
+    const preferMirror = loadVtMode() === 'mirror';
+    const want = (preferMirror && layoutFitsMirror(S.vt.tree, wrap.clientWidth)) ? 'mirror' : 'single';
     if (want !== S.vt.mode){
       const keep = S.vt.focus, tree = S.vt.tree, path = S.vt.worktree;
       unmountPanes();
@@ -1235,6 +1237,37 @@ function renderRendererBadge(active){
 // Resolve the renderer once the declarations above exist: `rendererReady` is a
 // `let`, so any call placed earlier in the file hits its temporal dead zone.
 ensureRenderer().then(renderRendererBadge);
+
+const VT_MODE_KEY = 'seahelm_vt_mode';
+function loadVtMode(){
+  const v = localStorage.getItem(VT_MODE_KEY);
+  return v === 'mirror' ? 'mirror' : 'single';
+}
+function setVtMode(mode){
+  localStorage.setItem(VT_MODE_KEY, mode);
+  renderVtModeBadge();
+  if (S.sel){
+    const path = S.sel, focus = S.vt.focus || S.selPane;
+    const tree = S.vt.tree, wt = S.vt.worktree;
+    if (tree && wt === path){
+      unmountPanes();
+      mountPanes(tree, focus, path);
+    } else {
+      requestLayout(path);
+    }
+  }
+}
+function renderVtModeBadge(){
+  const el = $('vtModeBadge');
+  if (!el) return;
+  const mode = loadVtMode();
+  el.textContent = mode === 'mirror' ? '镜像' : '单屏';
+  el.title = mode === 'mirror'
+    ? '镜像：每个 pane 一路 VT — 点击切到单屏'
+    : '单屏：只订阅焦点 pane — 点击切到镜像';
+  el.onclick = () => setVtMode(mode === 'mirror' ? 'single' : 'mirror');
+}
+renderVtModeBadge();
 
 // ── Shortcut bar ────────────────────────────────────────────────────────────
 // Some keys never reach a web page. Cmd+W closes the tab and is unpreventable
@@ -1473,7 +1506,8 @@ function mountPanes(tree, focusKey, path){
   }
   S.vt.worktree = path;
   S.vt.tree = tree;
-  S.vt.mode = layoutFitsMirror(tree, wrap.clientWidth) ? 'mirror' : 'single';
+  const preferMirror = loadVtMode() === 'mirror';
+  S.vt.mode = (preferMirror && layoutFitsMirror(tree, wrap.clientWidth)) ? 'mirror' : 'single';
 
   if (S.vt.mode === 'single'){
     const leaves = treeLeaves(tree);

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -385,9 +385,9 @@
 
 <link rel="stylesheet" href="./xterm.css" />
 <script src="./xterm.js"></script>
-<script src="./xterm-addon-webgl.js"></script>
 <script src="./input-coalescer.js"></script>
 <script src="./reconnect.js"></script>
+<script src="./e2ee.js"></script>
 <script>
 // ── state ─────────────────────────────────────────────────────────────────
 const GEOM_KEY = 'seahelm_pane_geometry';
@@ -1650,20 +1650,39 @@ function buildLayoutLeaf(node){
  * contexts (Chrome around 16), so a big enough layout will legitimately run out,
  * and a lost context leaves a blank canvas behind if the addon stays attached.
  * A pane rendering by DOM is slower; a pane rendering nothing is broken.
+ *
+ * The addon script is deferred until the first terminal open so the initial
+ * page load skips ~242KB on weak links.
  */
+let webglAddonPromise = null;
+function loadWebglAddon(){
+  if (typeof WebglAddon !== 'undefined' && WebglAddon.WebglAddon) {
+    return Promise.resolve(WebglAddon);
+  }
+  if (webglAddonPromise) return webglAddonPromise;
+  webglAddonPromise = new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = './xterm-addon-webgl.js';
+    s.onload = () => resolve(window.WebglAddon || WebglAddon);
+    s.onerror = () => reject(new Error('webgl addon failed'));
+    document.head.appendChild(s);
+  });
+  return webglAddonPromise;
+}
+
 function attachWebglRenderer(term){
   if (RENDERER === 'ghostty') return;              // ghostty-web draws its own canvas
-  if (typeof WebglAddon === 'undefined' || !WebglAddon.WebglAddon) return;
-  try {
-    const addon = new WebglAddon.WebglAddon();
+  loadWebglAddon().then((mod) => {
+    const Ctor = mod.WebglAddon || mod;
+    const addon = new Ctor();
     addon.onContextLoss(() => {
       log('sys', '(webgl)', 'context lost — 该面板回退到 DOM 渲染');
       try { addon.dispose(); } catch (e) {}
     });
     term.loadAddon(addon);
-  } catch (e) {
+  }).catch((e) => {
     log('sys', '(webgl)', `不可用,回退 DOM 渲染: ${e && e.message}`);
-  }
+  });
 }
 
 function focusPane(key){

--- a/docs/superpowers/plans/2026-08-29-seahelm-web-poor-network.md
+++ b/docs/superpowers/plans/2026-08-29-seahelm-web-poor-network.md
@@ -1,0 +1,806 @@
+# seahelm-web Poor-Network Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make seahelm-web usable on weak links by speeding page load, bounding VT backlog with drop-old/resync, prioritizing control/keys over VT, and letting the user choose single-pane vs mirror attach.
+
+**Architecture:** Keep one Host Gateway WebSocket and the zmx-attach PTY model. Harden `HostGatewayStaticFiles`/`HostGatewayServer` for gzip+cache+keep-alive; extend `HostGatewaySession` with dual egress queues and byte budgets; add negotiated binary key frames; add a client VT mode toggle defaulting to single-pane.
+
+**Tech Stack:** Swift 5.10 / Network.framework / Compression (zlib), XCTest, static `clients/seahelm-web` (xterm.js).
+
+**Spec:** `docs/superpowers/specs/2026-08-29-seahelm-web-poor-network-design.md`
+
+## Global Constraints
+
+- VT source remains `zmx attach` — never `zmx tail` / `zmx history --vt`.
+- Never call `zmx detach` when a remote client closes.
+- One WebSocket only (no dual-socket in this plan).
+- Default client VT mode is **single**; mirror is opt-in and persisted.
+- Binary keys and VT binary/deflate remain negotiated; old clients keep working.
+- macOS 14+, Swift 5.10, `@testable import seahelm`, XCTest only.
+- Prefer small focused types under `Sources/Core/`; extend existing Host Gateway tests.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `Sources/Core/HostGatewayStaticFiles.swift` | gzip, ETag, Cache-Control, Accept-Encoding-aware responses |
+| `Sources/Core/HostGatewayServer.swift` | HTTP keep-alive for static; WS binary inbound for keys; paced VT send |
+| `Sources/Core/HostGatewaySession.swift` | High/low egress queues, VT byte budget, drop-old + resync, keys_binary auth |
+| `Sources/Core/HostGatewayKeyFrame.swift` | Binary inbound key frame encode/decode |
+| `Sources/Core/ZmxVTAttachManager.swift` | Optional per-pane coalesce stretch when session requests it (light) |
+| `clients/seahelm-web/index.html` | Deferred WebGL, VT mode toggle, write-chain drop, binary keys |
+| `clients/seahelm-web/README.md` | Document mode toggle + load behavior |
+| `project.yml` | Exclude `bench.html` / `bench-corpus.js` from bundle |
+| `Tests/HostGatewayStaticFilesTests.swift` | gzip / cache / 304 |
+| `Tests/HostGatewaySessionBackpressureTests.swift` | Queue budget, priority, resync |
+| `Tests/HostGatewayKeyFrameTests.swift` | Binary keys round-trip |
+
+---
+
+### Task 1: Static gzip + cache headers
+
+**Files:**
+- Modify: `Sources/Core/HostGatewayStaticFiles.swift`
+- Modify: `Tests/HostGatewayStaticFilesTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `HostGatewayStaticFiles.RequestHeaders` with at least `acceptEncoding: String?`, `ifNoneMatch: String?`
+  - `response(method:target:headers:) -> Response`
+  - `Response` gains `cacheControl: String`, `contentEncoding: String?`, `etag: String?`, `vary: String?`
+  - `serialize(_:includeBody:) -> Data` emits those headers; `Content-Length` is compressed size when gzipped
+- Consumes: existing `resolve` / `contentType`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/HostGatewayStaticFilesTests.swift`:
+
+```swift
+func testGzipWhenAccepted() {
+    // Make body large enough that gzip shrinks it.
+    let raw = Data(repeating: 0x61, count: 4096) // "aaaa..."
+    try! raw.write(to: root.appendingPathComponent("big.js"))
+    let response = files.response(
+        method: "GET",
+        target: "/big.js",
+        headers: .init(acceptEncoding: "gzip, deflate", ifNoneMatch: nil))
+    XCTAssertEqual(response.status, 200)
+    XCTAssertEqual(response.contentEncoding, "gzip")
+    XCTAssertLessThan(response.body.count, raw.count)
+    XCTAssertEqual(response.cacheControl, "public, max-age=86400")
+    XCTAssertNotNil(response.etag)
+}
+
+func testNoGzipWithoutAcceptEncoding() {
+    let response = files.response(
+        method: "GET", target: "/e2ee.js",
+        headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
+    XCTAssertNil(response.contentEncoding)
+    XCTAssertEqual(String(decoding: response.body, as: UTF8.self), "var E2EE;")
+}
+
+func testHtmlIsNoCache() {
+    let response = files.response(
+        method: "GET", target: "/",
+        headers: .init(acceptEncoding: "gzip", ifNoneMatch: nil))
+    XCTAssertEqual(response.cacheControl, "no-cache")
+}
+
+func testVersionedAssetIsImmutable() {
+    let response = files.response(
+        method: "GET", target: "/e2ee.js?v=20260724",
+        headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
+    XCTAssertEqual(response.cacheControl, "public, max-age=31536000, immutable")
+}
+
+func testETagYields304() {
+    let first = files.response(
+        method: "GET", target: "/e2ee.js",
+        headers: .init(acceptEncoding: nil, ifNoneMatch: nil))
+    let etag = try! XCTUnwrap(first.etag)
+    let again = files.response(
+        method: "GET", target: "/e2ee.js",
+        headers: .init(acceptEncoding: nil, ifNoneMatch: etag))
+    XCTAssertEqual(again.status, 304)
+    XCTAssertTrue(again.body.isEmpty)
+}
+
+func testSerializeIncludesEncodingAndCache() {
+    let response = HostGatewayStaticFiles.Response(
+        status: 200, reason: "OK",
+        contentType: "text/javascript; charset=utf-8",
+        body: Data([0x1f, 0x8b]),
+        cacheControl: "public, max-age=86400",
+        contentEncoding: "gzip",
+        etag: "\"abc\"",
+        vary: "Accept-Encoding")
+    let wire = String(decoding: HostGatewayStaticFiles.serialize(response, includeBody: true), as: UTF8.self)
+    XCTAssertTrue(wire.contains("Content-Encoding: gzip\r\n"))
+    XCTAssertTrue(wire.contains("Cache-Control: public, max-age=86400\r\n"))
+    XCTAssertTrue(wire.contains("ETag: \"abc\"\r\n"))
+    XCTAssertTrue(wire.contains("Vary: Accept-Encoding\r\n"))
+    XCTAssertFalse(wire.contains("Connection: close\r\n"))
+}
+```
+
+Update existing call sites in this file that use `response(method:target:)` to pass `headers: .init(acceptEncoding: nil, ifNoneMatch: nil)` (or add a defaulted overload).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug \
+  -skipPackagePluginValidation -skipMacroValidation \
+  -only-testing:seahelmTests/HostGatewayStaticFilesTests test
+```
+
+Expected: FAIL — missing `headers` / `contentEncoding` / etc.
+
+- [ ] **Step 3: Implement minimal StaticFiles support**
+
+In `HostGatewayStaticFiles.swift`:
+
+```swift
+struct RequestHeaders: Equatable {
+    var acceptEncoding: String?
+    var ifNoneMatch: String?
+}
+
+struct Response: Equatable {
+    let status: Int
+    let reason: String
+    let contentType: String
+    let body: Data
+    let cacheControl: String
+    let contentEncoding: String?
+    let etag: String?
+    let vary: String?
+}
+
+func response(method: String, target: String,
+              headers: RequestHeaders = .init()) -> Response {
+    // ... existing 405/404 guards ...
+    // After reading `data` from disk:
+    let etag = Self.etag(for: data)
+    if let inm = headers.ifNoneMatch, inm == etag {
+        return Response(status: 304, reason: "Not Modified",
+                        contentType: contentType, body: Data(),
+                        cacheControl: cacheControl(for: target, pathExtension:),
+                        contentEncoding: nil, etag: etag, vary: nil)
+    }
+    let wantGzip = Self.acceptsGzip(headers.acceptEncoding)
+        && Self.gzipable(pathExtension)
+    var body = data
+    var encoding: String? = nil
+    var vary: String? = nil
+    if wantGzip, let gz = Self.gzip(data), gz.count < data.count {
+        body = gz
+        encoding = "gzip"
+        vary = "Accept-Encoding"
+    }
+    return Response(status: 200, reason: "OK", contentType: ...,
+                    body: body,
+                    cacheControl: Self.cacheControl(for: target, pathExtension: ...),
+                    contentEncoding: encoding, etag: etag, vary: vary)
+}
+```
+
+Helpers:
+
+- `acceptsGzip`: token-split `Accept-Encoding`, true if `gzip` present (ignore q=0).
+- `gzipable`: html/htm/js/mjs/css/svg/json/map/txt/md.
+- `gzip(_:)`: Foundation/`Compression` raw zlib wrapped as gzip (header + CRC), or `Data` via `NSData` compression if already used elsewhere — match existing deflate style in `HostGatewayVTFrame` only if you add a proper gzip container; simplest portable approach: use `Compression` zlib and write RFC 1952 gzip framing, **or** shell out is forbidden — implement gzip framing in ~40 lines.
+- `etag(for:)`: `"\"\(sha256-or-fnv hex of bytes)\""` — SHA256 via CryptoKit is fine.
+- `cacheControl(for:pathExtension:)`:
+  - html/htm → `no-cache`
+  - target contains `?v=` or `?v&` query → `public, max-age=31536000, immutable`
+  - else → `public, max-age=86400`
+
+`serialize`: emit optional `Content-Encoding`, `ETag`, `Vary`, `Cache-Control`; use `Connection: keep-alive` instead of `close`. For 304, `Content-Length: 0` and no body.
+
+Keep a convenience overload `response(method:target:)` calling empty headers so other call sites compile.
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+Same `xcodebuild` command as Step 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Core/HostGatewayStaticFiles.swift Tests/HostGatewayStaticFilesTests.swift
+git commit -m "feat: gzip and cache headers for Host Gateway static files"
+```
+
+---
+
+### Task 2: HTTP keep-alive for static requests
+
+**Files:**
+- Modify: `Sources/Core/HostGatewayServer.swift` (`route` / request-head loop ~267–278)
+- Test: extend `Tests/HostGatewayServerTests.swift` **or** add a focused unit test on a extracted `shouldKeepAlive(requestHead:)` helper if full NW loop is hard to unit-test
+
+**Interfaces:**
+- Produces: after a static response with keep-alive, connection stays open and reads another request head; `Connection: close` only when client asked or on error
+- Consumes: `HostGatewayStaticFiles.serialize` (already keep-alive)
+
+- [ ] **Step 1: Write failing test for header parse helper**
+
+In `HostGatewayServer` (or StaticFiles), add:
+
+```swift
+static func clientRequestsClose(head: String) -> Bool {
+    // HTTP/1.0 default close; HTTP/1.1 default keep-alive unless Connection: close
+}
+```
+
+Test:
+
+```swift
+func testKeepAliveDefaultHttp11() {
+    XCTAssertFalse(HostGatewayServer.clientRequestsClose(
+        head: "GET / HTTP/1.1\r\nHost: x\r\n"))
+    XCTAssertTrue(HostGatewayServer.clientRequestsClose(
+        head: "GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n"))
+    XCTAssertTrue(HostGatewayServer.clientRequestsClose(
+        head: "GET / HTTP/1.0\r\nHost: x\r\n"))
+}
+```
+
+- [ ] **Step 2: Run test — expect FAIL** (symbol missing)
+
+- [ ] **Step 3: Implement keep-alive path**
+
+Replace `route` static branch:
+
+```swift
+let headers = Self.parseRequestHeaders(head) // Accept-Encoding, If-None-Match, Connection
+let response = staticFiles.response(method: method, target: target, headers: headers)
+let close = Self.clientRequestsClose(head: head)
+var payload = HostGatewayStaticFiles.serialize(response, includeBody: method != "HEAD")
+// If serialize always says keep-alive, rewrite Connection when close==true:
+if close {
+    // ensure serialize can take connectionClose: Bool, or replace header string
+}
+connection.send(content: payload, isComplete: close, completion: .contentProcessed { [weak self] error in
+    guard let self else { return }
+    if error != nil || close {
+        connection.cancel()
+        return
+    }
+    self.readRequestHead(on: connection, buffered: Data())
+})
+```
+
+Parse `Accept-Encoding` / `If-None-Match` from `head` into `RequestHeaders`.
+
+- [ ] **Step 4: Run HostGatewayServer + StaticFiles tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Core/HostGatewayServer.swift Tests/HostGatewayServerTests.swift Tests/HostGatewayStaticFilesTests.swift
+git commit -m "feat: HTTP keep-alive for Host Gateway static hosting"
+```
+
+---
+
+### Task 3: Defer WebGL + exclude bench from bundle
+
+**Files:**
+- Modify: `clients/seahelm-web/index.html` (script tags + `attachWebglRenderer`)
+- Modify: `project.yml` Bundle seahelm-web rsync excludes
+- Modify: `clients/seahelm-web/README.md` (one line on deferred WebGL)
+- Run: `xcodegen generate` after `project.yml`
+
+**Interfaces:**
+- Produces: default HTML loads `e2ee.js` + `xterm.js` only; WebGL addon loaded on first terminal open via dynamic `<script>` or `import()`; bench files not copied into app Resources
+
+- [ ] **Step 1: Change HTML script includes**
+
+Remove synchronous:
+
+```html
+<script src="./xterm-addon-webgl.js"></script>
+```
+
+Keep:
+
+```html
+<script src="./xterm.js"></script>
+<script src="./e2ee.js"></script>
+```
+
+- [ ] **Step 2: Lazy-load WebGL in `attachWebglRenderer`**
+
+```javascript
+let webglAddonPromise = null;
+function loadWebglAddon(){
+  if (typeof WebglAddon !== 'undefined' && WebglAddon.WebglAddon) {
+    return Promise.resolve(WebglAddon);
+  }
+  if (webglAddonPromise) return webglAddonPromise;
+  webglAddonPromise = new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = './xterm-addon-webgl.js';
+    s.onload = () => resolve(window.WebglAddon || WebglAddon);
+    s.onerror = () => reject(new Error('webgl addon failed'));
+    document.head.appendChild(s);
+  });
+  return webglAddonPromise;
+}
+
+function attachWebglRenderer(term){
+  if (RENDERER === 'ghostty') return;
+  loadWebglAddon().then((mod) => {
+    const Ctor = mod.WebglAddon || mod;
+    const addon = new Ctor();
+    addon.onContextLoss(() => { try { addon.dispose(); } catch (e) {} });
+    term.loadAddon(addon);
+  }).catch((e) => {
+    log('sys', '(webgl)', `不可用,回退 DOM 渲染: ${e && e.message}`);
+  });
+}
+```
+
+Adapt to how the vendored file exposes `WebglAddon` today (check global name before coding).
+
+- [ ] **Step 3: Exclude bench from bundle**
+
+In `project.yml` rsync:
+
+```bash
+rsync -a \
+  --exclude '.gitignore' --exclude 'README.md' \
+  --exclude 'bench.html' --exclude 'bench-corpus.js' \
+  "${SRC}/" "${DEST}/"
+```
+
+Run `xcodegen generate`.
+
+- [ ] **Step 4: Smoke-check** — open `index.html` in Safari/Chrome local file or Gateway; confirm Network panel does not request `xterm-addon-webgl.js` until a pane opens; ghostty still only on `?renderer=ghostty`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/seahelm-web/index.html clients/seahelm-web/README.md project.yml seahelm.xcodeproj/project.pbxproj
+git commit -m "perf: defer WebGL addon and skip bench assets in Gateway bundle"
+```
+
+---
+
+### Task 4: Single / mirror VT mode toggle
+
+**Files:**
+- Modify: `clients/seahelm-web/index.html`
+- Modify: `clients/seahelm-web/README.md`
+
+**Interfaces:**
+- Produces: `localStorage.seahelm_vt_mode` = `single` | `mirror` (default `single`); header control toggles; `mountPanes` respects preference unless layout cannot mirror
+
+- [ ] **Step 1: Add state + UI control**
+
+Near renderer badge:
+
+```html
+<button class="renderer-badge" id="vtModeBadge" title="VT 订阅模式">单屏</button>
+```
+
+```javascript
+const VT_MODE_KEY = 'seahelm_vt_mode';
+function loadVtMode(){
+  const v = localStorage.getItem(VT_MODE_KEY);
+  return v === 'mirror' ? 'mirror' : 'single'; // default single
+}
+function setVtMode(mode){
+  localStorage.setItem(VT_MODE_KEY, mode);
+  renderVtModeBadge();
+  // remount if a worktree is open
+  if (S.sel) {
+    const path = S.sel, focus = S.vt.focus || S.selPane;
+    unmountPanes();
+    requestLayout(path); // or remount with cached tree if available
+  }
+}
+function renderVtModeBadge(){
+  const el = $('vtModeBadge');
+  if (!el) return;
+  const mode = loadVtMode();
+  el.textContent = mode === 'mirror' ? '镜像' : '单屏';
+  el.title = mode === 'mirror'
+    ? '镜像：每个 pane 一路 VT — 点击切到单屏'
+    : '单屏：只订阅焦点 pane — 点击切到镜像';
+  el.onclick = () => setVtMode(mode === 'mirror' ? 'single' : 'mirror');
+}
+```
+
+- [ ] **Step 2: Gate `mountPanes` mode selection**
+
+Replace mode decision:
+
+```javascript
+const preferMirror = loadVtMode() === 'mirror';
+S.vt.mode = (preferMirror && layoutFitsMirror(tree, wrap.clientWidth)) ? 'mirror' : 'single';
+```
+
+In `handleViewportResize`, same preference when deciding remount.
+
+- [ ] **Step 3: README** — document default single + toggle.
+
+- [ ] **Step 4: Manual check** — default opens one attach; switch to 镜像 opens N; switch back closes extras. Narrow window still forces single.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add clients/seahelm-web/index.html clients/seahelm-web/README.md
+git commit -m "feat: single/mirror VT subscribe toggle (default single)"
+```
+
+---
+
+### Task 5: Session egress priority + VT byte budget + resync
+
+**Files:**
+- Modify: `Sources/Core/HostGatewaySession.swift`
+- Create: `Tests/HostGatewaySessionBackpressureTests.swift`
+- Optionally touch: `Sources/Core/ZmxVTAttachManager.swift` only if exposing a coalesce hint API; otherwise stretch coalesce later / skip if too invasive — **prefer session-only first**
+
+**Interfaces:**
+- Produces:
+  - Constants: `maxPendingVTBytes = 256 * 1024`, `maxPendingVTBytesPerPane = 128 * 1024`, `resyncMinInterval = 1.0`
+  - `Pending` distinguishes `.high(HostGatewayWireFrame)` vs `.vt(VTEvent)`
+  - `enqueue` (RPC/decisions) → high; `enqueueVT` → low with budget
+  - On per-pane or total overflow: drop older `.vt` for that pane, set `needsResync`, enqueue synthetic empty/minimal `VTEvent(kind: .snapshot, ...)` rate-limited
+  - `drainNotifications()` returns **all high frames first**, then VT frames (encode as today)
+- Consumes: existing `encodeVT`, `openVTKeys`, auth flags
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+import XCTest
+@testable import seahelm
+
+final class HostGatewaySessionBackpressureTests: XCTestCase {
+    final class FakeVT: HostGatewayVTAttaching {
+        var opens: [String] = []
+        func open(paneSessionKey: String) -> [String: Any] {
+            opens.append(paneSessionKey)
+            return ["ok": true]
+        }
+        func close(paneSessionKey: String) {}
+        func keepalive(paneSessionKey: String) {}
+        func sendKeys(paneSessionKey: String, utf8: Data) -> Bool { true }
+        var observer: ((VTEvent) -> Void)?
+        func addObserver(_ observer: @escaping (VTEvent) -> Void) -> Int {
+            self.observer = observer; return 1
+        }
+        func removeObserver(_ token: Int) { observer = nil }
+    }
+
+    // Build session with fake router/vt like HostGatewaySessionTests — copy helpers.
+
+    func testHighPriorityDrainsBeforeVT() { /* enqueue VT then decision; drain; first frames are pane.event / ready */ }
+    func testDropsOldVTWhenOverBudget() { /* append many large vt.data; pending VT byte estimate ≤ cap; needs snapshot at end */ }
+    func testResyncRateLimited() { /* two overflows within 1s → one snapshot */ }
+}
+```
+
+Mirror construction patterns from `Tests/HostGatewaySessionTests.swift` (read that file and copy the fake router setup verbatim).
+
+- [ ] **Step 2: Run — FAIL**
+
+```bash
+xcodebuild ... -only-testing:seahelmTests/HostGatewaySessionBackpressureTests test
+```
+
+- [ ] **Step 3: Implement queue policy in `HostGatewaySession`**
+
+Sketch:
+
+```swift
+private enum Pending {
+    case high(HostGatewayWireFrame)
+    case vt(VTEvent)
+}
+
+private var needsResync: [String: Date] = [:] // pane → last resync time
+private var pendingVTBytes: Int = 0
+
+private func enqueue(_ frame: HostGatewayWireFrame) {
+    lock.lock()
+    pending.append(.high(frame))
+    let notify = pendingOutbound
+    lock.unlock()
+    notify?(self)
+}
+
+private func enqueueVT(_ event: VTEvent) {
+    lock.lock()
+    defer {
+        let notify = pendingOutbound
+        lock.unlock()
+        notify?(self)
+    }
+    guard authenticated, openVTKeys.contains(event.paneSessionKey) else { return }
+
+    pending.append(.vt(event))
+    pendingVTBytes += event.payload.count
+    trimVTIfNeeded(pane: event.paneSessionKey)
+}
+
+private func trimVTIfNeeded(pane: String) {
+    // While pendingVTBytes > max OR per-pane sum > perPaneMax:
+    // remove oldest .vt for `pane` (or any pane if total), subtract bytes.
+    // Then maybeScheduleResync(pane)
+}
+
+private func maybeScheduleResync(pane: String) {
+    let now = Date()
+    if let last = needsResync[pane], now.timeIntervalSince(last) < 1.0 { return }
+    needsResync[pane] = now
+    let snap = VTEvent(kind: .snapshot, paneSessionKey: pane, payload: Data(), cols: nil, rows: nil)
+    pending.append(.vt(snap))
+}
+
+func drainNotifications() -> [HostGatewayWireFrame] {
+    lock.lock()
+    let high = pending.compactMap { if case .high(let f) = $0 { return f } else { return nil } }
+    let vts = pending.compactMap { if case .vt(let e) = $0 { return e } else { return nil } }
+    pending.removeAll()
+    pendingVTBytes = 0
+    let binary = vtBinary
+    let deflate = vtDeflate
+    lock.unlock()
+    return high + vts.map { encodeVT($0, binary: binary, deflate: deflate) }
+}
+```
+
+Wire `handle` / auth replies as **return values** today (not via pending) — leave that as-is so request/response stays immediate. Only async notifies use queues.
+
+Optional follow-up in same task: make `HostGatewayServer.send` chain `contentProcessed` before sending the next low-priority frame (high still flush immediately). If that balloons scope, ship session-side budget first and note server pacing as Task 5b only if tests need it.
+
+- [ ] **Step 4: Run backpressure + existing HostGatewaySession tests — PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Core/HostGatewaySession.swift Tests/HostGatewaySessionBackpressureTests.swift
+git commit -m "feat: Host Gateway VT backpressure with drop-old resync"
+```
+
+---
+
+### Task 6: Browser write-chain drop under decode backlog
+
+**Files:**
+- Modify: `clients/seahelm-web/index.html` (`onGatewayBinaryFrame` / `handleVT` path)
+
+**Interfaces:**
+- Produces: per-pane pending apply depth capped (e.g. `N=8`); drop intermediate `vt.data`, never drop the newest; snapshots always applied
+
+- [ ] **Step 1: Implement depth tracking**
+
+```javascript
+const VT_APPLY_MAX = 8;
+const vtApplyDepth = new Map(); // key → count of queued applies
+
+function onGatewayBinaryFrame(buf){
+  const f = parseVTFrame(buf);
+  if (!f) { ...; return; }
+  const depth = vtApplyDepth.get(f.key) || 0;
+  if (f.type === 'vt.data' && depth >= VT_APPLY_MAX) {
+    // Drop this frame (old data). Newest-wins: alternatively replace a slot —
+    // simplest correct approach: if depth >= MAX, skip enqueue of this data frame.
+    log('sys', '(vt drop)', f.key);
+    return;
+  }
+  vtApplyDepth.set(f.key, depth + 1);
+  const prior = vtWriteChains.get(f.key) || Promise.resolve();
+  const next = prior.then(async () => {
+    try {
+      const bytes = f.deflated ? await inflateRaw(f.body) : f.body;
+      handleVT(f.key, { type: f.type, bytes, cols: f.cols, rows: f.rows });
+    } finally {
+      vtApplyDepth.set(f.key, Math.max(0, (vtApplyDepth.get(f.key) || 1) - 1));
+    }
+  }).catch(...);
+  vtWriteChains.set(f.key, next);
+}
+```
+
+Apply the same depth guard in JSON `onGatewayNotify` for `vt.data`.
+
+- [ ] **Step 2: Manual / note** — under throttle, terminal may jump but must not reorder.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add clients/seahelm-web/index.html
+git commit -m "fix: drop excess VT apply frames on the browser under backlog"
+```
+
+---
+
+### Task 7: Binary key frames (negotiate + server + client)
+
+**Files:**
+- Create: `Sources/Core/HostGatewayKeyFrame.swift`
+- Create: `Tests/HostGatewayKeyFrameTests.swift`
+- Modify: `Sources/Core/HostGatewaySession.swift` (`handleAuth` → `keys_binary`; add `handle(binary:)`)
+- Modify: `Sources/Core/HostGatewayServer.swift` (`receive` handles `.binary` opcode)
+- Modify: `clients/seahelm-web/index.html` (auth flag + binary send path)
+
+**Interfaces:**
+- Produces:
+  ```
+  u8 version=1 | u8 kind=1 (keys) | u8 keyLen | key UTF-8 | payload UTF-8 bytes
+  ```
+  - `HostGatewayKeyFrame.encode(paneSessionKey:utf8:) -> Data?`
+  - `HostGatewayKeyFrame.decode(_:) -> (paneSessionKey, utf8)?`
+  - Auth result includes `keys_binary: Bool`
+  - Server: binary WS → `session.handle(binary:)` → `vt.sendKeys`
+- Consumes: existing `sendKeys`, `isVTOpen`
+
+- [ ] **Step 1: Failing frame tests**
+
+```swift
+func testRoundTrip() {
+    let key = "seahelm-main-p1"
+    let utf8 = Data("hello".utf8)
+    let frame = try! XCTUnwrap(HostGatewayKeyFrame.encode(paneSessionKey: key, utf8: utf8))
+    let decoded = try! XCTUnwrap(HostGatewayKeyFrame.decode(frame))
+    XCTAssertEqual(decoded.paneSessionKey, key)
+    XCTAssertEqual(decoded.utf8, utf8)
+}
+
+func testRejectsOversizedKey() {
+    let key = String(repeating: "a", count: 300)
+    XCTAssertNil(HostGatewayKeyFrame.encode(paneSessionKey: key, utf8: Data()))
+}
+```
+
+- [ ] **Step 2: Implement `HostGatewayKeyFrame`**
+
+```swift
+enum HostGatewayKeyFrame {
+    static let version: UInt8 = 1
+    static let kindKeys: UInt8 = 1
+    static let maxKeyLength = 255
+
+    static func encode(paneSessionKey: String, utf8: Data) -> Data? { ... }
+    static func decode(_ frame: Data) -> (paneSessionKey: String, utf8: Data)? { ... }
+}
+```
+
+- [ ] **Step 3: Session + server wiring**
+
+Auth:
+
+```swift
+let keysBinary = ok && (params["keys_binary"] as? Bool ?? false)
+// store keysBinary on session
+result: ["ok": ok, "vt_binary": binary, "vt_deflate": deflate, "keys_binary": keysBinary]
+```
+
+```swift
+func handle(binary: Data) -> [HostGatewayWireFrame] {
+    guard authenticated else { return [] }
+    guard keysBinary, let decoded = HostGatewayKeyFrame.decode(binary) else { return [] }
+    guard isVTOpen(decoded.paneSessionKey) else { /* error frame optional */ return [] }
+    _ = vt.sendKeys(paneSessionKey: decoded.paneSessionKey, utf8: decoded.utf8)
+    return [] // no RPC id; fire-and-forget like coalesced keys
+}
+```
+
+Server `receive`:
+
+```swift
+if metadata.opcode == .binary, let data {
+    let outbound = session.handle(binary: data)
+    for frame in outbound { send(frame, on: connection) }
+    sendPendingNotifications(...)
+}
+```
+
+- [ ] **Step 4: Client**
+
+On auth:
+
+```javascript
+gwSend('auth', {
+  mac_id: S.mac, token: S.authPass,
+  vt_binary: true,
+  vt_deflate: typeof DecompressionStream === 'function',
+  keys_binary: true,
+}, (r, err) => {
+  S.gw.keysBinary = !!(r && r.keys_binary);
+  ...
+});
+```
+
+Replace key flush send:
+
+```javascript
+function sendKeysBinaryOrRpc(key, bytes) {
+  if (S.gw && S.gw.keysBinary && S.gw.ws.readyState === WebSocket.OPEN) {
+    const frame = encodeKeyFrame(key, bytes); // mirror Swift layout in JS
+    S.gw.ws.send(frame);
+    log('tx', 'keys', `${key} ${bytes.length}B`);
+    return;
+  }
+  sendCommand('pane.send_keys', { pane_session_key: key, b64: bytesToB64(bytes) });
+}
+```
+
+Use this from the 10ms `onData` flush and `sendRawKey`.
+
+- [ ] **Step 5: Run KeyFrame + Session + Server tests — PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/Core/HostGatewayKeyFrame.swift Sources/Core/HostGatewaySession.swift \
+  Sources/Core/HostGatewayServer.swift Tests/HostGatewayKeyFrameTests.swift \
+  clients/seahelm-web/index.html
+git commit -m "feat: negotiated binary send_keys on Host Gateway"
+```
+
+---
+
+### Task 8: README + verification pass
+
+**Files:**
+- Modify: `clients/seahelm-web/README.md` (summarize all four workstreams)
+- Run full Host Gateway test filter
+
+- [ ] **Step 1: Update README** with: gzip/cache, default single-pane toggle, backpressure behavior (user-visible: may jump under lag), binary keys automatic when supported.
+
+- [ ] **Step 2: Run**
+
+```bash
+xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug \
+  -skipPackagePluginValidation -skipMacroValidation \
+  -only-testing:seahelmTests/HostGatewayStaticFilesTests \
+  -only-testing:seahelmTests/HostGatewaySessionTests \
+  -only-testing:seahelmTests/HostGatewaySessionBackpressureTests \
+  -only-testing:seahelmTests/HostGatewayKeyFrameTests \
+  -only-testing:seahelmTests/HostGatewayServerTests \
+  -only-testing:seahelmTests/HostGatewayVTFrameTests \
+  test
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Manual on Tailscale/DERP** — page loads faster on repeat visit; single-pane default; typing remains responsive when `top` is flooding.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add clients/seahelm-web/README.md
+git commit -m "docs: seahelm-web poor-network behavior in README"
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec section | Task |
+|---|---|
+| §1 Static gzip | Task 1 |
+| §1 Cache-Control / ETag | Task 1 |
+| §1 keep-alive | Task 2 |
+| §1 defer WebGL / exclude bench | Task 3 |
+| §2 single/mirror toggle, default single | Task 4 |
+| §3 bounded queue drop-old / resync | Task 5 |
+| §3 browser write-chain drop | Task 6 |
+| §4 control priority | Task 5 (high before low) |
+| §4 binary keys | Task 7 |
+| Testing / README | Tasks 1–8 |
+
+## Out of plan (explicit)
+
+- Dual WebSocket
+- Brotli
+- Keeping xterm alive across pane switches without dispose
+- Server-side coalesce stretch in `ZmxVTAttachManager` (optional later if Task 5 insufficient)

--- a/docs/superpowers/specs/2026-08-29-seahelm-web-poor-network-design.md
+++ b/docs/superpowers/specs/2026-08-29-seahelm-web-poor-network-design.md
@@ -1,0 +1,236 @@
+# seahelm-web poor-network design
+
+> **Status:** Accepted for planning (2026-08-29)  
+> **Scope:** Host Gateway static hosting + VT send path + seahelm-web client  
+> **Out of scope:** Second WebSocket, screen-sync protocol, changing zmx/Ghostty fidelity, mandatory single-pane without a UI toggle
+
+## Problem
+
+Under poor networks (high latency, DERP relay, lossy links), seahelm-web feels bad in several ways at once:
+
+1. **Page load** — the Gateway serves ~720KB+ of JS uncompressed, with `Connection: close` and `Cache-Control: no-cache`, so the shell itself is hard to open.
+2. **VT backlog** — Mac reads PTY at full rate and queues outbound frames with no backpressure; the browser falls further behind.
+3. **Input lag** — `pane.send_keys` (JSON + base64) shares one WebSocket with VT floods and can be starved.
+4. **Multi-pane cost** — mirror mode opens one `zmx attach` per leaf (`N` full streams).
+
+Already in place (keep): binary VT frames, per-frame deflate, ~16ms adaptive coalesce, browser 10ms key batching, shallow scrollback under multi-pane, narrow-layout single attach.
+
+## Goals
+
+| Goal | Success signal |
+|---|---|
+| Page opens on weak links | gzip for text assets; keep-alive; cacheable JS/CSS; defer WebGL / ghostty |
+| Backlog does not snowball | bounded send queue; drop-old + resync instead of unbounded pending |
+| Typing stays usable | high-priority outbound control; optional binary keys |
+| User controls bandwidth | UI toggle: single-pane vs mirror; default **single** |
+
+## Non-goals (this iteration)
+
+- Dual WebSocket / separate VT socket
+- Adaptive “video-like” terminal quality or non-PTY screen protocol
+- Preserving browser scrollback across pane switches (same as today’s mobile single mode)
+- Forcing default single-pane with no override
+- Brotli (gzip is enough for v1)
+
+---
+
+## 1. Static assets
+
+### Current behavior
+
+`HostGatewayStaticFiles` returns raw file bytes, `Connection: close`, and site-wide `Cache-Control: no-cache`. Typical first paint pulls `xterm.js` (~478KB) + `xterm-addon-webgl.js` (~242KB); `vendor/ghostty-web.js` (~666KB) only when renderer=ghostty.
+
+### Design
+
+**gzip**
+
+- For `js` / `css` / `html` / `svg` / `json` / `mjs`: if `Accept-Encoding` includes `gzip`, respond with `Content-Encoding: gzip` and compressed body.
+- Cache `(path, mtime) → gzip bytes` in memory; invalidate when mtime changes.
+- On compress failure, fall back to identity encoding.
+
+**caching**
+
+- `index.html`: keep `Cache-Control: no-cache` (or very short max-age) so the shell stays fresh.
+- Fingerprinted or version-queried static assets (`?v=` or build fingerprint): `Cache-Control: public, max-age=31536000, immutable`.
+- Other static assets: at least `max-age=86400` plus `ETag` / `Last-Modified` and `304` support.
+
+**keep-alive**
+
+- Static HTTP/1.1 responses use `Connection: keep-alive` so one TCP/TLS (or tunnel) connection can fetch multiple assets.
+- Adjust `HostGatewayServer` static request handling if today’s path closes after each response.
+
+**deferred scripts (client)**
+
+- Critical path: `e2ee.js` + `xterm.js` only.
+- Load `xterm-addon-webgl.js` dynamically after the first terminal `open`; on failure keep DOM renderer.
+- `ghostty-web`: only on `?renderer=ghostty` / explicit toggle (no default request).
+- Exclude `bench.html` / `bench-corpus.js` from the app bundle (`project.yml` rsync excludes).
+
+### Files
+
+- `Sources/Core/HostGatewayStaticFiles.swift`
+- `Sources/Core/HostGatewayServer.swift` (keep-alive / multi-request)
+- `clients/seahelm-web/index.html`
+- `project.yml` (bundle excludes)
+
+---
+
+## 2. Single-pane / mirror toggle
+
+### UI
+
+- Control next to the terminal header badges (same tier as renderer badge): **单屏** / **镜像**.
+- Persist in `localStorage` (`seahelm_vt_mode = single | mirror`).
+- On narrow layouts where `layoutFitsMirror` is false, force single; disable or hide mirror.
+
+### Behavior
+
+| Mode | Attach | UI |
+|---|---|---|
+| **single** | Only `vt_open` the focused pane; on switch, `vt_close` old then open new | One terminal + pane strip (`mountSinglePane`) |
+| **mirror** | When layout fits, `vt_open` every leaf (current mirror) | Nested flex tree |
+
+- Toggling remounts immediately (`unmountPanes` → `mountPanes`). Browser scrollback for disposed terminals is lost (acceptable; matches mobile today).
+- **Default: `single`** (poor-network friendly). User choice remembered.
+- No new Mac RPCs.
+
+### History
+
+- Mac/zmx session and agent processes are untouched.
+- Re-open uses attach **snapshot** (current screen fidelity), not deep browser scrollback.
+- “Keep xterm alive while pausing the stream” is explicitly out of scope for this design.
+
+### Files
+
+- `clients/seahelm-web/index.html` (and README note)
+
+---
+
+## 3. Send backpressure + drop-old / resync
+
+### Problem
+
+PTY is read at full speed; `NWConnection.send` completions are effectively ignored. Under a slow tunnel, pending VT grows and the UI falls behind.
+
+### Design
+
+Per Gateway **session** (and tracked per pane):
+
+1. **Bounded outbound VT budget**  
+   - Example caps (tune in implementation, document constants): total pending VT ≤ **256KB**, or per-pane ≤ **128KB**.  
+   - Count encoded-or-estimated payload consistently.
+
+2. **On overflow: drop old, keep latest**  
+   - Discard older `vt.data` for that pane from the low-priority queue.  
+   - Set `needsResync[pane] = true`.  
+   - Never drop high-priority control/RPC frames.
+
+3. **Resync**  
+   - When marked, emit a `vt.snapshot` as soon as practical so the client `term.reset()` and resumes from a clean screen.  
+   - If a full screen buffer is not available, a minimal/empty snapshot that still triggers client reset is acceptable; TUIs repaint; shell may briefly lack scrollback.  
+   - Optional explicit `vt.resync` notify is allowed but not required if snapshot already resets.  
+   - **Rate-limit** forced resync per pane (e.g. ≥1s) to avoid snapshot storms.
+
+4. **Light read-side adaptation**  
+   - While `needsResync` or the queue stays full: increase coalesce window (e.g. 16ms → 80ms) and allow larger chunks for that pane.  
+   - Do **not** tear down `zmx attach` for backpressure.
+
+5. **Browser assist**  
+   - If per-pane `vtWriteChains` depth exceeds N, drop intermediate `vt.data`, keep newest; honor snapshot reset.
+
+### Non-goals here
+
+- Full RTT-based ABR controller  
+- Stopping the PTY reader / applying backpressure into zmx
+
+### Files
+
+- `Sources/Core/HostGatewaySession.swift` (queues, drain, caps)
+- `Sources/Core/HostGatewayServer.swift` (send completion → drain)
+- `Sources/Core/ZmxVTAttachManager.swift` (optional coalesce knobs)
+- `clients/seahelm-web/index.html` (write-chain drop)
+- Tests: new session queue tests; existing Host Gateway tests must still pass
+
+---
+
+## 4. Control priority + binary keys
+
+### Outbound priority (same WebSocket)
+
+Two egress queues per session:
+
+| Priority | Traffic |
+|---|---|
+| **High** | RPC replies, auth-related, `pane.event`, errors |
+| **Low** | `vt.data` / `vt.snapshot` / binary VT |
+
+Drain rule: **always empty high before low**. Low still obeys §3 byte budgets.
+
+No second socket in this design.
+
+### Binary `send_keys` (negotiated)
+
+- Client may send `keys_binary: true` on `auth` (alongside existing `vt_binary` / `vt_deflate`).
+- Binary inbound frame (symmetric spirit to VT frames), e.g.  
+  `u8 version | u8 kind=keys | u8 keyLen | key… | raw UTF-8 bytes`  
+  (no JSON envelope, no base64).
+- Server routes to existing `sendKeys`; clients without negotiation keep JSON `pane.send_keys`.
+- Keep browser 10ms key coalescing.
+- Client must not let VT inflate/write Promise chains block `ws.send` for keys.
+
+Echo still depends on VT downlink; §3 prevents multi-second backlog from owning the pipe.
+
+### Files
+
+- `Sources/Core/HostGatewaySession.swift` / server inbound binary demux
+- Shared frame helper (extend `HostGatewayVTFrame` or sibling `HostGatewayKeyFrame`)
+- `clients/seahelm-web/index.html`
+- Unit tests for encode/decode round-trip + auth negotiation
+
+---
+
+## Error handling / degradation
+
+| Failure | Fallback |
+|---|---|
+| gzip fails | identity body |
+| WebGL dynamic import fails | DOM renderer |
+| `keys_binary` unsupported | JSON `send_keys` |
+| Resync thrash | per-pane minimum interval |
+| Queue drops | debug counters only (no user toast in v1) |
+
+---
+
+## Testing
+
+| Layer | Coverage |
+|---|---|
+| Unit | StaticFiles: gzip headers, Accept-Encoding, ETag/304, Cache-Control split html vs assets |
+| Unit | VT queue: over-budget drop-old, needsResync, high priority not starved |
+| Unit | Binary keys round-trip + negotiation |
+| Manual / light client | Mode toggle opens/closes the expected pane set |
+| Regression | Existing `HostGateway*Tests`, `VTPipelineBenchmarks` |
+
+---
+
+## Implementation order
+
+1. Static gzip + cache + keep-alive + deferred WebGL + exclude bench from bundle  
+2. Single / mirror UI toggle (default single)  
+3. Server egress priority + bounded queue drop-old / resync (+ light client write-chain drop)  
+4. Binary keys negotiation  
+
+---
+
+## Open parameters (fix at implement time, not product unknowns)
+
+- Exact pending byte caps (256KB / 128KB starting points)
+- Resync minimum interval (~1s starting point)
+- Client write-chain drop depth `N`
+- Whether versioned URLs use existing `?v=` stamps or content hashes
+
+## References
+
+- `docs/superpowers/specs/2026-08-10-web-host-gateway-design.md`
+- `Sources/Core/HostGatewayStaticFiles.swift`, `HostGatewaySession.swift`, `HostGatewayVTFrame.swift`, `ZmxVTAttachManager.swift`
+- `clients/seahelm-web/index.html`

--- a/project.yml
+++ b/project.yml
@@ -152,6 +152,7 @@ targets:
           mkdir -p "${DEST}"
           rsync -a \
             --exclude 'devbroker' --exclude '.gitignore' --exclude 'README.md' \
+            --exclude 'bench.html' --exclude 'bench-corpus.js' \
             "${SRC}/" "${DEST}/"
     sources:
       - path: Sources

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -1898,7 +1898,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\nSRC=\"${SRCROOT}/clients/seahelm-web\"\nDEST=\"${CODESIGNING_FOLDER_PATH}/Contents/Resources/seahelm-web\"\nrm -rf \"${DEST}\"\nmkdir -p \"${DEST}\"\nrsync -a \\\n  --exclude 'devbroker' --exclude '.gitignore' --exclude 'README.md' \\\n  \"${SRC}/\" \"${DEST}/\"\n";
+			shellScript = "set -euo pipefail\nSRC=\"${SRCROOT}/clients/seahelm-web\"\nDEST=\"${CODESIGNING_FOLDER_PATH}/Contents/Resources/seahelm-web\"\nrm -rf \"${DEST}\"\nmkdir -p \"${DEST}\"\nrsync -a \\\n  --exclude 'devbroker' --exclude '.gitignore' --exclude 'README.md' \\\n  --exclude 'bench.html' --exclude 'bench-corpus.js' \\\n  \"${SRC}/\" \"${DEST}/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		8BBCB395DA0D4E99A6407A59 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56E02C4A6D726C18E655451 /* main.swift */; };
 		8D46D0CD23A90F281380306A /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E1906E0816DDA737033BBF1 /* AVFoundation.framework */; };
 		8EABBB670FE78F05B40F735B /* IslandModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8704C54160BF8CD4FE29B9D6 /* IslandModel.swift */; };
+		8EABC0497151BA1CC9E3C12A /* HostGatewaySessionBackpressureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC94EE653B0D0F418057A15 /* HostGatewaySessionBackpressureTests.swift */; };
 		8EAE24B6C81EA826474EEC90 /* StatusDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6A0AE5886DB08F5B0D024C /* StatusDetector.swift */; };
 		8F0624099E494AEDE963E0CC /* FirstMateEvaluateOutcomeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4089897C96C2E4E3E151DDD2 /* FirstMateEvaluateOutcomeTests.swift */; };
 		8F88CCC86880979546321D70 /* IMessageSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0129F6EBD2E1650EFE04DC4A /* IMessageSender.swift */; };
@@ -587,6 +588,7 @@
 		3F4CB69B94BFFAB30A5D430C /* ChromeHeaderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeHeaderDelegate.swift; sourceTree = "<group>"; };
 		3F67CBC84404085C3483C910 /* TestViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewHelpers.swift; sourceTree = "<group>"; };
 		3FA6E78D00BFAF395356B892 /* IMessageRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IMessageRuleTests.swift; sourceTree = "<group>"; };
+		3FC94EE653B0D0F418057A15 /* HostGatewaySessionBackpressureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewaySessionBackpressureTests.swift; sourceTree = "<group>"; };
 		4089897C96C2E4E3E151DDD2 /* FirstMateEvaluateOutcomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateEvaluateOutcomeTests.swift; sourceTree = "<group>"; };
 		40CAD3E9929AC9E5E32EBA9F /* Station.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Station.swift; sourceTree = "<group>"; };
 		4110371EE0D93ADF67AEE009 /* PasteRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteRegressionTests.swift; sourceTree = "<group>"; };
@@ -1416,6 +1418,7 @@
 				D09525B8D6C093323B62D10B /* HostGatewayDecisionsTests.swift */,
 				CBC709BF6C114756E9794146 /* HostGatewayFrameTests.swift */,
 				A7F8EA0DFCBD7F74049EA635 /* HostGatewayServerTests.swift */,
+				3FC94EE653B0D0F418057A15 /* HostGatewaySessionBackpressureTests.swift */,
 				1D9E5FDD907FFB3D57373A8A /* HostGatewaySessionTests.swift */,
 				BB735C1E5E1238DE2F51758B /* HostGatewayStaticFilesTests.swift */,
 				16AC3A2325B391B90BFD6175 /* HostGatewayVTFrameTests.swift */,
@@ -1967,6 +1970,7 @@
 				785DB0B4417DD04E94CD58AD /* HostGatewayDecisionsTests.swift in Sources */,
 				50C0E2D95435EA0741D4BFE4 /* HostGatewayFrameTests.swift in Sources */,
 				9684C23FB2CD701D95E47EDA /* HostGatewayServerTests.swift in Sources */,
+				8EABC0497151BA1CC9E3C12A /* HostGatewaySessionBackpressureTests.swift in Sources */,
 				71206C48591B67FF56E51E8E /* HostGatewaySessionTests.swift in Sources */,
 				72897701FB2E01A0DA5305D1 /* HostGatewayStaticFilesTests.swift in Sources */,
 				868325DCA0D71C5CF997E11E /* HostGatewayVTFrameTests.swift in Sources */,

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		240921180850A7640A6F4B3B /* FleetListFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C0DF900BA9C1BFA53BE7D /* FleetListFormatterTests.swift */; };
 		242BFEB70069EF4739848192 /* FirstMateCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E599A3810CED6E82EBD8BBC9 /* FirstMateCoordinator.swift */; };
 		26C985212F717B41F6439476 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DFD4558DAFB3276A91514A2 /* SwiftUI.framework */; };
+		270AFAAC108BA4157E1DFF3D /* HostGatewayKeyFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7593CE0AF827928487EEC349 /* HostGatewayKeyFrame.swift */; };
 		277DAB1789BBBA842FAB8C5F /* UsageSummaryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A912279D16E32ED9BADB27B /* UsageSummaryStore.swift */; };
 		28F64A45113C9031DE991377 /* WrappedPathAtClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EF8621D5464BAE7F393215 /* WrappedPathAtClickTests.swift */; };
 		29495AEAADEAB3360FDADEDB /* GmailAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88D1AA083189266856E9B02 /* GmailAccessToken.swift */; };
@@ -265,6 +266,7 @@
 		9684C23FB2CD701D95E47EDA /* HostGatewayServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F8EA0DFCBD7F74049EA635 /* HostGatewayServerTests.swift */; };
 		969A1488531C0DC09B3C0D84 /* IntegrationBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1876E1900448D0350043DB3 /* IntegrationBuilderTests.swift */; };
 		98451F4BB27B209594F5F732 /* FileTreeOutlineControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6207F1F7B2A126A6C5D69E91 /* FileTreeOutlineControllerTests.swift */; };
+		988AAE1AC653EE7C31D2E267 /* HostGatewayKeyFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EB483855694F79BFA1A7B7 /* HostGatewayKeyFrameTests.swift */; };
 		9959580EE4A6E02EAF3ECDA4 /* UsageSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693DBDBBFD25BEA5D9BE4E26 /* UsageSummary.swift */; };
 		99BB4AD91CE2F1ED5C8FAFC9 /* PRReviewCoordinatorLifetimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68134AF6F747CFF2862FC31F /* PRReviewCoordinatorLifetimeTests.swift */; };
 		9A03CF75CF0BCBBD3E4778FA /* PersistedStringMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF3E143D632D86B7DBBC840E /* PersistedStringMap.swift */; };
@@ -560,6 +562,7 @@
 		32ED7C4B1150BC7F4AA25A2D /* BridgeCardModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeCardModelTests.swift; sourceTree = "<group>"; };
 		3344C98CC0017F85B162D3CF /* CenterOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterOverlayView.swift; sourceTree = "<group>"; };
 		33E9418C39C2F95AA6193F67 /* AppFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFont.swift; sourceTree = "<group>"; };
+		33EB483855694F79BFA1A7B7 /* HostGatewayKeyFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayKeyFrameTests.swift; sourceTree = "<group>"; };
 		340F0D26DC8D1C8F72279B6A /* IngestOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngestOutcome.swift; sourceTree = "<group>"; };
 		34B653BECE0F1476C0850355 /* ChromeIconClusterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeIconClusterView.swift; sourceTree = "<group>"; };
 		358662BE2D7B5944F3C610F9 /* FuzzyMatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FuzzyMatchTests.swift; sourceTree = "<group>"; };
@@ -684,6 +687,7 @@
 		73FDA109B06DD6B1F279D87A /* PaneReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneReducerTests.swift; sourceTree = "<group>"; };
 		755D82DD1EFBD20111AC9BF2 /* RepoPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoPage.swift; sourceTree = "<group>"; };
 		75619FAA0B399E6EFEFD58ED /* WorktreeFileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeFileIndexTests.swift; sourceTree = "<group>"; };
+		7593CE0AF827928487EEC349 /* HostGatewayKeyFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayKeyFrame.swift; sourceTree = "<group>"; };
 		7598CDC2F8E33DD35632FAB7 /* StatusDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDetectorTests.swift; sourceTree = "<group>"; };
 		75A3D6310957D04ABCB2768A /* AppPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPage.swift; sourceTree = "<group>"; };
 		75EE0AFE306266CD4A4EE940 /* ChromeTitlebarRegionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeTitlebarRegionTests.swift; sourceTree = "<group>"; };
@@ -1034,6 +1038,7 @@
 				CFB1ED030DFAE92B65E7E8D1 /* HostGatewayConfig.swift */,
 				399B19A39BB25DDA3D401B60 /* HostGatewayDecisions.swift */,
 				A0FFC00EE90A3DAECD6396FC /* HostGatewayFrame.swift */,
+				7593CE0AF827928487EEC349 /* HostGatewayKeyFrame.swift */,
 				AE7778575158B23A9C90C792 /* HostGatewayServer.swift */,
 				7842E00A1A18C4FAD50AF0ED /* HostGatewaySession.swift */,
 				ADAB7F280D7925E9A0CD660C /* HostGatewayStaticFiles.swift */,
@@ -1417,6 +1422,7 @@
 				BDF8548571F540C914ACA11E /* HostGatewayConfigTests.swift */,
 				D09525B8D6C093323B62D10B /* HostGatewayDecisionsTests.swift */,
 				CBC709BF6C114756E9794146 /* HostGatewayFrameTests.swift */,
+				33EB483855694F79BFA1A7B7 /* HostGatewayKeyFrameTests.swift */,
 				A7F8EA0DFCBD7F74049EA635 /* HostGatewayServerTests.swift */,
 				3FC94EE653B0D0F418057A15 /* HostGatewaySessionBackpressureTests.swift */,
 				1D9E5FDD907FFB3D57373A8A /* HostGatewaySessionTests.swift */,
@@ -1969,6 +1975,7 @@
 				FAF2ABF4372E190D0A42EE2A /* HostGatewayConfigTests.swift in Sources */,
 				785DB0B4417DD04E94CD58AD /* HostGatewayDecisionsTests.swift in Sources */,
 				50C0E2D95435EA0741D4BFE4 /* HostGatewayFrameTests.swift in Sources */,
+				988AAE1AC653EE7C31D2E267 /* HostGatewayKeyFrameTests.swift in Sources */,
 				9684C23FB2CD701D95E47EDA /* HostGatewayServerTests.swift in Sources */,
 				8EABC0497151BA1CC9E3C12A /* HostGatewaySessionBackpressureTests.swift in Sources */,
 				71206C48591B67FF56E51E8E /* HostGatewaySessionTests.swift in Sources */,
@@ -2203,6 +2210,7 @@
 				4DEB41D0F7E47035706006E2 /* HostGatewayConfig.swift in Sources */,
 				5E77C3E6AA55F970F5DD877E /* HostGatewayDecisions.swift in Sources */,
 				506FABB5322B42EDC75221F8 /* HostGatewayFrame.swift in Sources */,
+				270AFAAC108BA4157E1DFF3D /* HostGatewayKeyFrame.swift in Sources */,
 				C2733167BB2AB84E425AC1D1 /* HostGatewayServer.swift in Sources */,
 				0302EB911AF4960365D33FB1 /* HostGatewaySession.swift in Sources */,
 				12348F72590729F9B44FC244 /* HostGatewayStaticFiles.swift in Sources */,


### PR DESCRIPTION
## Summary

- **Static load path**: gzip + cache headers, HTTP keep-alive, deferred WebGL addon, bench assets excluded from the Gateway bundle
- **VT streaming**: server-side backpressure with drop-old + rate-limited resync; browser-side apply-depth cap; single/mirror pane subscribe toggle (default single)
- **Input path**: negotiated binary `send_keys` frames on Host Gateway, wired through the existing keystroke coalescer
- **Docs**: design spec + implementation plan under `docs/superpowers/`

Rebased onto latest `main` and merged with recent gateway client improvements (auth snapshot fold-in, `input-coalescer.js`, `reconnect.js`).

## Test plan

- [x] `HostGatewayStaticFilesTests` — gzip, ETag, cache headers
- [x] `HostGatewayServerTests` — keep-alive loop, ephemeral HTTP sessions
- [x] `HostGatewaySessionBackpressureTests` — drop-old, resync, high-priority survival
- [x] `HostGatewayKeyFrameTests` + `HostGatewaySessionTests` — binary keys negotiation
- [ ] Manual smoke over Tailscale/DERP: page load, typing latency, pane switch in single mode, mirror toggle
- [ ] Verify older Mac / cached page still works (JSON VT + base64 keys fallback)


Made with [Cursor](https://cursor.com)