### PR TITLE
docs: stop the bench workflow depending on bench.html being bundled

### DIFF
--- a/clients/seahelm-web/devbroker/bench-collector.js
+++ b/clients/seahelm-web/devbroker/bench-collector.js
@@ -9,6 +9,13 @@
 //   → on the phone, over the tunnel:
 //     https://gw.seahelm.dev/bench.html?report=http://<mac-lan-ip>:28099/
 //
+// That URL resolves only while the gateway is serving a tree that contains
+// bench.html, and a release bundle has no reason to carry a benchmark page — so
+// do not assume the shipped app serves one. Point `host_gateway.web_root` in
+// ~/.config/seahelm/config.json at this working copy and the gateway serves the
+// files from here instead of from the bundle. That is what you want while
+// iterating anyway: edits land without a rebuild.
+//
 // The phone must be able to reach the Mac for the POST — same LAN is simplest.
 // If it cannot, the page still shows everything on screen; this is convenience.
 'use strict';


### PR DESCRIPTION
Comment only, 7 lines. No behaviour change.

## The problem

`devbroker/bench-collector.js` (added in #83) documents the workflow as:

```
https://gw.seahelm.dev/bench.html?report=http://<mac-lan-ip>:28099/
```

That resolves only while the gateway is serving a tree containing `bench.html`. Today the bundle carries it, so the instruction is true *by accident*.

#84 (`feat/seahelm-web-poor-network`) has `7ded732 perf: defer WebGL addon and skip bench assets in Gateway bundle`, which adds `--exclude 'bench.html' --exclude 'bench-corpus.js'` to the rsync in `project.yml`. That is the right call — a release has no reason to ship a benchmark page — but the moment it lands, the documented URL 404s. `HostGatewayStaticFiles` has no special case for bench assets; they were served purely as bundled static files.

The two branches merge clean, so nothing catches this: it is a semantic collision between an already-merged commit and one still in flight.

## The fix

Point at `host_gateway.web_root`, which exists for exactly this. `HostGatewayStaticFiles.resolveRoot(override:)` prefers it and falls back to the bundle; `HostGatewayStaticFilesTests:66` covers it.

Aim it at the working copy and the gateway serves from source — correct whether or not the bundle carries bench assets, and the better loop regardless, since edits then land without a rebuild.

## Verified against the running app

- bundle currently contains `bench.html`
- `GET http://127.0.0.1:2783/bench.html` → 200
- `GET http://127.0.0.1:2783/` → 200
- live config has `host_gateway = {enabled, port: 2783}` with no `web_root`, i.e. the bundle fallback

The override path itself was not exercised against the live gateway — doing so would mean editing the user's config and restarting it. It is a two-line resolution with test coverage.

## If you'd rather bench.html kept shipping

Then the fix belongs on #84 instead: drop the two `--exclude` flags. This PR does not touch that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)