### PR TITLE
feat: destructive actions decide from what would actually be lost

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -938,6 +938,9 @@ dashboard.stationManager = terminalCoordinator.stationManager
             }
             self.runIntegration(repoPath: repoPath, mode: .excludeConflicting, force: false)
         }
+        dashboard.onResetIntegration = { [weak self] checkoutPath in
+            self?.resetIntegration(checkoutPath: checkoutPath, force: false)
+        }
         dashboard.onAddWorktreeToProject = { [weak self] project, rect, anchor in
             self?.presentAddWorktreePopover(project: project, rect: rect, anchor: anchor)
         }
@@ -1290,6 +1293,7 @@ dashboard.stationManager = terminalCoordinator.stationManager
                 .filter { WorktreeDiscovery.findRepoRoot(from: $0.path) == repoPath }
             let integrationPath = IntegrationWorktreeStore.shared.worktreePath(forRepo: repoPath)
                 ?? IntegrationWorktree.defaultPath(forRepo: repoPath)
+            let lastPublished = IntegrationWorktreeStore.shared.lastPublishedCommit(forCheckout: integrationPath)
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
                     let report = try IntegrationRunner.run(
@@ -1297,11 +1301,22 @@ dashboard.stationManager = terminalCoordinator.stationManager
                         integrationPath: integrationPath,
                         worktrees: worktrees,
                         mode: mode,
-                        force: force
+                        force: force,
+                        lastPublished: lastPublished,
+                        // Typed by hand is exactly when an agent is most likely
+                        // to be mid-turn, so this needs the same guard the
+                        // automatic round has: a busy worktree comes in at HEAD
+                        // rather than as a half-written file that reads as a
+                        // conflict it is not.
+                        isBusy: { AgentRegistry.shared.hasRunningPane(inWorktree: $0) }
                     )
                     DispatchQueue.main.async {
                         IntegrationWorktreeStore.shared.set(report.integrationWorktreePath, forRepo: repoPath)
                         IntegrationStatusStore.shared.set(report.panelState, forWorktree: report.integrationWorktreePath)
+                        if case .published(let commit) = report.outcome {
+                            IntegrationWorktreeStore.shared.recordPublished(
+                                commit, forCheckout: report.integrationWorktreePath)
+                        }
                     }
                     reply(report.summary)
                 } catch {
@@ -1429,18 +1444,20 @@ dashboard.stationManager = terminalCoordinator.stationManager
     }
 
     private func runIntegration(repoPath: String, mode: IntegrationConflictMode, force: Bool) {
+        let integrationPath = IntegrationWorktreeStore.shared.worktreePath(forRepo: repoPath)
+            ?? IntegrationWorktree.defaultPath(forRepo: repoPath)
         guard config.integrationEnabled else {
             enqueueIntegrationReport(
                 "Integration is turned off in Settings ▸ General ▸ Integration",
-                repoPath: repoPath
+                repoPath: repoPath,
+                checkoutPath: integrationPath
             )
             return
         }
         let worktrees = tabCoordinator.allWorktrees
             .map(\.info)
             .filter { WorktreeDiscovery.findRepoRoot(from: $0.path) == repoPath }
-        let integrationPath = IntegrationWorktreeStore.shared.worktreePath(forRepo: repoPath)
-            ?? IntegrationWorktree.defaultPath(forRepo: repoPath)
+        let lastPublished = IntegrationWorktreeStore.shared.lastPublishedCommit(forCheckout: integrationPath)
 
         DispatchQueue.global(qos: .userInitiated).async {
             let outcome: Result<IntegrationRunReport, Error>
@@ -1450,7 +1467,9 @@ dashboard.stationManager = terminalCoordinator.stationManager
                     integrationPath: integrationPath,
                     worktrees: worktrees,
                     mode: mode,
-                    force: force
+                    force: force,
+                    lastPublished: lastPublished,
+                    isBusy: { AgentRegistry.shared.hasRunningPane(inWorktree: $0) }
                 ))
             } catch {
                 outcome = .failure(error)
@@ -1463,32 +1482,131 @@ dashboard.stationManager = terminalCoordinator.stationManager
                     // pointing at a directory that was never created.
                     IntegrationWorktreeStore.shared.set(report.integrationWorktreePath, forRepo: repoPath)
                     IntegrationStatusStore.shared.set(report.panelState, forWorktree: report.integrationWorktreePath)
+                    if case .published(let commit) = report.outcome {
+                        IntegrationWorktreeStore.shared.recordPublished(
+                            commit, forCheckout: report.integrationWorktreePath)
+                    }
                     // A round that published cleanly is meant to be invisible —
                     // the integration worktree is simply current. Only speak up
                     // when something was dropped or held back.
                     if report.needsAttention {
-                        self?.enqueueIntegrationReport(report.summary, repoPath: repoPath)
+                        self?.enqueueIntegrationReport(
+                            report.summary,
+                            repoPath: repoPath,
+                            checkoutPath: report.integrationWorktreePath,
+                            options: report.cardOptions
+                        )
                     }
                 case .failure(let error):
                     self?.enqueueIntegrationReport(
                         "Integration failed: \(error.localizedDescription)",
-                        repoPath: repoPath
+                        repoPath: repoPath,
+                        checkoutPath: integrationPath
                     )
                 }
             }
         }
     }
 
