### PR TITLE
docs: replace generic "Why Seahelm" bullets with real differentiators

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,30 @@ Full walkthrough: [YouTube](https://youtu.be/WUUcuglx_Ks)
 
 ## Why Seahelm
 
-- **Minimal** — No bloated code editor or diff review. Everything is delegated to agents; the UI stays out of the way.
-- **Fast** — Native macOS, built on the Ghostty terminal and AppKit. Low latency, responsive rendering.
-- **Compatible** — Works with up to 12 coding agents out of the box. Not locked into any single platform.
+Several tools now run coding agents side by side on macOS. Seahelm shares the obvious
+parts with them — Swift, libghostty, one git worktree per agent, hooks for status.
+Three things are its own.
+
+**It lives outside the terminal.** A multiplexer puts status inside the window you
+are trying to stop watching. Seahelm's Island sits at the edge of the screen and
+stays quiet until a worktree needs you, blocked agents raise real system
+notifications, and you can answer one from your phone over iMessage. Claude and
+Codex token and quota usage are summarised in-app, so you also see when an agent is
+about to run out of budget rather than out of ideas.
+
+**Built around the decision, not the display.** Seahelm intercepts the Stop hook and
+makes the agent hand back its next-step options before it is allowed to stop. Those
+arrive as clickable cards. First Mate watches status transitions and either handles
+them or queues them for your approval. Showing "awaiting input" is the easy half; the
+question is what to do about it.
+
+**The pane follows its agent.** When an agent creates a worktree and starts working
+there, that pane moves to the new worktree's card instead of an empty pane appearing
+beside it. Keyed on the cwd every hook payload carries, with a same-repo gate and a
+cooldown so a `cd x && ...` tool call doesn't walk the pane back and forth.
+
+Beyond that: native rendering on the Ghostty engine rather than Electron, sessions
+that survive a reboot via zmx, and status detection for 12 agents out of the box.
 
 ## Install
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,9 +12,25 @@
 
 ## 为什么选择 Seahelm
 
-- **简洁** — 没有复杂的代码编辑和 diff review,一切都交给 agent,界面不挡路。
-- **高性能** — macOS 原生,基于 Ghostty 终端和 AppKit 渲染,低延迟、响应快。
-- **兼容性** — 兼容多达 12 种 coding agent,不绑死在单一平台。
+macOS 上并行跑 coding agent 的工具已经不止一个。相同的部分 Seahelm 并不回避：Swift、
+libghostty、每个 agent 一个 git worktree、用 hook 上报状态。真正属于自己的有三点。
+
+**它活在终端之外。** 多路复用器把状态放在你正想别再盯着的那个窗口里。Seahelm 的 Island
+停在屏幕边缘，只有 worktree 需要你时才出声；被卡住的 agent 会触发真正的系统通知；你还能
+用 iMessage 从手机上回复它。Claude 和 Codex 的 token 与额度消耗也在 App 里汇总，所以你
+能提前看到某个 agent 快把预算跑光，而不是等它停下来才知道。
+
+**围绕决策设计，而不是围绕展示。** Seahelm 会拦截 Stop hook，逼 agent 在停下之前交出
+下一步的选项，这些选项以可点击的卡片送到你面前。First Mate 监听状态变化，要么自动处理，
+要么排进待批准队列。显示「正在等你」是容易的那一半，难的是接下来该做什么。
+
+**pane 跟着它的 agent 走。** 当一个 agent 创建了新的 worktree 并开始在里面工作，这个
+pane 会迁移到新 worktree 的卡片上，而不是在旁边多出一个空终端。依据是每个 hook 负载都
+携带的 cwd，配合同仓库判定和冷却时间，这样 agent 执行 `cd x && ...` 这类单次调用不会
+把 pane 来回拖动。
+
+除此之外：基于 Ghostty 引擎的原生渲染而非 Electron、通过 zmx 让会话在重启后依然存活、
+开箱支持 12 种 agent 的状态识别。
 
 ## 安装
 


### PR DESCRIPTION
## Why

The old three bullets — minimal, fast, compatible — describe cmux, Supacode and herdr just as well as they describe Seahelm, so they said nothing.

Reddit made that concrete. The first question on the r/ClaudeCode post was what this does differently from cmux and Supacode; r/ClaudeAI called it a copy of herdr. Those threads are where this rewrite came from.

## What changed

`README.md` and `README.zh-CN.md` now state the overlap up front — Swift, libghostty, one git worktree per agent, hooks for status — and then three things that are actually ours:

- **It lives outside the terminal.** Island at the screen edge, real system notifications, answering an agent from your phone over iMessage, Claude/Codex usage summarised in-app.
- **Built around the decision, not the display.** Stop-hook interception forces the agent to hand back next-step options before it can stop; those become clickable cards, with First Mate handling or queueing transitions.
- **The pane follows its agent** into a worktree that agent creates, instead of an empty pane appearing beside it.

## One claim was withdrawn

An earlier draft led with introspectable detection via `seahelm pane explain`. herdr ships `agent explain`, which additionally reports manifest source and version, region evidence, a `--verbose` evaluated-rules dump, and offline replay from a saved fixture. That is more than ours does, so the claim was wrong. It is not in this PR, and corrections are posted on both Reddit threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C54ESAX1vDdS5EPoXQ8EDZ