### PR TITLE
fix(zh): the Island's closed pill is 胶囊, not 药丸

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@ curl -fsSL https://seahelm.dev/install.sh | sh
 
 **侧边栏** — 文件树、代码编辑器(CodeEditSourceEditor)、Markdown 预览、git diff 审查,不离开当前 worktree。
 
-**灵动岛** — 屏幕顶部常驻药丸,平时安静,有事才展开:哪个 worktree 在跑、在等你、出错了。agent 建议弹成可点卡片。
+**灵动岛** — 屏幕顶部常驻胶囊,平时安静,有事才展开:哪个 worktree 在跑、在等你、出错了。agent 建议弹成可点卡片。
 
 **First Mate** — 观察 pane 状态迁移,生成建议卡片、等待/报错提醒、worktree 回收提示。
 

--- a/site/zh/index.html
+++ b/site/zh/index.html
@@ -253,7 +253,7 @@
       </div>
       <div class="row">
         <dt>Token 用量</dt>
-        <dd>解析 Claude 和 Codex 的本地会话日志，算出 token 和额度数字，在状态药丸里一次轮播一条。</dd>
+        <dd>解析 Claude 和 Codex 的本地会话日志，算出 token 和额度数字，在状态胶囊里一次轮播一条。</dd>
       </div>
       <div class="row">
         <dt>持续集成</dt>
@@ -268,7 +268,7 @@
     <div class="lift">
       <div>
         <h3>灵动岛</h3>
-        <p>屏幕顶部的一颗药丸，没事的时候一直闭着，直到某个 worktree 需要你。它只为三件事张开：有东西在跑、有东西在等、有东西坏了。agent 的建议会以可点击的卡片形式落在里面。</p>
+        <p>屏幕顶部的一颗胶囊，没事的时候一直闭着，直到某个 worktree 需要你。它只为三件事张开：有东西在跑、有东西在等、有东西坏了。agent 的建议会以可点击的卡片形式落在里面。</p>
       </div>
       <div>
         <h3>First Mate（大副）</h3>


### PR DESCRIPTION
`药丸` is a medicine pill. The shape is right and the word is not: Chinese UI writing calls a pill-shaped element `胶囊`.

The repo already agreed with that before this PR. `docs/technical-design.md` describes the same thing as `UI 胶囊`, against a type the code itself names `PrimaryCapsuleFrame`. So `药丸` was the odd one out in its own repository, and it sat in the two places a Chinese reader is most likely to meet the Island first.

| File | Was | Now |
| --- | --- | --- |
| `README.zh-CN.md` | 屏幕顶部常驻药丸 | 屏幕顶部常驻胶囊 |
| `site/zh/index.html` | 屏幕顶部的一颗药丸 | 屏幕顶部的一颗胶囊 |
| `site/zh/index.html` | 在状态药丸里一次轮播一条 | 在状态胶囊里一次轮播一条 |

Nothing else in the repo used the word. `灵动岛` is untouched — that name was never in question.

## Testing

```
python3 scripts/check-site-parity.py
site parity ok — 520 structural nodes, 38 code spans, 8 links
```

Text-only, no structure moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012usnkbocZb2zBJJMHQJTZh
