### PR TITLE
fix: quote the session key so a workspace with a space in its path can attach

### DIFF
--- a/Sources/Terminal/Station.swift
+++ b/Sources/Terminal/Station.swift
@@ -175,8 +175,14 @@ class Station {
     /// against a leaked ZMX_SESSION (e.g. app relaunched from inside a pane):
     /// zmx attach prefers $ZMX_SESSION over its argument, which would silently
     /// attach every pane to the wrong session.
+    ///
+    /// The session key is single-quoted: this string is handed to a shell, and a
+    /// workspace directory with a space in it (`~/My Project`) yields a key with a
+    /// space in it. Unquoted, the shell splits it and zmx reads the tail as the
+    /// command to run — `zmx attach seahelm-me-My Project` means session
+    /// `seahelm-me-My`, command `Project` — so the pane dies on launch.
     static func zmxAttachCommand(paneSessionKey: String) -> String {
-        "/usr/bin/env -u ZMX_SESSION \(ShellEscape.singleQuote(ZmxLocator.executable())) attach \(paneSessionKey)"
+        "/usr/bin/env -u ZMX_SESSION \(ShellEscape.singleQuote(ZmxLocator.executable())) attach \(ShellEscape.singleQuote(paneSessionKey))"
     }
 
     private func attachZmx(

--- a/Tests/StationZmxAttachCommandTests.swift
+++ b/Tests/StationZmxAttachCommandTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import seahelm
+
+final class StationZmxAttachCommandTests: XCTestCase {
+    /// Regression: the attach command is a string handed to a shell, so a session
+    /// key containing a space was split by the shell. `zmx attach <name> [command...]`
+    /// then read the tail as the command to run — a workspace at `~/Bodkin AI`
+    /// produced `zmx attach seahelm-me-Bodkin AI`, i.e. session `seahelm-me-Bodkin`
+    /// running the command `AI`, which exits non-zero. Every pane for that
+    /// workspace failed to launch.
+    func testSessionKeyWithSpaceIsQuoted() {
+        let command = Station.zmxAttachCommand(paneSessionKey: "seahelm-me-Bodkin AI")
+        XCTAssertTrue(
+            command.hasSuffix("attach 'seahelm-me-Bodkin AI'"),
+            "session key must reach the shell as one argument, got: \(command)"
+        )
+    }
+
+    func testPlainSessionKeyIsQuoted() {
+        let command = Station.zmxAttachCommand(paneSessionKey: "seahelm-me-repo")
+        XCTAssertTrue(command.hasSuffix("attach 'seahelm-me-repo'"), command)
+    }
+
+    /// A directory name may legitimately contain an apostrophe (`~/Nick's Repo`).
+    func testSessionKeyWithApostropheIsEscaped() {
+        let command = Station.zmxAttachCommand(paneSessionKey: "seahelm-me-Nick's Repo")
+        XCTAssertTrue(command.hasSuffix("attach 'seahelm-me-Nick'\\''s Repo'"), command)
+    }
+
+    /// The ZMX_SESSION guard must survive the quoting change: zmx prefers the
+    /// environment variable over its argument, so a leaked one would silently
+    /// attach every pane to the wrong session.
+    func testUnsetsLeakedZmxSession() {
+        let command = Station.zmxAttachCommand(paneSessionKey: "seahelm-me-repo")
+        XCTAssertTrue(command.hasPrefix("/usr/bin/env -u ZMX_SESSION "), command)
+    }
+}


### PR DESCRIPTION
Fixes #100.

`Station.zmxAttachCommand` builds a string that a shell interprets. It quoted the zmx binary path via `ShellEscape.singleQuote`, but passed `paneSessionKey` raw:

```swift
"/usr/bin/env -u ZMX_SESSION \(ShellEscape.singleQuote(ZmxLocator.executable())) attach \(paneSessionKey)"
```

A workspace directory with a space in it yields a session key with a space in it, so the shell split it. Given `zmx attach <name> [command...]`, this:

```
zmx attach seahelm-me-Bodkin AI
```

means session `seahelm-me-Bodkin` running the command `AI`. `AI` isn't a command, the process exits 1, and every pane for that workspace dies on launch with *"Ghostty failed to launch the requested command"* after ~38 ms.

## The change

One line — the existing helper, applied to the session key too. Plus a doc comment on the function, and `Tests/StationZmxAttachCommandTests.swift` covering the space case, an apostrophe in the path (`~/Nick's Repo`), and that the `env -u ZMX_SESSION` guard still leads the command.

## Correction to the issue

I wrote in #100 that `zmx run` was likely affected too. It isn't. `SessionManager.swift:395` and `ZmxChannel.swift:15` pass the name as its own argv element, no shell in between. Only `attach` builds a shell string — which is exactly why the session got created under the correct name while attaching to it failed.

## Verification

I couldn't run the suite locally — the `ghostty` submodule isn't fetched here and I don't have xcodegen — so this leans on CI. What I did check:

- The four expected strings, compiled and asserted against a standalone copy of `ShellEscape.singleQuote` — including the apostrophe case, which is easy to get wrong in a Swift literal.
- End-to-end against the real bundled zmx 0.7.1 and a live session with a space in its name, using `get` so it stays non-interactive:

```
$ eval "/usr/bin/env -u ZMX_SESSION '$ZMX' get seahelm-nickralph-Bodkin AI"   # old form
exit=1
$ eval "/usr/bin/env -u ZMX_SESSION '$ZMX' get 'seahelm-nickralph-Bodkin AI'" # new form
exit=0
```

Seahelm 2.0.57, zmx 0.7.1, macOS 15 (Darwin 25.6.0), arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uqjW4r333JQ9bWbfzdgXH