-    private func enqueueIntegrationReport(_ message: String, repoPath: String) {
-        tabCoordinator.pendingOrders.enqueue(
+    /// The row's "Reset to origin/main": fetch trunk and move the integration
+    /// checkout onto it, dropping whatever rounds had folded in. Same rules
+    /// as a round's publish — edits or commits made in the checkout by hand
+    /// hold it, and the sheet that follows names them; a confirmed reset
+    /// comes back through here with `force`.
+    private func resetIntegration(checkoutPath: String, force: Bool) {
+        guard let repoPath = IntegrationWorktreeStore.shared.repoPath(forCheckout: checkoutPath)
+            ?? WorktreeDiscovery.findRepoRoot(from: checkoutPath) else {
+            NSSound.beep()
+            return
+        }
+        let expectedHead = IntegrationWorktreeStore.shared.lastPublishedCommit(forCheckout: checkoutPath)
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            // The fetch is the slow part; the forced retry has just done one.
+            guard let target = IntegrationWorktree.resetTarget(repoPath: repoPath, fetch: !force) else {
+                DispatchQueue.main.async {
+                    self?.presentIntegrationResetFailure("Could not find origin/main or origin/master to reset to.")
+                }
+                return
+            }
+            let outcome = IntegrationWorktree.reset(
+                to: target, at: checkoutPath, force: force, expectedHead: expectedHead)
+            DispatchQueue.main.async {
+                self?.handleIntegrationReset(outcome, target: target, checkoutPath: checkoutPath)
+            }
+        }
+    }
+
+    private func handleIntegrationReset(
+        _ outcome: IntegrationPublishOutcome,
+        target: IntegrationWorktree.ResetTarget,
+        checkoutPath: String
+    ) {
+        switch outcome {
+        case .published(let commit), .unchanged(let commit):
+            // The reset commit is seahelm's own, so the next round does not
+            // mistake it for work that arrived by hand.
+            IntegrationWorktreeStore.shared.recordPublished(commit, forCheckout: checkoutPath)
+            IntegrationStatusStore.shared.set(
+                IntegrationPanelState(
+                    line: "integration · reset to \(target.ref)",
+                    included: [], excluded: [], conflictedPaths: [], isHeld: false
+                ),
+                forWorktree: checkoutPath
+            )
+            // A held-round card was about the state that was just discarded.
+            tabCoordinator.pendingOrders.resolveWorktree(path: checkoutPath)
+        case .held(let reason, _):
+            guard let window else { return }
+            let alert = NSAlert()
+            alert.alertStyle = .critical
+            alert.messageText = "Reset integration to \(target.ref)?"
+            alert.informativeText = reason.lossDescription
+            alert.addButton(withTitle: "Reset")
+            alert.addButton(withTitle: "Cancel")
+            alert.buttons[0].hasDestructiveAction = true
+            alert.beginSheetModal(for: window) { [weak self] response in
+                guard response == .alertFirstButtonReturn else { return }
+                self?.resetIntegration(checkoutPath: checkoutPath, force: true)
+            }
+        case .failed(let message):
+            presentIntegrationResetFailure(message)
+        }
+    }
+
+    private func presentIntegrationResetFailure(_ message: String) {
+        let alert = NSAlert()
+        alert.alertStyle = .critical
+        alert.messageText = "Failed to reset integration worktree"
+        alert.informativeText = message
+        if let window {
+            alert.beginSheetModal(for: window)
+        } else {
+            alert.runModal()
+        }
+    }
+
+    /// One card per checkout, keyed by the checkout rather than the repo so the
+    /// manual path and the automatic one address the same card instead of
+    /// stacking two. `upsert` because a later round supersedes an earlier one —
+    /// `enqueue` would leave the card reading whatever the first round said.
+    private func enqueueIntegrationReport(
+        _ message: String,
+        repoPath: String,
+        checkoutPath: String,
+        options: [String]? = nil
+    ) {
+        tabCoordinator.pendingOrders.upsert(
             FirstMateAction(
                 kind: .integrationReport,
                 zone: .red,
-                worktreePath: repoPath,
+                worktreePath: checkoutPath,
                 branch: "",
                 project: tabCoordinator.repoName(forWorktree: repoPath),
                 terminalID: "",
-                message: message
+                message: message,
+                payload: repoPath,
+                options: options
             )
         )
     }
@@ -2292,12 +2410,8 @@ extension MainWindowController: DashboardDelegate {
         tabCoordinator.showCloseProjectModal(project, window: window)
     }
 
-    func dashboardDidRequestDelete(_ terminalID: String) {
-        tabCoordinator.dashboardDidRequestDelete(terminalID, window: window)
-    }
-
-    func dashboardDidRequestDeleteWithBranch(_ terminalID: String) {
-        tabCoordinator.dashboardDidRequestDeleteWithBranch(terminalID, window: window)
+    func dashboardDidRequestDeleteWorktree(path: String) {
+        tabCoordinator.dashboardDidRequestDeleteWorktree(path: path, window: window)
     }
 
     func dashboardDidRequestAddProject() {
@@ -2940,10 +3054,24 @@ extension MainWindowController: TerminalCoordinatorDelegate {
 // MARK: - Bridge Actions
 
 extension MainWindowController {
-    /// Routes a suggestion chip tap. `returnToPort` chips trigger actual deletion;
-    /// all other kinds forward the option text to the agent terminal.
+    /// Routes a suggestion chip tap. `integrationReport` chips run or decline the
+    /// discard; `returnToPort` chips trigger actual deletion; all other kinds
+    /// forward the option text to the agent terminal.
     func handleSuggestionTapped(order: PendingOrder, optionText: String) {
-        if order.action.kind == .returnToPort {
+        if order.action.kind == .integrationReport {
+            // The card is the only place the discard is offered, and it is the
+            // one irreversible step in the feature — so the option that takes
+            // it says so, and anything else just clears the card.
+            tabCoordinator.pendingOrders.resolve(id: order.id)
+            guard IntegrationRunReport.isDiscardOption(optionText) else { return }
+            // The repo travels on the card: its worktreePath is the checkout.
+            guard let repoPath = order.action.payload
+                ?? IntegrationWorktreeStore.shared.repoPath(forCheckout: order.action.worktreePath) else {
+                NSSound.beep()
+                return
+            }
+            runIntegration(repoPath: repoPath, mode: .excludeConflicting, force: true)
+        } else if order.action.kind == .returnToPort {
             // Guard against a stale card: if the agent started running after the
             // card was enqueued, refuse the reap and drop the card.
             if AgentRegistry.shared.hasRunningPane(inWorktree: order.action.worktreePath) {

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -144,10 +144,20 @@ class TabCoordinator {
             integrationPath: { IntegrationWorktreeStore.shared.worktreePath(forRepo: $0) },
             isCheckoutBusy: { AgentRegistry.shared.hasRunningPane(inWorktree: $0) },
             isWorktreeBusy: { AgentRegistry.shared.hasRunningPane(inWorktree: $0) },
-            onReport: { [weak self] report, _ in
+            lastPublished: { IntegrationWorktreeStore.shared.lastPublishedCommit(forCheckout: $0) },
+            onReport: { [weak self] report, repo in
                 IntegrationStatusStore.shared.set(report.panelState, forWorktree: report.integrationWorktreePath)
+                if case .published(let commit) = report.outcome {
+                    IntegrationWorktreeStore.shared.recordPublished(
+                        commit, forCheckout: report.integrationWorktreePath)
+                }
                 guard report.needsAttention else { return }
-                self?.pendingOrders.enqueue(
+                // upsert, not enqueue: the key is (checkout, kind), so an
+                // enqueue would pin the card to the *first* round's summary
+                // while the side panel moved on with every later one — the two
+                // surfaces reading one round is the whole point of panelState.
+                // An unchanged report compares equal and does not re-pop.
+                self?.pendingOrders.upsert(
                     FirstMateAction(
                         kind: .integrationReport,
                         zone: .red,
@@ -155,7 +165,11 @@ class TabCoordinator {
                         branch: "",
                         project: self?.repoName(forWorktree: report.integrationWorktreePath) ?? "",
                         terminalID: "",
-                        message: report.summary
+                        message: report.summary,
+                        // The repo to re-run against: the card's own path is the
+                        // checkout, and resolving back from it is a guess.
+                        payload: repo,
+                        options: report.cardOptions
                     )
                 )
             }
@@ -1394,6 +1408,10 @@ class TabCoordinator {
         }
 
         config.workspacePaths.removeAll { $0 == tab.repoPath }
+        // The integration checkout goes with the repo. Nothing pruned these
+        // before, so a repo removed and re-added came back with a checkout
+        // pointing at a directory that had been deleted with it.
+        IntegrationWorktreeStore.shared.forget(repoPath: tab.repoPath)
         saveConfig()
 
         workspaceManager.removeTab(at: tabIndex)
@@ -1593,18 +1611,13 @@ class TabCoordinator {
         // Dashboard handles focus panel — no separate tab needed
     }
 
-    func dashboardDidRequestDelete(_ terminalID: String, window: NSWindow?) {
-        guard let agent = AgentRegistry.shared.pane(for: terminalID) else { return }
-        let worktreePath = agent.worktreePath
-        guard let item = allWorktrees.first(where: { $0.info.path == worktreePath }) else { return }
+    func dashboardDidRequestDeleteWorktree(path: String, window: NSWindow?) {
+        let wanted = WorktreeDiscovery.canonicalPath(path)
+        guard let item = allWorktrees.first(where: { WorktreeDiscovery.canonicalPath($0.info.path) == wanted }) else {
+            NSSound.beep()
+            return
+        }
         terminalCoordinator.confirmAndDeleteWorktree(item.info, window: window)
-    }
-
-    func dashboardDidRequestDeleteWithBranch(_ terminalID: String, window: NSWindow?) {
-        guard let agent = AgentRegistry.shared.pane(for: terminalID) else { return }
-        let worktreePath = agent.worktreePath
-        guard let item = allWorktrees.first(where: { $0.info.path == worktreePath }) else { return }
-        terminalCoordinator.confirmAndDeleteWorktree(item.info, window: window, preferredDeleteBranch: true)
     }
 
     // MARK: - New Branch Integration

--- a/Sources/App/TerminalCoordinator.swift
+++ b/Sources/App/TerminalCoordinator.swift
@@ -528,71 +528,62 @@ class TerminalCoordinator {
 
     // MARK: - Worktree Deletion
 
-    func confirmAndDeleteWorktree(_ info: WorktreeInfo, window: NSWindow?, preferredDeleteBranch: Bool? = nil) {
+    /// The row's Delete. Decides on its own whether to ask: a worktree with
+    /// nothing of its own — clean, every commit already on trunk or its
+    /// upstream — goes outright, branch included. Anything that would be lost
+    /// gets one sheet that names it, and a confirmed delete is a forced one.
+    /// See `WorktreeDeleteAssessment` for why there is no sheet on the safe
+    /// path.
+    func confirmAndDeleteWorktree(_ info: WorktreeInfo, window: NSWindow?) {
         guard !info.isMainWorktree else { return }
         guard let window else { return }
 
-        // Both are synchronous git subprocesses (up to a 5s timeout on a wedged
-        // repo) — run them off the main thread, then present the alert.
+        // The integration checkout is detached and its commits are throwaway
+        // builds, so "what would be lost" is a different question there: only
+        // work that arrived by hand counts, which is what its hold logic knows.
+        let isIntegration = IntegrationWorktreeStore.shared.isIntegrationWorktree(info.path)
+        let expectedHead = isIntegration
+            ? IntegrationWorktreeStore.shared.lastPublishedCommit(forCheckout: info.path)
+            : nil
+
+        // Several synchronous git subprocesses (up to a 5s timeout each on a
+        // wedged repo) — run them off the main thread, then decide.
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let hasChanges = WorktreeDeleter.hasUncommittedChanges(worktreePath: info.path)
             let repoPath = WorktreeDiscovery.findRepoRoot(from: info.path) ?? info.path
+            let assessment = isIntegration
+                ? IntegrationWorktree.assessDeletion(path: info.path, repoPath: repoPath, expectedHead: expectedHead)
+                : WorktreeDeleter.assessDeletion(worktreePath: info.path, repoPath: repoPath, branchName: info.branch)
             DispatchQueue.main.async {
-                self?.presentDeleteConfirmation(info, window: window,
-                                                hasChanges: hasChanges,
-                                                repoPath: repoPath,
-                                                preferredDeleteBranch: preferredDeleteBranch)
+                guard let self else { return }
+                if assessment.isSafe {
+                    // The assessment established the branch's commits are on
+                    // trunk or upstream, so `-D`: git's own `-d` only consults
+                    // the upstream and would keep a PR-merged branch with one
+                    // unpushed commit for no reason.
+                    self.performDeleteWorktree(info, repoPath: repoPath,
+                                               deleteBranch: assessment.deletesBranch,
+                                               force: false, forceBranch: true)
+                } else {
+                    self.presentDeleteConfirmation(info, window: window, repoPath: repoPath, assessment: assessment)
+                }
             }
         }
     }
 
     private func presentDeleteConfirmation(_ info: WorktreeInfo, window: NSWindow,
-                                           hasChanges: Bool, repoPath: String,
-                                           preferredDeleteBranch: Bool?) {
+                                           repoPath: String, assessment: WorktreeDeleteAssessment) {
         let alert = NSAlert()
-        alert.alertStyle = hasChanges ? .critical : .warning
-        alert.messageText = "Delete worktree \"\(info.branch)\"?"
-        let deleteBranch = preferredDeleteBranch ?? false
-        if hasChanges {
-            if deleteBranch {
-                alert.informativeText = "This worktree has uncommitted changes that will be lost. Seahelm will also try to delete the local branch."
-            } else {
-                alert.informativeText = "This worktree has uncommitted changes that will be lost."
-            }
-        } else {
-            if deleteBranch {
-                alert.informativeText = "The worktree directory will be removed, then Seahelm will try to delete the local branch."
-            } else {
-                alert.informativeText = "The worktree directory will be removed."
-            }
-        }
-        if let preferredDeleteBranch {
-            alert.addButton(withTitle: preferredDeleteBranch ? "Delete + Branch" : "Delete")
-            alert.addButton(withTitle: "Cancel")
-        } else {
-            alert.addButton(withTitle: "Delete")
-            alert.addButton(withTitle: "Delete + Branch")
-            alert.addButton(withTitle: "Cancel")
-        }
-
+        alert.alertStyle = .critical
+        alert.messageText = "Delete worktree \u{201C}\(info.displayName)\u{201D}?"
+        alert.informativeText = assessment.losses.joined(separator: "\n\n")
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
         alert.buttons[0].hasDestructiveAction = true
-        if preferredDeleteBranch == nil {
-            alert.buttons[1].hasDestructiveAction = true
-        }
 
         alert.beginSheetModal(for: window) { [weak self] response in
-            guard let self else { return }
-            if let preferredDeleteBranch {
-                if response == .alertFirstButtonReturn {
-                    self.performDeleteWorktree(info, repoPath: repoPath, deleteBranch: preferredDeleteBranch, force: hasChanges)
-                }
-                return
-            }
-            if response == .alertFirstButtonReturn {
-                self.performDeleteWorktree(info, repoPath: repoPath, deleteBranch: false, force: hasChanges)
-            } else if response == .alertSecondButtonReturn {
-                self.performDeleteWorktree(info, repoPath: repoPath, deleteBranch: true, force: hasChanges)
-            }
+            guard let self, response == .alertFirstButtonReturn else { return }
+            self.performDeleteWorktree(info, repoPath: repoPath,
+                                       deleteBranch: assessment.deletesBranch, force: true)
         }
     }
 
@@ -613,7 +604,8 @@ class TerminalCoordinator {
         }
     }
 
-    private func performDeleteWorktree(_ info: WorktreeInfo, repoPath: String, deleteBranch: Bool, force: Bool) {
+    private func performDeleteWorktree(_ info: WorktreeInfo, repoPath: String, deleteBranch: Bool,
+                                       force: Bool, forceBranch: Bool? = nil) {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             do {
                 let result = try WorktreeDeleter.deleteWorktree(
@@ -621,7 +613,8 @@ class TerminalCoordinator {
                     repoPath: repoPath,
                     branchName: info.branch,
                     deleteBranch: deleteBranch,
-                    force: force
+                    force: force,
+                    forceBranch: forceBranch
                 )
                 DispatchQueue.main.async {
                     guard let self else { return }
@@ -652,6 +645,13 @@ class TerminalCoordinator {
         config.focusedPaneIds.removeValue(forKey: info.path)
         config.save()
         stationManager.removeTree(forPath: info.path)
+        // Deleting the integration checkout is opting the repo back out:
+        // automatic rounds already stop on a missing directory, and leaving
+        // the record behind would show a stale status line for a checkout that
+        // no longer exists. `/integrate` recreates and re-records it.
+        if let repo = IntegrationWorktreeStore.shared.repoPath(forCheckout: info.path) {
+            IntegrationWorktreeStore.shared.forget(repoPath: repo)
+        }
         delegate?.terminalCoordinator(self, didDeleteWorktree: info)
     }
 

--- a/Sources/Core/ControlProtocol.swift
+++ b/Sources/Core/ControlProtocol.swift
@@ -119,6 +119,10 @@ protocol ControlDataSource: AnyObject {
     func wakePane(paneId: String?) -> [String]?
     /// This process's own memory accounting plus awake/asleep pane counts.
     func memoryStats() -> [String: Any]?
+    /// The integration checkouts and what the last round put in them. `path` is
+    /// any path inside a repo (an agent's cwd, usually) and narrows the answer
+    /// to that repo; nil returns every checkout.
+    func integrationStatus(path: String?) -> [String: Any]?
 }
 
 extension ControlDataSource {
@@ -140,6 +144,7 @@ extension ControlDataSource {
     func sleepPane(paneId: String?) -> [String]? { nil }
     func wakePane(paneId: String?) -> [String]? { nil }
     func memoryStats() -> [String: Any]? { nil }
+    func integrationStatus(path: String?) -> [String: Any]? { nil }
 }
 
 /// Pure mapping of named keys/combos to the raw bytes they deliver to the PTY.
@@ -386,6 +391,16 @@ final class ControlRouter {
             }
             guard let detail = dataSource?.explainPane(paneId: paneId) else {
                 return .error(code: ControlError.notFound, message: "pane not found: \(paneId)")
+            }
+            return .ok(detail)
+
+        case "integration.status":
+            // Read-only, and the answer an agent cannot get any other way: the
+            // round that folds its work in is triggered by its own turn ending,
+            // so looking at git from inside the turn always shows the round
+            // before. This is the only way to ask without racing that edge.
+            guard let detail = dataSource?.integrationStatus(path: params["path"] as? String) else {
+                return .error(code: ControlError.notFound, message: "no integration state")
             }
             return .ok(detail)
 

--- a/Sources/Core/IntegrationCoordinator.swift
+++ b/Sources/Core/IntegrationCoordinator.swift
@@ -32,6 +32,9 @@ final class IntegrationCoordinator {
     /// Whether a worktree has an agent mid-turn. Such a worktree contributes its
     /// HEAD rather than a live snapshot — see `IntegrationRunner.run`.
     private let isWorktreeBusy: (String) -> Bool
+    /// The commit seahelm last published into a checkout, so a round can tell
+    /// work that arrived by hand from work it put there itself.
+    private let lastPublished: (String) -> String?
     private let onReport: (IntegrationRunReport, String) -> Void
     private let runRound: (String, String, [WorktreeInfo]) throws -> IntegrationRunReport
 
@@ -46,6 +49,7 @@ final class IntegrationCoordinator {
         integrationPath: @escaping (String) -> String?,
         isCheckoutBusy: @escaping (String) -> Bool,
         isWorktreeBusy: @escaping (String) -> Bool = { _ in false },
+        lastPublished: @escaping (String) -> String? = { _ in nil },
         onReport: @escaping (IntegrationRunReport, String) -> Void,
         runRound: ((String, String, [WorktreeInfo]) throws -> IntegrationRunReport)? = nil
     ) {
@@ -56,10 +60,13 @@ final class IntegrationCoordinator {
         self.integrationPath = integrationPath
         self.isCheckoutBusy = isCheckoutBusy
         self.isWorktreeBusy = isWorktreeBusy
+        self.lastPublished = lastPublished
         self.onReport = onReport
         self.runRound = runRound ?? { repo, path, trees in
             try IntegrationRunner.run(repoPath: repo, integrationPath: path,
-                                      worktrees: trees, isBusy: isWorktreeBusy)
+                                      worktrees: trees,
+                                      lastPublished: lastPublished(path),
+                                      isBusy: isWorktreeBusy)
         }
     }
 

--- a/Sources/Core/IntegrationRunner.swift
+++ b/Sources/Core/IntegrationRunner.swift
@@ -36,8 +36,10 @@ struct IntegrationRunReport: Equatable {
             // and raising one every round would be pure noise.
             line += " · \(committedOnly.count) still working"
         }
-        if case .held = outcome {
-            line += " · pending"
+        switch outcome {
+        case .held(.dirtyWorktree, _): line += " · held · local edits"
+        case .held(.movedHead, _): line += " · held · commits made here"
+        case .published, .unchanged, .failed: break
         }
         return line
     }
@@ -46,7 +48,15 @@ struct IntegrationRunReport: Equatable {
     /// round, so they cannot disagree about it.
     var panelState: IntegrationPanelState {
         var held = false
-        if case .held = outcome { held = true }
+        var heldPaths: [String]?
+        var heldHead: String?
+        if case .held(let reason, _) = outcome {
+            held = true
+            switch reason {
+            case .dirtyWorktree(let paths): heldPaths = paths
+            case .movedHead(let head): heldHead = head
+            }
+        }
         return IntegrationPanelState(
             line: cardLine,
             included: result.included,
@@ -54,9 +64,34 @@ struct IntegrationRunReport: Equatable {
                 IntegrationPanelState.Excluded(label: $0.label, paths: $0.conflictingPaths)
             },
             conflictedPaths: result.conflictedPaths,
-            isHeld: held
+            isHeld: held,
+            heldPaths: heldPaths,
+            heldHead: heldHead
         )
     }
+
+    /// Whether the hold is one `force` would clear. Drives the card's options:
+    /// offering to discard is only honest when there is something to discard.
+    var isHeld: Bool {
+        if case .held = outcome { return true }
+        return false
+    }
+
+    /// Buttons for the report card. A held round is the only one with something
+    /// to decide — publishing would destroy what is in the checkout — and the
+    /// label has to name what goes, because that is the whole decision.
+    /// Everything else is a notice, and takes the default single button.
+    var cardOptions: [String]? {
+        switch outcome {
+        case .held(.dirtyWorktree, _): return ["Discard edits & update", "Leave it"]
+        case .held(.movedHead, _): return ["Discard commits & update", "Leave it"]
+        case .published, .unchanged, .failed: return nil
+        }
+    }
+
+    /// Whether a card option means "run it again with force". Matched on the
+    /// prefix the two discard labels share, so the wording stays free to change.
+    static func isDiscardOption(_ text: String) -> Bool { text.hasPrefix("Discard") }
 
     /// One line for a notification or the helm.
     var summary: String {
@@ -83,11 +118,24 @@ struct IntegrationRunReport: Equatable {
         switch outcome {
         case .published: break
         case .unchanged: parts.append("already current")
-        case .held(.dirtyWorktree, _):
-            parts.append("not checked out — local edits in the integration worktree; `/integrate force` to discard them")
+        case .held(.dirtyWorktree(let paths), _):
+            parts.append(
+                "not checked out — local edits in the integration worktree"
+                    + Self.pathList(paths)
+                    + "; `/integrate force` to discard them"
+            )
+        case .held(.movedHead(let head), _):
+            parts.append(
+                "not checked out — the checkout is at \(head.prefix(9)), which seahelm did not put there;"
+                    + " commit or move that work somewhere it will survive, or `/integrate force` to drop it"
+            )
         case .failed(let message): parts.append("checkout failed: \(message)")
         }
         return parts.joined(separator: " · ")
+    }
+
+    private static func pathList(_ paths: [String], limit: Int = 4) -> String {
+        IntegrationWorktree.pathList(paths, limit: limit)
     }
 }
 
@@ -140,15 +188,22 @@ enum IntegrationRunner {
         worktrees: [WorktreeInfo],
         mode: IntegrationConflictMode = .excludeConflicting,
         force: Bool = false,
+        lastPublished: String? = nil,
         isBusy: (String) -> Bool = { _ in false }
     ) throws -> IntegrationRunReport {
         guard let base = GitDiff.resolveBaseRef(worktreePath: repoPath) else {
             throw IntegrationRunError.noBaseRef
         }
 
+        var createdHead: String?
         if !FileManager.default.fileExists(atPath: integrationPath) {
             do {
                 try IntegrationWorktree.create(repoPath: repoPath, at: integrationPath, base: base)
+                createdHead = GitProcess.run(
+                    ["rev-parse", "--verify", "--quiet", "HEAD"],
+                    in: integrationPath,
+                    timeout: IntegrationWorktree.timeout
+                )?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
             } catch {
                 throw IntegrationRunError.worktreeUnavailable(error.localizedDescription)
             }
@@ -192,7 +247,16 @@ enum IntegrationRunner {
             throw IntegrationRunError.noBaseRef
         }
 
-        let outcome = IntegrationWorktree.publish(commit: result.commit, to: integrationPath, force: force)
+        let outcome = IntegrationWorktree.publish(
+            commit: result.commit,
+            to: integrationPath,
+            force: force,
+            // A checkout this round just created is at `base` and nothing else,
+            // so it is its own provenance — without this the very first round
+            // into a new checkout would hold on a head it wrote itself.
+            expectedHead: lastPublished ?? createdHead,
+            base: base
+        )
         return IntegrationRunReport(
             integrationWorktreePath: integrationPath,
             result: result,
@@ -201,4 +265,8 @@ enum IntegrationRunner {
             committedOnly: partial
         )
     }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
 }

--- a/Sources/Core/IntegrationStatusStore.swift
+++ b/Sources/Core/IntegrationStatusStore.swift
@@ -14,12 +14,31 @@ struct IntegrationPanelState: Codable, Equatable {
     var excluded: [Excluded]
     /// Paths carrying conflict markers, when the round kept conflicting sources.
     var conflictedPaths: [String]
-    /// The result was built but not checked out — local edits in the checkout.
+    /// The result was built but not checked out — something in the checkout
+    /// would have been destroyed by the reset.
     var isHeld: Bool
+    /// What was in the way. Optional so state written before this existed still
+    /// decodes — a card that falls back to the raw JSON reads far worse than a
+    /// card missing one line.
+    var heldPaths: [String]?
+    /// Set instead of `heldPaths` when the hold was a commit made in the
+    /// checkout rather than an uncommitted edit.
+    var heldHead: String?
 
     struct Excluded: Codable, Equatable {
         var label: String
         var paths: [String]
+    }
+
+    init(line: String, included: [String], excluded: [Excluded], conflictedPaths: [String],
+         isHeld: Bool, heldPaths: [String]? = nil, heldHead: String? = nil) {
+        self.line = line
+        self.included = included
+        self.excluded = excluded
+        self.conflictedPaths = conflictedPaths
+        self.isHeld = isHeld
+        self.heldPaths = heldPaths
+        self.heldHead = heldHead
     }
 }
 

--- a/Sources/Core/IntegrationWorktreeStore.swift
+++ b/Sources/Core/IntegrationWorktreeStore.swift
@@ -11,6 +11,10 @@ final class IntegrationWorktreeStore {
     static let shared = IntegrationWorktreeStore()
 
     private let store = PersistedStringMap(fileName: "integration-worktrees.json")
+    /// Checkout path → the commit seahelm last published there. Provenance,
+    /// not display: `IntegrationWorktree.publish` compares it against the
+    /// checkout's real HEAD to notice work that arrived by hand.
+    private let published = PersistedStringMap(fileName: "integration-published.json")
     /// Membership cache. `isIntegrationWorktree` is asked once per pane per
     /// render, on a two-second poll, so it must not rebuild a set each time.
     private var knownPaths: Set<String>
@@ -32,8 +36,34 @@ final class IntegrationWorktreeStore {
         refreshCache()
     }
 
+    /// Every repo's checkout, keyed by repo path.
+    var checkoutsByRepo: [String: String] { store.entries }
+
+    /// Which repo a checkout belongs to. The reverse lookup, for the paths that
+    /// arrive as a checkout — a card, a CLI call from inside one.
+    func repoPath(forCheckout path: String) -> String? {
+        let canonical = WorktreeDiscovery.canonicalPath(path)
+        return store.entries.first { $0.value == canonical }?.key
+    }
+
+    /// The commit seahelm last checked out there, or nil if it never has.
+    func lastPublishedCommit(forCheckout path: String) -> String? {
+        published[WorktreeDiscovery.canonicalPath(path)]?.nonEmptyTrimmed
+    }
+
+    func recordPublished(_ commit: String, forCheckout path: String) {
+        published.set(commit, forKey: WorktreeDiscovery.canonicalPath(path))
+    }
+
+    /// Drops everything remembered about a repo's checkout. Worktree paths get
+    /// reused, so a stale entry would answer for whatever lands there next.
     func forget(repoPath: String) {
-        store.remove(forKey: WorktreeDiscovery.canonicalPath(repoPath))
+        let key = WorktreeDiscovery.canonicalPath(repoPath)
+        if let checkout = store[key] {
+            published.remove(forKey: checkout)
+            IntegrationStatusStore.shared.forget(worktreePath: checkout)
+        }
+        store.remove(forKey: key)
         refreshCache()
     }
 

--- a/Sources/Core/PersistedStringMap.swift
+++ b/Sources/Core/PersistedStringMap.swift
@@ -39,6 +39,12 @@ final class PersistedStringMap {
         return Set(map.values)
     }
 
+    /// Snapshot of the whole map, for the callers that need the keys too.
+    var entries: [String: String] {
+        lock.lock(); defer { lock.unlock() }
+        return map
+    }
+
     /// Drop a key. Worktree paths get reused — a stale entry left behind by a
     /// deleted worktree would answer for whatever is created at that path next.
     func remove(forKey key: String) {

--- a/Sources/Core/SeahelmCliInstaller.swift
+++ b/Sources/Core/SeahelmCliInstaller.swift
@@ -6,7 +6,7 @@ import Foundation
 /// pure python3 (present wherever the CLTs/agent runtimes are) and talks the same
 /// newline-delimited JSON protocol as ControlSocketServer.
 enum SeahelmCliInstaller {
-    private static let versionMarker = "# seahelm-cli v8"
+    private static let versionMarker = "# seahelm-cli v9"
 
     static func scriptContents() -> String {
         return #"""
@@ -51,7 +51,7 @@ enum SeahelmCliInstaller {
         def main():
             argv = sys.argv[1:]
             if not argv:
-                die("usage: seahelm <ping|memory|session|pane|wait|events|layout> ...", 2)
+                die("usage: seahelm <ping|memory|session|pane|wait|events|layout|integration> ...", 2)
             g = argv[0]; a = argv[1:]
 
             if g == "ping":
@@ -83,6 +83,18 @@ enum SeahelmCliInstaller {
                 except Exception as e:
                     die("socket error: %s" % e)
                 return
+
+            if g == "integration":
+                # seahelm integration status [path]
+                # Defaults to the cwd's repo: an agent asking "did my work get
+                # folded in?" is asking about the repo it is standing in.
+                if a and a[0] not in ("status",):
+                    die("unknown integration subcommand: %s" % a[0])
+                rest = a[1:] if a else []
+                path = rest[0] if rest and not rest[0].startswith("--") else (
+                    None if has(rest, "--all") else os.getcwd())
+                p = {"path": path} if path else {}
+                print(json.dumps(call("integration.status", p).get("checkouts", []), indent=2)); return
 
             if g == "layout":
                 if not a: die("usage: seahelm layout <export|apply [file|-]>")

--- a/Sources/Core/SeahelmControlDataSource.swift
+++ b/Sources/Core/SeahelmControlDataSource.swift
@@ -252,6 +252,50 @@ final class SeahelmControlDataSource: ControlDataSource {
         MemoryProbe.stats()
     }
 
+    /// The integration checkouts, live. Reads the stores rather than the app's
+    /// UI state, so it answers the same from any thread the socket serves.
+    func integrationStatus(path: String?) -> [String: Any]? {
+        let all = IntegrationWorktreeStore.shared.checkoutsByRepo
+        var wanted = all
+        if let path, !path.isEmpty {
+            // An unknown repo answers with an empty list rather than with every
+            // other repo's state: "this one has no checkout" is the true answer,
+            // and a fleet-wide dump would read as if it did.
+            let repo = WorktreeDiscovery.findRepoRoot(from: path).map(WorktreeDiscovery.canonicalPath)
+            wanted = all.filter { $0.key == repo }
+        }
+
+        let checkouts: [[String: Any]] = wanted.keys.sorted().compactMap { repo in
+            guard let checkout = wanted[repo] else { return nil }
+            var entry: [String: Any] = ["repo": repo, "checkout": checkout]
+            entry["exists"] = FileManager.default.fileExists(atPath: checkout)
+            let head = GitProcess.run(
+                ["rev-parse", "--verify", "--quiet", "HEAD"],
+                in: checkout,
+                timeout: IntegrationWorktree.timeout
+            )?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let head, !head.isEmpty { entry["head"] = head }
+            let published = IntegrationWorktreeStore.shared.lastPublishedCommit(forCheckout: checkout)
+            if let published {
+                entry["last_published"] = published
+                // The state the desktop card calls "commits made here": worth
+                // its own field, because it is the one an agent should react to.
+                entry["moved_by_hand"] = (head != nil && head != published)
+            }
+            if let state = IntegrationStatusStore.shared.state(forWorktree: checkout) {
+                entry["line"] = state.line
+                entry["included"] = state.included
+                entry["excluded"] = state.excluded.map { ["label": $0.label, "paths": $0.paths] }
+                entry["conflicted_paths"] = state.conflictedPaths
+                entry["held"] = state.isHeld
+                if let paths = state.heldPaths { entry["held_paths"] = paths }
+                if let heldHead = state.heldHead { entry["held_head"] = heldHead }
+            }
+            return entry
+        }
+        return ["checkouts": checkouts]
+    }
+
     func explainPane(paneId: String) -> [String: Any]? {
         guard let station = station(for: paneId) else { return nil }
         let pane = AgentRegistry.shared.pane(for: station.id)

--- a/Sources/Git/IntegrationWorktree.swift
+++ b/Sources/Git/IntegrationWorktree.swift
@@ -3,8 +3,27 @@ import Foundation
 /// Why a freshly built integration was not checked out.
 enum IntegrationHoldReason: Equatable {
     /// Someone edited files in the integration checkout. Publishing would
-    /// discard them, so it waits to be told.
-    case dirtyWorktree
+    /// discard them, so it waits to be told. It carries the paths because the
+    /// only useful question about a hold is which files are in the way.
+    case dirtyWorktree(paths: [String])
+    /// The checkout is not where seahelm left it — someone committed in here.
+    /// `reset --hard` would drop those commits with nothing to recover them
+    /// from, and a hand-resolved conflict is exactly the kind of work that
+    /// arrives this way: the checkout is where you go to resolve one.
+    case movedHead(head: String)
+
+    /// The sheet line for a reset or delete that would destroy this. Names
+    /// what goes, because that is the whole decision.
+    var lossDescription: String {
+        switch self {
+        case .dirtyWorktree(let paths):
+            return "Local edits in the integration worktree will be discarded"
+                + IntegrationWorktree.pathList(paths) + "."
+        case .movedHead(let head):
+            return "Commits made in the integration worktree (at \(head.prefix(9))) are on no branch"
+                + " and will be dropped."
+        }
+    }
 }
 
 enum IntegrationPublishOutcome: Equatable {
@@ -95,7 +114,21 @@ enum IntegrationWorktree {
     /// instead — this is the one irreversible step in the feature, and it needs
     /// a deliberate `force` rather than happening quietly while someone is
     /// mid-edit.
-    static func publish(commit: String, to path: String, force: Bool = false) -> IntegrationPublishOutcome {
+    ///
+    /// Uncommitted work is not the only thing a reset can destroy: a commit made
+    /// in the checkout leaves it perfectly clean, so the dirty check waves it
+    /// through and the next round overwrites it. `expectedHead` (the commit
+    /// seahelm last published here) and `base` (the trunk this round is built
+    /// on) are what let it tell its own work from someone else's — see
+    /// `isSeahelmsOwnWork`. Passing neither skips the check entirely, because
+    /// with no information at all a guard could only guess.
+    static func publish(
+        commit: String,
+        to path: String,
+        force: Bool = false,
+        expectedHead: String? = nil,
+        base: String? = nil
+    ) -> IntegrationPublishOutcome {
         // Trees, not commits. `commit-tree` stamps a timestamp, so rebuilding an
         // unchanged fleet yields a different commit holding identical files —
         // comparing commits would make every round look like a change and reset
@@ -105,18 +138,15 @@ enum IntegrationWorktree {
         }
         let targetTree = revParse("\(commit)^{tree}", in: path)
 
-        let status = GitProcess.run(
-            ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
-            in: path,
-            timeout: timeout
-        )
-        let isDirty = !(status ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let dirtyPaths = localEditPaths(at: path)
 
-        if let targetTree, targetTree == headTree, !isDirty {
+        // Nothing to do: the files already match, so neither a stray commit nor
+        // the absence of one can cost anything — there is no reset to hold back.
+        if let targetTree, targetTree == headTree, dirtyPaths.isEmpty {
             return .unchanged(commit: commit)
         }
-        if isDirty && !force {
-            return .held(reason: .dirtyWorktree, commit: commit)
+        if !force, let reason = handWork(at: path, dirtyPaths: dirtyPaths, expectedHead: expectedHead, base: base) {
+            return .held(reason: reason, commit: commit)
         }
 
         let result = GitProcess.capture(["reset", "--hard", commit], in: path, timeout: timeout)
@@ -124,6 +154,147 @@ enum IntegrationWorktree {
             return .failed(result.stderr.isEmpty ? "git reset --hard failed" : result.stderr)
         }
         return .published(commit: commit)
+    }
+
+    /// Work in the checkout that arrived by hand — what a `reset --hard` would
+    /// destroy. Nil when there is none. `expectedHead` and `base` as in
+    /// `publish`; passing neither skips the commit check.
+    static func handWork(at path: String, expectedHead: String?, base: String?) -> IntegrationHoldReason? {
+        handWork(at: path, dirtyPaths: localEditPaths(at: path), expectedHead: expectedHead, base: base)
+    }
+
+    private static func handWork(
+        at path: String,
+        dirtyPaths: [String],
+        expectedHead: String?,
+        base: String?
+    ) -> IntegrationHoldReason? {
+        // Checked before the dirty case: both block the same reset, but losing
+        // committed work is the more surprising of the two, and "discard your
+        // edits" is the wrong thing to offer someone who committed them.
+        if expectedHead != nil || base != nil, let head = revParse("HEAD", in: path),
+           !isSeahelmsOwnWork(head: head, expectedHead: expectedHead, base: base, path: path) {
+            return .movedHead(head: head)
+        }
+        if !dirtyPaths.isEmpty {
+            return .dirtyWorktree(paths: dirtyPaths)
+        }
+        return nil
+    }
+
+    // MARK: - Reset to trunk
+
+    /// Where a reset lands.
+    struct ResetTarget: Equatable {
+        let ref: String
+        let commit: String
+    }
+
+    /// The trunk a reset moves the checkout onto: `origin/main` when the repo
+    /// has one, then the same list `GitDiff` guesses a base from. `fetch`
+    /// refreshes it from origin first — "in sync with origin/main" means the
+    /// origin's main, not the one seen at the last fetch — but only best
+    /// effort: offline, the reset still lands on the trunk already known.
+    static func resetTarget(repoPath: String, fetch: Bool = true) -> ResetTarget? {
+        if fetch { fetchTrunk(repoPath: repoPath) }
+        for ref in GitDiff.preferredBaseRefs {
+            if let commit = revParse(ref, in: repoPath) {
+                return ResetTarget(ref: ref, commit: commit)
+            }
+        }
+        return nil
+    }
+
+    private static func fetchTrunk(repoPath: String) {
+        for name in ["main", "master"] {
+            // `+` so a rewound trunk still updates; the prompt is disabled
+            // because there is no terminal to answer one on.
+            _ = GitProcess.capture(
+                ["fetch", "--quiet", "origin", "+\(name):refs/remotes/origin/\(name)"],
+                in: repoPath,
+                timeout: timeout,
+                environment: ["GIT_TERMINAL_PROMPT": "0"]
+            )
+        }
+    }
+
+    /// Moves the checkout onto trunk. Same hold rules as `publish`, so a
+    /// reset never quietly walks over edits or commits someone made here —
+    /// the caller presents a held reset and comes back with `force`.
+    ///
+    /// Unlike `publish`, this compares commits rather than trees: the point
+    /// is for HEAD to *be* trunk, not merely to hold the same files.
+    static func reset(
+        to target: ResetTarget,
+        at path: String,
+        force: Bool = false,
+        expectedHead: String? = nil
+    ) -> IntegrationPublishOutcome {
+        guard let head = revParse("HEAD", in: path) else {
+            return .failed("Not a worktree: \(path)")
+        }
+        let dirtyPaths = localEditPaths(at: path)
+        if head == target.commit, dirtyPaths.isEmpty {
+            return .unchanged(commit: target.commit)
+        }
+        if !force, let reason = handWork(at: path, dirtyPaths: dirtyPaths, expectedHead: expectedHead, base: target.ref) {
+            return .held(reason: reason, commit: target.commit)
+        }
+        let result = GitProcess.capture(["reset", "--hard", target.commit], in: path, timeout: timeout)
+        guard result.succeeded else {
+            return .failed(result.stderr.isEmpty ? "git reset --hard failed" : result.stderr)
+        }
+        return .published(commit: target.commit)
+    }
+
+    /// What deleting the checkout would destroy, in the same terms a reset
+    /// uses. A checkout sitting where seahelm left it holds nothing of its
+    /// own — its commits are throwaway builds — so it goes without a sheet.
+    static func assessDeletion(path: String, repoPath: String, expectedHead: String?) -> WorktreeDeleteAssessment {
+        let base = resetTarget(repoPath: repoPath, fetch: false)?.ref
+        let losses = handWork(at: path, expectedHead: expectedHead, base: base).map { [$0.lossDescription] } ?? []
+        // Detached: there is no branch to delete.
+        return WorktreeDeleteAssessment(losses: losses, deletesBranch: false)
+    }
+
+    /// A hold is only actionable if it says what is in the way, and only
+    /// readable if it stops before the whole tree — a `pnpm install` dirties
+    /// hundreds of paths.
+    static func pathList(_ paths: [String], limit: Int = 4) -> String {
+        guard !paths.isEmpty else { return "" }
+        let shown = paths.prefix(limit).joined(separator: ", ")
+        let rest = paths.count - min(limit, paths.count)
+        return rest > 0 ? " (\(shown) +\(rest) more)" : " (\(shown))"
+    }
+
+    /// Whether the checkout's HEAD is something seahelm put there.
+    ///
+    /// Three ways to be sure, in order of how directly they answer:
+    ///
+    /// 1. it is the commit we recorded publishing;
+    /// 2. it carries seahelm's committer identity, which only
+    ///    `WorktreeSnapshotter.commitTree` writes — this is what makes the
+    ///    guard work on the *first* round after an upgrade, rather than one
+    ///    round late, which is one round too late for the work it protects;
+    /// 3. it is contained in the trunk this round builds on, i.e. the checkout
+    ///    holds nothing of its own. A checkout sitting where it was created
+    ///    answers here.
+    ///
+    /// Anything else is work that arrived by hand, and a `reset --hard` would
+    /// be the only record that it ever existed.
+    static func isSeahelmsOwnWork(head: String, expectedHead: String?, base: String?, path: String) -> Bool {
+        if let expectedHead, head == expectedHead { return true }
+        let committer = GitProcess.run(["log", "-1", "--format=%ce", head], in: path, timeout: timeout)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if committer == WorktreeSnapshotter.authorEmail { return true }
+        if let base {
+            return GitProcess.capture(
+                ["merge-base", "--is-ancestor", head, base],
+                in: path,
+                timeout: timeout
+            ).succeeded
+        }
+        return false
     }
 
     private static func revParse(_ rev: String, in path: String) -> String? {
@@ -134,11 +305,34 @@ enum IntegrationWorktree {
 
     /// True when the checkout carries edits that publishing would discard.
     static func hasLocalEdits(at path: String) -> Bool {
+        !localEditPaths(at: path).isEmpty
+    }
+
+    /// The paths publishing would discard — modified, staged and untracked.
+    static func localEditPaths(at path: String) -> [String] {
         guard let status = GitProcess.run(
             ["status", "--porcelain=v1", "-z", "--untracked-files=all"],
             in: path,
             timeout: timeout
-        ) else { return false }
-        return !status.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        ) else { return [] }
+        return parseStatusPaths(status)
+    }
+
+    /// `XY <path>\0` per entry, except renames and copies, which append the
+    /// origin path as a field of its own. Reading that origin as another entry
+    /// would list a file that is not in the way twice over.
+    static func parseStatusPaths(_ raw: String) -> [String] {
+        var paths: [String] = []
+        var fields = raw.components(separatedBy: "\0").filter { !$0.isEmpty }[...]
+        while let entry = fields.first {
+            fields = fields.dropFirst()
+            guard entry.count > 3 else { continue }
+            let code = entry.prefix(2)
+            paths.append(String(entry.dropFirst(3)))
+            if code.contains("R") || code.contains("C") {
+                fields = fields.dropFirst()
+            }
+        }
+        return paths
     }
 }

--- a/Sources/Git/WorktreeDeleter.swift
+++ b/Sources/Git/WorktreeDeleter.swift
@@ -25,6 +25,25 @@ struct WorktreeMergeCheck: Equatable {
     let targetBranch: String?
 }
 
+/// What deleting a worktree would destroy, decided before anything is touched.
+///
+/// The row's Delete reads this to choose between deleting outright and asking
+/// first. A checkout with nothing of its own — clean, every commit already on
+/// trunk or its upstream — is just disk space, and a sheet in front of that is
+/// ceremony that teaches people to click through it, which is the one habit
+/// the sheet exists to prevent. So the sheet appears only when `losses` has
+/// something to say, and it says exactly that.
+struct WorktreeDeleteAssessment: Equatable {
+    /// One line per thing the delete would destroy. Empty means nothing would.
+    var losses: [String]
+    /// Whether the branch goes with the worktree. False for a detached
+    /// checkout (nothing to delete) and for a branch that is a trunk itself —
+    /// a worktree on `main` is removable, `main` is not.
+    var deletesBranch: Bool
+
+    var isSafe: Bool { losses.isEmpty }
+}
+
 struct WorktreeCleanupSummary: Equatable {
     struct Skipped: Equatable {
         let path: String
@@ -47,12 +66,18 @@ enum WorktreeDeleter {
     ///   - repoPath: Root repo path (for running git commands)
     ///   - deleteBranch: If true, also deletes the local branch
     ///   - force: If true, uses --force for dirty worktrees
+    ///   - forceBranch: `-D` rather than `-d` for the branch. Defaults to
+    ///     `force`. A caller that has already established the branch's commits
+    ///     are on trunk (`assessDeletion`) passes true: git's own `-d` check
+    ///     only looks at the upstream, so a branch merged through a PR but
+    ///     with unpushed commits would be kept for no reason.
     static func deleteWorktree(
         worktreePath: String,
         repoPath: String,
         branchName: String,
         deleteBranch: Bool = false,
-        force: Bool = false
+        force: Bool = false,
+        forceBranch: Bool? = nil
     ) throws -> WorktreeDeleteResult {
         // Don't allow deleting the main worktree.
         // Use the first entry from `git worktree list` which is always the main worktree.
@@ -86,11 +111,12 @@ enum WorktreeDeleter {
 
         // Optionally delete the branch
         var branchWarning: String?
-        if deleteBranch {
-            let flag = force ? "-D" : "-d"
+        if deleteBranch, !branchName.isEmpty {
+            let forced = forceBranch ?? force
+            let flag = forced ? "-D" : "-d"
             let (branchOk, branchErr) = runGitWithStderr(args: ["branch", flag, branchName], in: repoPath)
             if !branchOk {
-                branchWarning = classifyBranchDeleteError(branchErr, branch: branchName, forced: force)
+                branchWarning = classifyBranchDeleteError(branchErr, branch: branchName, forced: forced)
                 NSLog("Warning: worktree removed but branch delete failed: \(branchWarning ?? branchErr)")
             }
         }
@@ -101,6 +127,88 @@ enum WorktreeDeleter {
     static func hasUncommittedChanges(worktreePath: String) -> Bool {
         let output = runGit(args: ["status", "--porcelain"], in: worktreePath) ?? ""
         return !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Delete assessment
+
+    static func assessDeletion(worktreePath: String, repoPath: String, branchName: String) -> WorktreeDeleteAssessment {
+        assessDeletion(
+            worktreePath: worktreePath,
+            repoPath: repoPath,
+            branchName: branchName,
+            recordedBase: WorktreeBaseBranchStore.shared.baseBranch(forWorktree: worktreePath)
+        )
+    }
+
+    /// Seam for tests, so they can name the base without writing to the
+    /// user's store. Local only — no fetch, so it answers in well under a
+    /// second and the same offline. What it cannot see is a branch merged on
+    /// the server since the last fetch; that one asks, and the answer is yes.
+    static func assessDeletion(
+        worktreePath: String,
+        repoPath: String,
+        branchName: String,
+        recordedBase: String?
+    ) -> WorktreeDeleteAssessment {
+        var losses: [String] = []
+        if hasUncommittedChanges(worktreePath: worktreePath) {
+            losses.append("It has uncommitted changes that will be lost.")
+        }
+
+        let trunk = GitDiff.resolveBaseRef(worktreePath: worktreePath, recordedBase: recordedBase)
+        let branchIsTrunk = !branchName.isEmpty
+            && (isTrunkName(branchName) || trunk.map { sameBranch($0, branchName) } == true)
+        let deletesBranch = !branchName.isEmpty && !branchIsTrunk
+
+        switch unpublishedCommitCount(worktreePath: worktreePath, trunk: trunk) {
+        case .some(0):
+            break
+        case .some(let count):
+            // `trunk` is non-nil whenever a count is: the count is measured
+            // against it.
+            let subject = branchName.isEmpty ? "It has" : "Branch \u{201C}\(branchName)\u{201D} has"
+            var line = "\(subject) \(count) commit\(count == 1 ? "" : "s") not in \(trunk ?? "trunk") and not pushed"
+            line += deletesBranch ? "; the branch will be deleted with them." : "."
+            losses.append(line)
+        case .none:
+            losses.append("Seahelm could not check whether its commits are merged anywhere.")
+        }
+        return WorktreeDeleteAssessment(losses: losses, deletesBranch: deletesBranch)
+    }
+
+    /// Commits reachable from the worktree's HEAD that are on neither `trunk`
+    /// nor the branch's upstream — what deleting the branch would lose.
+    /// Patch-equivalent commits count as present, so a branch rebased onto
+    /// trunk reads as merged; a squash merge does not, and asks.
+    /// Nil when there is no trunk to measure against.
+    static func unpublishedCommitCount(worktreePath: String, trunk: String?) -> Int? {
+        var refs: [String] = []
+        if let trunk { refs.append(trunk) }
+        if let upstream = runGit(args: ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], in: worktreePath)?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !upstream.isEmpty {
+            refs.append(upstream)
+        }
+        for ref in refs where runGitFull(args: ["merge-base", "--is-ancestor", "HEAD", ref], in: worktreePath).success {
+            return 0
+        }
+        guard let trunk,
+              let output = runGit(
+                args: ["rev-list", "--count", "--cherry-pick", "--right-only", "--no-merges", "\(trunk)...HEAD"],
+                in: worktreePath
+              ),
+              let count = Int(output.trimmingCharacters(in: .whitespacesAndNewlines)) else { return nil }
+        return count
+    }
+
+    private static func isTrunkName(_ branch: String) -> Bool {
+        GitDiff.preferredBaseRefs.contains { sameBranch($0, branch) }
+    }
+
+    /// `origin/main` and `main` name the same branch for the purpose of "is
+    /// this worktree sitting on trunk".
+    private static func sameBranch(_ ref: String, _ branch: String) -> Bool {
+        let stripped = ref.hasPrefix("origin/") ? String(ref.dropFirst("origin/".count)) : ref
+        return stripped == branch
     }
 
     /// Checks whether a linked worktree's committed code is already contained

--- a/Sources/UI/Dashboard/DashboardOverviewView.swift
+++ b/Sources/UI/Dashboard/DashboardOverviewView.swift
@@ -38,7 +38,9 @@ final class DashboardOverviewView: NSView {
     /// the pane's worktree path and its Station id.
     var onSelectPane: ((String, String) -> Void)?
     var onDeleteWorktree: ((String) -> Void)?
-    var onDeleteWorktreeWithBranch: ((String) -> Void)?
+    /// Move a repo's integration checkout back onto origin/main. Only offered
+    /// on rows that are one.
+    var onResetIntegration: ((String) -> Void)?
     /// Right-click "Close Project…" on a project group header. Untracks the repo
     /// and tears down its sessions; worktrees stay on disk.
     var onCloseProject: ((String) -> Void)?
@@ -538,10 +540,11 @@ final class DashboardOverviewView: NSView {
                 let row = RowView(pane: pane,
                                   status: groupedItem.status,
                                   selected: groupedItem.id == selectedId,
-                                  showsRepository: groupingMode != .repository)
+                                  showsRepository: groupingMode != .repository,
+                                  isIntegration: groupedItem.isIntegration)
                 row.onTap = { [weak self] path in self?.onSelectWorktree?(path) }
                 row.onDelete = { [weak self] path in self?.onDeleteWorktree?(path) }
-                row.onDeleteWithBranch = { [weak self] path in self?.onDeleteWorktreeWithBranch?(path) }
+                row.onResetIntegration = { [weak self] path in self?.onResetIntegration?(path) }
                 row.onHoverChanged = { [weak self] row, entered in
                     self?.rowHoverChanged(row, entered: entered)
                 }
@@ -617,7 +620,8 @@ final class DashboardOverviewView: NSView {
             for item in group.items {
                 guard let pane = panesByPath[item.path] else { continue }
                 if let row = rowViewsByID[item.id] {
-                    row.update(pane: pane, status: item.status, selected: item.id == selectedId)
+                    row.update(pane: pane, status: item.status, selected: item.id == selectedId,
+                               isIntegration: item.isIntegration)
                 }
                 if groupingMode == .pane, pane.panes.count > 1 {
                     for paneInfo in pane.panes {
@@ -999,13 +1003,15 @@ final class DashboardOverviewView: NSView {
         /// row, decides what that means — see `FleetHoverRow`.
         var onHoverChanged: ((FleetHoverRow, Bool) -> Void)?
         var onDelete: ((String) -> Void)?
-        var onDeleteWithBranch: ((String) -> Void)?
+        var onResetIntegration: ((String) -> Void)?
         /// Refreshed by `update` rather than fixed at init: a row is keyed by its
         /// station id, and a worktree transfer (`handleNewBranch`) re-registers the
         /// same stations under a new path. A reused row that kept its original
         /// `path` would open, reveal, and *delete* the worktree it used to be.
         private var path: String
         private var isMainWorktree: Bool
+        /// The repo's integration checkout, which gets a Reset in its menu.
+        private var isIntegration: Bool
         private var selected: Bool
         private let showsRepository: Bool
         private let staticDot: NSTextField
@@ -1054,9 +1060,10 @@ final class DashboardOverviewView: NSView {
         }
 
         init(pane: WorktreeRowInfo, status: AgentStatus, selected: Bool,
-             showsRepository: Bool) {
+             showsRepository: Bool, isIntegration: Bool = false) {
             self.path = pane.worktreePath
             self.isMainWorktree = pane.isMainWorktree
+            self.isIntegration = isIntegration
             self.selected = selected
             self.showsRepository = showsRepository
             self.staticDot = Self.label(status.glyph, status.color, 8)
@@ -1184,9 +1191,10 @@ final class DashboardOverviewView: NSView {
             return result
         }
 
-        func update(pane: WorktreeRowInfo, status: AgentStatus, selected: Bool) {
+        func update(pane: WorktreeRowInfo, status: AgentStatus, selected: Bool, isIntegration: Bool = false) {
             path = pane.worktreePath
             isMainWorktree = pane.isMainWorktree
+            self.isIntegration = isIntegration
             setSelected(selected, animated: false)
             setAccessibilityLabel(pane.name)
             applyContent(pane: pane, status: status)
@@ -1248,17 +1256,25 @@ final class DashboardOverviewView: NSView {
                 menu.addItem(item)
             }
             menu.addItem(.separator())
+            if isIntegration {
+                let resetItem = NSMenuItem(title: "Reset to origin/main",
+                                           action: #selector(resetIntegrationAction), keyEquivalent: "")
+                resetItem.target = self
+                resetItem.toolTip = "Fetch origin and move the integration checkout onto trunk."
+                    + " Asks first if edits or commits made here would be lost."
+                menu.addItem(resetItem)
+            }
+            // One Delete, and it takes the branch with it. Whether to ask is
+            // decided from what would be lost, not by a second menu item —
+            // see `TerminalCoordinator.confirmAndDeleteWorktree`.
             let deleteItem = NSMenuItem(title: "Delete", action: #selector(deleteAction), keyEquivalent: "")
             deleteItem.target = self
+            deleteItem.toolTip = "Remove the worktree and its branch."
+                + " Asks first if uncommitted changes or unmerged commits would be lost."
             menu.addItem(deleteItem)
-            let deleteBranchItem = NSMenuItem(title: "Delete + Branch", action: #selector(deleteWithBranchAction), keyEquivalent: "")
-            deleteBranchItem.target = self
-            menu.addItem(deleteBranchItem)
             if isMainWorktree {
                 deleteItem.isEnabled = false
-                deleteBranchItem.isEnabled = false
                 deleteItem.toolTip = "Main worktree cannot be deleted."
-                deleteBranchItem.toolTip = "Main worktree cannot be deleted."
             }
             return menu
         }
@@ -1278,7 +1294,7 @@ final class DashboardOverviewView: NSView {
 
         @objc private func deleteAction() { onDelete?(path) }
 
-        @objc private func deleteWithBranchAction() { onDeleteWithBranch?(path) }
+        @objc private func resetIntegrationAction() { onResetIntegration?(path) }
 
         private var tracking: NSTrackingArea?
         override func updateTrackingAreas() {

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -7,8 +7,10 @@ protocol DashboardDelegate: AnyObject {
     func dashboardDidSelectProject(_ project: String, thread: String)
     func dashboardDidRequestEnterProject(_ project: String)
     func dashboardDidReorderCards(order: [String])
-    func dashboardDidRequestDelete(_ terminalID: String)
-    func dashboardDidRequestDeleteWithBranch(_ terminalID: String)
+    /// The row's Delete. Keyed by worktree path: a row is a worktree, and a
+    /// worktree with no registered agent (a pane that never spoke) must still
+    /// be deletable — the old pane-id key silently dropped those.
+    func dashboardDidRequestDeleteWorktree(path: String)
     func dashboardDidRequestCloseRepo(_ project: String)
     func dashboardDidRequestAddProject()
     func dashboardDidChangeSelection(_ dashboard: DashboardViewController)
@@ -106,6 +108,8 @@ class DashboardViewController: NSViewController {
     /// Fold this project's worktrees into its integration checkout. Equivalent
     /// to typing `/integrate` with that repo selected.
     var onIntegrateProject: ((String) -> Void)?
+    /// Move an integration checkout (by path) back onto origin/main.
+    var onResetIntegration: ((String) -> Void)?
     /// Master switch for the integration feature, forwarded to the fleet view.
     var integrationEnabled: Bool = true {
         didSet { overviewView.integrationEnabled = integrationEnabled }
@@ -340,14 +344,12 @@ class DashboardViewController: NSViewController {
         overviewView.onSelectPane = { [weak self] path, stationId in
             self?.handlePaneRowClick(path: path, stationId: stationId)
         }
-        // Row context menu → the delegate's confirm-and-tear-down path.
+        // Row context menu → the delegate's assess-then-tear-down path.
         overviewView.onDeleteWorktree = { [weak self] path in
-            guard let self, let agent = self.agents.first(where: { $0.worktreePath == path }) else { return }
-            self.dashboardDelegate?.dashboardDidRequestDelete(agent.id)
+            self?.dashboardDelegate?.dashboardDidRequestDeleteWorktree(path: path)
         }
-        overviewView.onDeleteWorktreeWithBranch = { [weak self] path in
-            guard let self, let agent = self.agents.first(where: { $0.worktreePath == path }) else { return }
-            self.dashboardDelegate?.dashboardDidRequestDeleteWithBranch(agent.id)
+        overviewView.onResetIntegration = { [weak self] path in
+            self?.onResetIntegration?(path)
         }
         overviewView.onCloseProject = { [weak self] project in
             self?.dashboardDelegate?.dashboardDidRequestCloseRepo(project)

--- a/Sources/UI/SidePanel/WorktreeSidePanelViewController.swift
+++ b/Sources/UI/SidePanel/WorktreeSidePanelViewController.swift
@@ -688,7 +688,26 @@ final class WorktreeSidePanelViewController: NSViewController {
             lines.append(("conflict markers: " + state.conflictedPaths.joined(separator: ", "), .systemOrange))
         }
         if state.isHeld {
-            lines.append(("not checked out — local edits here · /integrate force", .systemOrange))
+            // Name what is in the way. "local edits here" was true but not
+            // actionable: the checkout is where things get run, so something is
+            // nearly always dirty and the question is only ever *what*.
+            if let head = state.heldHead {
+                lines.append((
+                    "not checked out — commits made here (\(head.prefix(9))) · /integrate force drops them",
+                    .systemOrange
+                ))
+            } else {
+                let paths = state.heldPaths ?? []
+                let shown = paths.prefix(3).joined(separator: ", ")
+                let rest = paths.count - min(3, paths.count)
+                let detail = paths.isEmpty
+                    ? ""
+                    : " (" + shown + (rest > 0 ? " +\(rest) more" : "") + ")"
+                lines.append((
+                    "not checked out — local edits here\(detail) · /integrate force",
+                    .systemOrange
+                ))
+            }
         }
 
         let stack = NSStackView(views: lines.map { text, color in

--- a/Tests/ControlRouterTests.swift
+++ b/Tests/ControlRouterTests.swift
@@ -41,6 +41,12 @@ private final class FakeDataSource: ControlDataSource {
     func focusPane(paneId: String) -> Bool { focused.append(paneId); return mutableOk }
     var explains: [String: [String: Any]] = [:]
     func explainPane(paneId: String) -> [String: Any]? { explains[paneId] }
+    var integrationPaths: [String?] = []
+    var integration: [String: Any]?
+    func integrationStatus(path: String?) -> [String: Any]? {
+        integrationPaths.append(path)
+        return integration
+    }
     var options: [String: [[String: Any]]] = [:]
     var knownForOptions: Set<String> = []
     func paneOptions(paneId: String) -> [[String: Any]]? {
@@ -567,4 +573,34 @@ final class ControlRouterTests: XCTestCase {
         XCTAssertNil(first["memory_mb"])
         XCTAssertNil(first["process_name"])
     }
+
+    // MARK: - integration.status
+
+    /// The one question an agent cannot answer from git: the round that folds
+    /// its work in is triggered by its own turn ending, so reading the checkout
+    /// from inside the turn always shows the round before.
+    func testIntegrationStatusPassesThePathThrough() {
+        let source = FakeDataSource()
+        source.integration = ["checkouts": [["repo": "/repo", "held": true]]]
+        let router = ControlRouter(dataSource: source)
+
+        guard case .ok(let payload) = router.handle(method: "integration.status",
+                                                    params: ["path": "/repo/worktrees/a"]) else {
+            return XCTFail("expected ok")
+        }
+        XCTAssertEqual(source.integrationPaths, ["/repo/worktrees/a"])
+        XCTAssertEqual((payload["checkouts"] as? [[String: Any]])?.count, 1)
+    }
+
+    func testIntegrationStatusWithoutAPathAsksForEverything() {
+        let source = FakeDataSource()
+        source.integration = ["checkouts": []]
+        let router = ControlRouter(dataSource: source)
+
+        guard case .ok = router.handle(method: "integration.status", params: [:]) else {
+            return XCTFail("expected ok")
+        }
+        XCTAssertEqual(source.integrationPaths, [nil])
+    }
+
 }

--- a/Tests/DashboardViewControllerClickTests.swift
+++ b/Tests/DashboardViewControllerClickTests.swift
@@ -257,8 +257,7 @@ private class DashboardDelegateSpy: DashboardDelegate {
     }
     func dashboardDidRequestEnterProject(_ project: String) {}
     func dashboardDidReorderCards(order: [String]) {}
-    func dashboardDidRequestDelete(_ terminalID: String) {}
-    func dashboardDidRequestDeleteWithBranch(_ terminalID: String) {}
+    func dashboardDidRequestDeleteWorktree(path: String) {}
     func dashboardDidRequestCloseRepo(_ project: String) {}
     func dashboardDidRequestAddProject() {}
     func dashboardDidChangeSelection(_ dashboard: DashboardViewController) {

--- a/Tests/IntegrationWorktreeTests.swift
+++ b/Tests/IntegrationWorktreeTests.swift
@@ -87,7 +87,7 @@ final class IntegrationWorktreeTests: XCTestCase {
         XCTAssertTrue(IntegrationWorktree.hasLocalEdits(at: path))
         XCTAssertEqual(
             IntegrationWorktree.publish(commit: target, to: path),
-            .held(reason: .dirtyWorktree, commit: target)
+            .held(reason: .dirtyWorktree(paths: ["base.txt"]), commit: target)
         )
         XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: path), headBefore, "a hold must not move HEAD")
         XCTAssertEqual(try String(contentsOfFile: path + "/base.txt", encoding: .utf8), "hand edit\n")
@@ -109,7 +109,7 @@ final class IntegrationWorktreeTests: XCTestCase {
         let target = gitOutput(["rev-parse", "agentA"], in: repo)
         XCTAssertEqual(
             IntegrationWorktree.publish(commit: target, to: path),
-            .held(reason: .dirtyWorktree, commit: target)
+            .held(reason: .dirtyWorktree(paths: ["scratch.txt"]), commit: target)
         )
     }
 
@@ -279,4 +279,224 @@ final class IntegrationWorktreeTests: XCTestCase {
     }
 
     private func runGit(_ args: [String], in directory: String) { gitOutput(args, in: directory) }
+
+    // MARK: - reset to trunk
+
+    func testResetTargetPrefersOriginMainOverLocalMain() throws {
+        let repo = try makeFleet()
+        XCTAssertEqual(IntegrationWorktree.resetTarget(repoPath: repo, fetch: false)?.ref, "main")
+
+        runGit(["update-ref", "refs/remotes/origin/main", "main"], in: repo)
+        let target = IntegrationWorktree.resetTarget(repoPath: repo, fetch: false)
+        XCTAssertEqual(target?.ref, "origin/main")
+        XCTAssertEqual(target?.commit, gitOutput(["rev-parse", "main"], in: repo))
+    }
+
+    /// The row's Reset: a checkout full of seahelm's own rounds goes straight
+    /// back to trunk — HEAD *is* trunk afterwards, not merely the same files.
+    func testResetMovesACheckoutSeahelmPublishedBackOntoTrunk() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let round = gitOutput(["rev-parse", "agentA"], in: repo)
+        XCTAssertEqual(IntegrationWorktree.publish(commit: round, to: path), .published(commit: round))
+
+        // Trunk moves on underneath.
+        try "trunk moved\n".write(toFile: repo + "/base.txt", atomically: true, encoding: .utf8)
+        commitAll(repo, "trunk moves")
+        runGit(["update-ref", "refs/remotes/origin/main", "main"], in: repo)
+        let target = try XCTUnwrap(IntegrationWorktree.resetTarget(repoPath: repo, fetch: false))
+
+        let outcome = IntegrationWorktree.reset(to: target, at: path, expectedHead: round)
+
+        XCTAssertEqual(outcome, .published(commit: target.commit))
+        XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: path), gitOutput(["rev-parse", "main"], in: repo))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: path + "/a.txt"), "the round's files are gone")
+    }
+
+    func testResetOfACheckoutAlreadyOnTrunkIsANoop() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let target = try XCTUnwrap(IntegrationWorktree.resetTarget(repoPath: repo, fetch: false))
+
+        XCTAssertEqual(IntegrationWorktree.reset(to: target, at: path), .unchanged(commit: target.commit))
+    }
+
+    /// Same rule as publish: a reset is the one irreversible step, and it does
+    /// not walk over edits made here without being told to.
+    func testResetHoldsOnLocalEditsUntilForced() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        try "hand edit\n".write(toFile: path + "/base.txt", atomically: true, encoding: .utf8)
+        let target = try XCTUnwrap(IntegrationWorktree.resetTarget(repoPath: repo, fetch: false))
+
+        XCTAssertEqual(
+            IntegrationWorktree.reset(to: target, at: path),
+            .held(reason: .dirtyWorktree(paths: ["base.txt"]), commit: target.commit)
+        )
+        XCTAssertEqual(IntegrationWorktree.reset(to: target, at: path, force: true), .published(commit: target.commit))
+        XCTAssertEqual(try String(contentsOfFile: path + "/base.txt"), "base\n")
+    }
+
+    func testResetHoldsOnACommitMadeInTheCheckout() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let created = gitOutput(["rev-parse", "HEAD"], in: path)
+        try "resolved by hand\n".write(toFile: path + "/shared.txt", atomically: true, encoding: .utf8)
+        commitAll(path, "hand-resolved")
+        let byHand = gitOutput(["rev-parse", "HEAD"], in: path)
+        let target = try XCTUnwrap(IntegrationWorktree.resetTarget(repoPath: repo, fetch: false))
+
+        XCTAssertEqual(
+            IntegrationWorktree.reset(to: target, at: path, expectedHead: created),
+            .held(reason: .movedHead(head: byHand), commit: target.commit)
+        )
+    }
+
+    // MARK: - delete assessment
+
+    /// A checkout sitting where seahelm left it is throwaway: it deletes
+    /// without a sheet, and never takes a branch with it (there is none).
+    func testDeletingAnUntouchedCheckoutIsSafe() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let round = gitOutput(["rev-parse", "agentA"], in: repo)
+        XCTAssertEqual(IntegrationWorktree.publish(commit: round, to: path), .published(commit: round))
+
+        let assessment = IntegrationWorktree.assessDeletion(path: path, repoPath: repo, expectedHead: round)
+
+        XCTAssertTrue(assessment.isSafe, assessment.losses.joined(separator: " / "))
+        XCTAssertFalse(assessment.deletesBranch)
+    }
+
+    func testDeletingACheckoutWithHandEditsNamesThem() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        try "hand edit\n".write(toFile: path + "/base.txt", atomically: true, encoding: .utf8)
+
+        let assessment = IntegrationWorktree.assessDeletion(path: path, repoPath: repo, expectedHead: nil)
+
+        XCTAssertEqual(assessment.losses, [IntegrationHoldReason.dirtyWorktree(paths: ["base.txt"]).lossDescription])
+        XCTAssertTrue(assessment.losses[0].contains("base.txt"))
+    }
+
+    // MARK: - work that arrived by hand
+
+    /// The hole the dirty check cannot see: committing in the checkout leaves it
+    /// clean, so `reset --hard` used to walk straight over it. A hand-resolved
+    /// conflict is exactly the work that lands this way.
+    func testACommitMadeInTheCheckoutHoldsThePublish() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let published = gitOutput(["rev-parse", "HEAD"], in: path)
+
+        try "resolved by hand\n".write(toFile: path + "/shared.txt", atomically: true, encoding: .utf8)
+        runGit(["add", "-A"], in: path)
+        runGit(["-c", "user.name=t", "-c", "user.email=t@t", "commit", "-m", "hand resolve"], in: path)
+        let handMade = gitOutput(["rev-parse", "HEAD"], in: path)
+        XCTAssertFalse(IntegrationWorktree.hasLocalEdits(at: path), "a commit leaves the checkout clean")
+
+        let target = gitOutput(["rev-parse", "agentA"], in: repo)
+        XCTAssertEqual(
+            IntegrationWorktree.publish(commit: target, to: path, expectedHead: published),
+            .held(reason: .movedHead(head: handMade), commit: target)
+        )
+        XCTAssertEqual(gitOutput(["rev-parse", "HEAD"], in: path), handMade, "a hold must not move HEAD")
+
+        XCTAssertEqual(
+            IntegrationWorktree.publish(commit: target, to: path, force: true, expectedHead: published),
+            .published(commit: target)
+        )
+    }
+
+    /// The case that matters on the first launch after an upgrade: a checkout
+    /// carrying a hand-made merge has no recorded head to compare against, and
+    /// waiting a round to learn one would be a round too late. The commit's own
+    /// identity answers instead — seahelm's rounds are committed as seahelm.
+    func testAHandMergeHoldsEvenWithNothingRecorded() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        runGit(["-c", "user.name=t", "-c", "user.email=t@t", "merge", "--no-ff", "-m", "hand merge", "agentA"],
+               in: path)
+        let handMade = gitOutput(["rev-parse", "HEAD"], in: path)
+
+        let target = gitOutput(["rev-parse", "agentD"], in: repo)
+        XCTAssertEqual(
+            IntegrationWorktree.publish(commit: target, to: path, expectedHead: nil, base: "main"),
+            .held(reason: .movedHead(head: handMade), commit: target)
+        )
+    }
+
+    /// The counterpart: a checkout still sitting where it was created holds
+    /// nothing of its own, so it must not hold just because trunk's tip is a
+    /// commit some human authored.
+    func testACheckoutStillAtTrunkPublishesWithNothingRecorded() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let target = gitOutput(["rev-parse", "agentA"], in: repo)
+        XCTAssertEqual(
+            IntegrationWorktree.publish(commit: target, to: path, expectedHead: nil, base: "main"),
+            .published(commit: target)
+        )
+    }
+
+    /// With neither a recorded head nor a base there is nothing to reason from,
+    /// and a guard that guesses is worse than no guard.
+    func testNoRecordedHeadMeansNoMovedHeadHold() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let target = gitOutput(["rev-parse", "agentA"], in: repo)
+        XCTAssertEqual(
+            IntegrationWorktree.publish(commit: target, to: path, expectedHead: nil),
+            .published(commit: target)
+        )
+    }
+
+    /// Same files, different commit: there is no reset to hold back, so a stray
+    /// commit that changed nothing must not freeze the checkout forever.
+    func testAMovedHeadWithTheSameTreeIsStillANoop() throws {
+        let repo = try makeFleet()
+        let path = tempDir.appendingPathComponent("integration").path
+        try IntegrationWorktree.create(repoPath: repo, at: path, base: "main")
+        let published = gitOutput(["rev-parse", "HEAD"], in: path)
+        runGit(["-c", "user.name=t", "-c", "user.email=t@t", "commit", "--allow-empty", "-m", "empty"], in: path)
+
+        XCTAssertEqual(
+            IntegrationWorktree.publish(commit: published, to: path, expectedHead: published),
+            .unchanged(commit: published)
+        )
+    }
+
+    /// A checkout this round created is its own provenance — the first publish
+    /// into a brand new checkout must not hold on a head seahelm just wrote.
+    func testFirstRoundIntoAFreshCheckoutPublishes() throws {
+        let repo = try makeFleet()
+        let worktrees = try addWorktrees(["agentA"], in: repo)
+        let path = tempDir.appendingPathComponent("integration").path
+
+        let report = try IntegrationRunner.run(repoPath: repo, integrationPath: path, worktrees: worktrees)
+        XCTAssertEqual(report.outcome, .published(commit: report.result.commit))
+    }
+
+    // MARK: - status parsing
+
+    /// A rename appends its origin as a field of its own; reading that as
+    /// another entry would list a file that is not in the way at all.
+    func testStatusParsingSkipsRenameOrigins() {
+        let raw = "R  new.txt\0old.txt\0 M other.txt\0?? scratch.txt\0"
+        XCTAssertEqual(
+            IntegrationWorktree.parseStatusPaths(raw),
+            ["new.txt", "other.txt", "scratch.txt"]
+        )
+    }
+
 }

--- a/Tests/PendingOrdersQueueTests.swift
+++ b/Tests/PendingOrdersQueueTests.swift
@@ -203,4 +203,28 @@ final class PendingOrdersQueueTests: XCTestCase {
         q.resolvePane(terminalID: "t1")
         XCTAssertEqual(notifications, 1)
     }
+
+    /// Integration reports upsert rather than enqueue: the key is (checkout,
+    /// kind), so enqueueing pinned the card to the first round's summary while
+    /// the side panel moved on with every later one.
+    func testALaterIntegrationRoundRewritesTheCard() {
+        let q = PendingOrdersQueue()
+        let checkout = "/repo-worktrees/integration"
+        func report(_ message: String, options: [String]? = nil) -> FirstMateAction {
+            FirstMateAction(kind: .integrationReport, zone: .red, worktreePath: checkout,
+                            branch: "", project: "p", terminalID: "", message: message,
+                            payload: "/repo", options: options)
+        }
+
+        q.upsert(report("integrated agentA · excluded agentB"))
+        q.upsert(report("integrated agentA · not checked out — local edits (package.json)",
+                        options: ["Discard edits & update", "Leave it"]))
+
+        XCTAssertEqual(q.all().count, 1, "one card per checkout")
+        XCTAssertEqual(q.all().first?.action.message,
+                       "integrated agentA · not checked out — local edits (package.json)")
+        XCTAssertEqual(q.all().first?.action.options, ["Discard edits & update", "Leave it"])
+        XCTAssertEqual(q.all().first?.action.payload, "/repo")
+    }
+
 }

--- a/Tests/WorktreeDeleterTests.swift
+++ b/Tests/WorktreeDeleterTests.swift
@@ -160,6 +160,133 @@ final class WorktreeDeleterTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: worktreePath))
     }
 
+    // MARK: - delete assessment
+
+    /// Nothing of its own: clean, and every commit already on trunk. That is
+    /// the case that must not get a sheet.
+    func testAssessmentIsSafeForACleanMergedWorktree() throws {
+        let worktreePath = createWorktree(branch: "feature-safe")
+        try commitFile("safe.txt", in: worktreePath)
+        git(["merge", "--ff-only", "feature-safe"], in: repoPath)
+        git(["update-ref", "refs/remotes/origin/main", "main"], in: repoPath)
+
+        let assessment = WorktreeDeleter.assessDeletion(
+            worktreePath: worktreePath, repoPath: repoPath, branchName: "feature-safe", recordedBase: nil)
+
+        XCTAssertTrue(assessment.isSafe, assessment.losses.joined(separator: " / "))
+        XCTAssertTrue(assessment.deletesBranch)
+    }
+
+    func testAssessmentCountsCommitsThatAreNowhereElse() throws {
+        git(["update-ref", "refs/remotes/origin/main", "main"], in: repoPath)
+        let worktreePath = createWorktree(branch: "feature-unpublished")
+        try commitFile("one.txt", in: worktreePath)
+        try commitFile("two.txt", in: worktreePath)
+
+        let assessment = WorktreeDeleter.assessDeletion(
+            worktreePath: worktreePath, repoPath: repoPath, branchName: "feature-unpublished", recordedBase: nil)
+
+        XCTAssertFalse(assessment.isSafe)
+        XCTAssertTrue(assessment.deletesBranch)
+        XCTAssertEqual(assessment.losses.count, 1)
+        XCTAssertTrue(assessment.losses[0].contains("2 commits not in origin/main"), assessment.losses[0])
+        XCTAssertTrue(assessment.losses[0].contains("branch will be deleted"), assessment.losses[0])
+    }
+
+    func testAssessmentNamesUncommittedChanges() throws {
+        git(["update-ref", "refs/remotes/origin/main", "main"], in: repoPath)
+        let worktreePath = createWorktree(branch: "feature-dirty")
+        try "wip".write(toFile: worktreePath + "/wip.txt", atomically: true, encoding: .utf8)
+
+        let assessment = WorktreeDeleter.assessDeletion(
+            worktreePath: worktreePath, repoPath: repoPath, branchName: "feature-dirty", recordedBase: nil)
+
+        XCTAssertEqual(assessment.losses, ["It has uncommitted changes that will be lost."])
+    }
+
+    /// Pushed but unmerged: the remote still has every commit, so deleting
+    /// the local branch loses nothing.
+    func testAssessmentTreatsAFullyPushedBranchAsSafe() throws {
+        git(["update-ref", "refs/remotes/origin/main", "main"], in: repoPath)
+        let worktreePath = createWorktree(branch: "feature-pushed")
+        try commitFile("pushed.txt", in: worktreePath)
+        // `@{upstream}` needs the remote's fetch refspec to map the branch to
+        // its tracking ref; the URL is never contacted.
+        git(["remote", "add", "origin", repoPath], in: repoPath)
+        git(["update-ref", "refs/remotes/origin/feature-pushed", "feature-pushed"], in: repoPath)
+        git(["config", "branch.feature-pushed.remote", "origin"], in: repoPath)
+        git(["config", "branch.feature-pushed.merge", "refs/heads/feature-pushed"], in: repoPath)
+
+        let assessment = WorktreeDeleter.assessDeletion(
+            worktreePath: worktreePath, repoPath: repoPath, branchName: "feature-pushed", recordedBase: nil)
+
+        XCTAssertTrue(assessment.isSafe, assessment.losses.joined(separator: " / "))
+    }
+
+    /// A rebase rewrites hashes but not patches. The branch is merged in every
+    /// sense that matters, and must read that way.
+    func testAssessmentSeesARebasedBranchAsMerged() throws {
+        let worktreePath = createWorktree(branch: "feature-rebased")
+        try commitFile("rebased.txt", in: worktreePath)
+        // Land the same patch on main under a different hash.
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test", "cherry-pick", "feature-rebased"], in: repoPath)
+        git(["update-ref", "refs/remotes/origin/main", "main"], in: repoPath)
+
+        let assessment = WorktreeDeleter.assessDeletion(
+            worktreePath: worktreePath, repoPath: repoPath, branchName: "feature-rebased", recordedBase: nil)
+
+        XCTAssertTrue(assessment.isSafe, assessment.losses.joined(separator: " / "))
+    }
+
+    /// A worktree checked out on trunk is removable; trunk is not.
+    func testAssessmentKeepsATrunkBranch() throws {
+        git(["checkout", "-b", "elsewhere"], in: repoPath)
+        let worktreePath = tempDir.appendingPathComponent("worktrees/on-main").path
+        git(["worktree", "add", worktreePath, "main"], in: repoPath)
+
+        let assessment = WorktreeDeleter.assessDeletion(
+            worktreePath: worktreePath, repoPath: repoPath, branchName: "main", recordedBase: nil)
+
+        XCTAssertTrue(assessment.isSafe, assessment.losses.joined(separator: " / "))
+        XCTAssertFalse(assessment.deletesBranch)
+    }
+
+    func testAssessmentOfADetachedWorktreeDeletesNoBranch() throws {
+        let worktreePath = tempDir.appendingPathComponent("worktrees/detached").path
+        git(["worktree", "add", "--detach", worktreePath, "main"], in: repoPath)
+
+        let assessment = WorktreeDeleter.assessDeletion(
+            worktreePath: worktreePath, repoPath: repoPath, branchName: "", recordedBase: nil)
+
+        XCTAssertTrue(assessment.isSafe, assessment.losses.joined(separator: " / "))
+        XCTAssertFalse(assessment.deletesBranch)
+    }
+
+    /// The assessment already established the commits are on trunk, so the
+    /// branch must go even where git's own `-d` check (upstream only) would
+    /// refuse: merged through a PR with an unpushed commit still on it.
+    func testForcedBranchDeleteIgnoresAStaleUpstream() throws {
+        let worktreePath = createWorktree(branch: "feature-stale-upstream")
+        git(["update-ref", "refs/remotes/origin/feature-stale-upstream", "feature-stale-upstream"], in: repoPath)
+        git(["config", "branch.feature-stale-upstream.remote", "origin"], in: repoPath)
+        git(["config", "branch.feature-stale-upstream.merge", "refs/heads/feature-stale-upstream"], in: repoPath)
+        try commitFile("late.txt", in: worktreePath)
+        git(["merge", "--ff-only", "feature-stale-upstream"], in: repoPath)
+
+        let result = try WorktreeDeleter.deleteWorktree(
+            worktreePath: worktreePath, repoPath: repoPath, branchName: "feature-stale-upstream",
+            deleteBranch: true, force: false, forceBranch: true)
+
+        XCTAssertNil(result.branchWarning)
+        XCTAssertFalse(git(["branch", "--list", "feature-stale-upstream"], in: repoPath).contains("feature-stale-upstream"))
+    }
+
+    private func commitFile(_ name: String, in worktreePath: String) throws {
+        try name.write(toFile: worktreePath + "/" + name, atomically: true, encoding: .utf8)
+        git(["add", name], in: worktreePath)
+        git(["-c", "user.email=test@test.com", "-c", "user.name=Test", "commit", "-m", "add \(name)"], in: worktreePath)
+    }
+
     // MARK: - merge check
 
     func testMergedWorktreeCanBeCleanedWhenHeadIsInOriginMain() throws {

--- a/Tests/WorktreeSidePanelViewControllerTests.swift
+++ b/Tests/WorktreeSidePanelViewControllerTests.swift
@@ -172,4 +172,44 @@ final class WorktreeSidePanelViewControllerTests: XCTestCase {
         // the card on upgrade.
         XCTAssertNil(IntegrationStatusStore.decode("integration · 3 worktrees"))
     }
+
+    /// "local edits here" was true but not actionable — the checkout is where
+    /// things get run, so something is nearly always dirty and the only
+    /// question is which files.
+    func testCompositionNamesWhatIsHoldingTheCheckout() {
+        let vc = makeIntegrationVC(IntegrationPanelState(
+            line: "integration · 1 worktree · held · local edits",
+            included: ["agentA"],
+            excluded: [],
+            conflictedPaths: [],
+            isHeld: true,
+            heldPaths: ["package.json", "pnpm-lock.yaml"]
+        ))
+        vc.loadViewIfNeeded()
+        vc.selectTab(.changes)
+
+        XCTAssertEqual(compositionLines(vc), [
+            "in: agentA",
+            "not checked out — local edits here (package.json, pnpm-lock.yaml) · /integrate force",
+        ])
+    }
+
+    /// A commit made in the checkout reads differently from an uncommitted
+    /// edit, and its remedy is not "discard your edits".
+    func testCompositionCallsOutCommitsMadeInTheCheckout() {
+        let vc = makeIntegrationVC(IntegrationPanelState(
+            line: "integration · 1 worktree · held · commits made here",
+            included: ["agentA"],
+            excluded: [],
+            conflictedPaths: [],
+            isHeld: true,
+            heldHead: "545c39d127ca11aa97d1ade5f298a0d5baf9dbc5"
+        ))
+        vc.loadViewIfNeeded()
+        vc.selectTab(.changes)
+
+        XCTAssertEqual(compositionLines(vc).last,
+                       "not checked out — commits made here (545c39d12) · /integrate force drops them")
+    }
+
 }

--- a/docs/feature-design.md
+++ b/docs/feature-design.md
@@ -379,11 +379,18 @@ surface.reparent(to: newContainer)
 
 ### 工作树删除
 ```
-右键 → 确认（检查未提交更改）
-  → 3 选项：Delete / Delete + Branch / Cancel
+右键 Delete（只有一项，分支一起删）
+  → 后台评估 WorktreeDeleter.assessDeletion()
+      未提交改动？未合并到 trunk 且未推送的 commit？
+  → 没有损失：直接删（-D 分支，评估已确认 commit 都在 trunk/upstream 上）
+  → 有损失：一次确认弹窗，逐条列出会丢什么 → Delete 强删
   → surface.destroy()
   → WorktreeDeleter.deleteWorktree()
   → 更新 UI（dashboard, tabs, statusPublisher）
+
+integration checkout 的行另有 "Reset to origin/main"：
+  fetch → IntegrationWorktree.reset()，规则同 publish：
+  手改/手提交的内容会先弹确认，再 reset --hard
 ```
 
 ---

--- a/run.sh
+++ b/run.sh
@@ -60,7 +60,7 @@ fi
 xcodebuild -project seahelm.xcodeproj -scheme seahelm -configuration Debug \
   -derivedDataPath "$BUILD_DIR" \
   -skipPackagePluginValidation \
-  "${SIGN_ARGS[@]}" \
+  "${SIGN_ARGS[@]+"${SIGN_ARGS[@]}"}" \
   build
 
 # PRODUCT_NAME is Seahelm; on case-insensitive APFS seahelm.app resolves to the same bundle.


### PR DESCRIPTION
Delete and the integration checkout's reset both end in `git` throwing work away. Neither could tell whose work it was, so both leaned on the user to be the check — which is the arrangement that trains people to click through sheets, and then the one sheet that mattered goes the same way.

## One Delete on a fleet row, and it takes the branch

`Delete` / `Delete + Branch` asked a question the user is in a worse position to answer than we are: whether the branch still holds anything. `WorktreeDeleter.assessDeletion` answers it before anything is touched — uncommitted changes, plus commits reachable from HEAD that are on neither trunk nor the branch's upstream, counted with `--cherry-pick` so a rebased branch reads as merged.

| Assessment | What happens |
| --- | --- |
| Nothing would be lost | Worktree and branch go, no sheet |
| Something would be lost | One sheet naming it line by line, then a forced delete |

The safe path deletes the branch with `-D` on purpose. Git's own `-d` consults only the upstream, so a branch merged through a PR but holding one unpushed commit would be kept for no reason — the assessment has already established the commits are on trunk.

A squash merge still asks, because from inside the worktree it is indistinguishable from unmerged work. That is the right direction for this to fail.

## A commit made in the integration checkout is not seahelm's to reset

The dirty check waved it straight through: committing leaves the checkout perfectly clean, so the next round's `reset --hard` overwrote it with nothing to recover it from. A hand-resolved conflict is exactly the kind of work that arrives that way, since the checkout is where you go to resolve one.

`IntegrationWorktree.isSeahelmsOwnWork` answers by three routes — the commit we recorded publishing (a new `integration-published.json`), seahelm's own committer identity, or containment in the trunk this round builds on. The identity route is what makes the guard work on the first round after an upgrade rather than one round late, which for the work it protects is one round too late.

## Holds name what is in the way

`dirtyWorktree` now carries its paths and `movedHead` its commit, through the card, the side panel and `/integrate` alike. "Local edits here" was true but not actionable: the checkout is where things get built and run, so something is nearly always dirty and the only question was ever which files. The card's buttons say what goes, and it upserts on the checkout so a later round rewrites the card rather than stacking a second one that contradicts the side panel.

## Reset to origin/main

New on the integration row's context menu. Fetches trunk, then moves the checkout onto it under the same hold rules, so it cannot quietly walk over hand-made work either. This is the way out of a checkout that has drifted; previously that meant deleting it.

## `seahelm integration status`

Over the control socket, defaulting to the cwd's repo. An agent cannot get this from git: the round that folds its work in is triggered by its own turn ending, so looking at the checkout from inside the turn always shows the round before. `moved_by_hand` is broken out as its own field because it is the one state an agent should react to.

## Also

- Deleting a checkout, or removing its repo, forgets the recorded state. Worktree paths get reused, and a stale entry would answer for whatever lands there next.
- The row's Delete is keyed by worktree path rather than pane id. A worktree whose pane never registered an agent was silently undeletable.
- `run.sh` survives an empty `SIGN_ARGS` under `set -u`, in its own commit. An unsigned local build died before `xcodebuild` ran.

## Testing

27 tests added across the assessment, the provenance check, `git status -z` parsing, the card composition and the socket route.

```
xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug \
  -skipPackagePluginValidation -skipMacroValidation test \
  -only-testing:seahelmTests/IntegrationWorktreeTests \
  -only-testing:seahelmTests/WorktreeDeleterTests \
  -only-testing:seahelmTests/ControlRouterTests \
  -only-testing:seahelmTests/PendingOrdersQueueTests \
  -only-testing:seahelmTests/WorktreeSidePanelViewControllerTests \
  -only-testing:seahelmTests/DashboardViewControllerClickTests
```

151 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012usnkbocZb2zBJJMHQJTZh
