### PR TITLE
feat(telegram): QR pairing wizard and inline command buttons

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -77,6 +77,10 @@ class MainWindowController: NSWindowController {
     /// Nil when the bridge is unconfigured or was started by AppDelegate and
     /// never reconfigured — `unregisterChannel("telegram")` covers that case.
     private var telegramChannel: TelegramChannel?
+    /// The throwaway bridge the setup wizard runs on. Held apart from
+    /// `telegramChannel` so ending pairing restores the configured bridge
+    /// rather than leaving the wizard's token in place.
+    private var telegramPairingChannel: TelegramChannel?
     /// One executor for every surface: the Helm line, Telegram and mail all
     /// run their lines through it, so a command means one thing everywhere.
     private lazy var commandExecutor = CommandExecutor(host: self, sessions: tabCoordinator.commandSessions)
@@ -2523,27 +2527,88 @@ extension MainWindowController: SettingsDelegate {
             startGmailMailChannel(config: config.gmailMail)
         }
 
-        // Hot-reload the Telegram bridge on config change.
-        if oldTelegram != config.telegram {
-            AgentRegistry.shared.unregisterChannel(telegramChannel?.channelId ?? "telegram")
-            telegramChannel = nil
-            // A fresh save deserves a fresh alert, even for the same mistake.
-            lastTelegramError = nil
-
-            if let telegramConfig = config.telegram, telegramConfig.resolvedAutoConnect {
-                let channel = TelegramChannel(config: telegramConfig)
-                channel.onStateChange = { [weak self] state in
-                    // A rejected token or a bot polled elsewhere is something
-                    // only the user can fix, so a failure has to be said out
-                    // loud — otherwise the channel is just silently dead.
-                    if case .error(let msg) = state { self?.presentTelegramError(msg) }
-                }
-                AgentRegistry.shared.registerChannel(channel)
-                channel.connect()
-                telegramChannel = channel
-                NSLog("[Settings] Telegram bridge reconnecting")
-            }
+        // Hot-reload the Telegram bridge on config change. Not while the setup
+        // wizard is pairing: that bridge is holding the bot's single poll slot,
+        // and its own teardown brings the configured one back.
+        if oldTelegram != config.telegram, telegramPairingChannel == nil {
+            restartTelegramBridge()
         }
+    }
+
+    /// Tear the Telegram bridge down and stand it back up from `config`.
+    ///
+    /// `disconnect()` rather than a bare release: the old poller is parked in a
+    /// `getUpdates` that Telegram holds open for twenty seconds, and a
+    /// successor that starts while it is still in flight is the 409 the error
+    /// text blames on "a second seahelm running".
+    private func restartTelegramBridge() {
+        AgentRegistry.shared.unregisterChannel(telegramChannel?.channelId ?? "telegram")
+        telegramChannel?.disconnect()
+        telegramChannel = nil
+        // A fresh save deserves a fresh alert, even for the same mistake.
+        lastTelegramError = nil
+
+        guard let telegramConfig = config.telegram, telegramConfig.resolvedAutoConnect else { return }
+        let channel = TelegramChannel(config: telegramConfig)
+        channel.onStateChange = { [weak self] state in
+            // A rejected token or a bot polled elsewhere is something only the
+            // user can fix, so a failure has to be said out loud — otherwise
+            // the channel is just silently dead.
+            if case .error(let msg) = state { self?.presentTelegramError(msg) }
+        }
+        AgentRegistry.shared.registerChannel(channel)
+        channel.connect()
+        telegramChannel = channel
+        NSLog("[Settings] Telegram bridge reconnecting")
+    }
+
+    func settings(_ settings: SettingsViewController,
+                  beginTelegramPairing token: String,
+                  session: TelegramPairingSession,
+                  onPaired: @escaping (TelegramPairingResult) -> Void) {
+        // One poller per bot. Whatever is live has to go first, or Telegram
+        // answers 409 and the QR on screen never resolves.
+        AgentRegistry.shared.unregisterChannel(telegramChannel?.channelId ?? "telegram")
+        telegramChannel?.disconnect()
+        telegramChannel = nil
+        telegramPairingChannel?.disconnect()
+
+        // The token is not in the saved config yet — the wizard writes it only
+        // when it finishes — so this bridge runs on a config that lives exactly
+        // as long as the pairing. Empty allowlist and no rules on purpose:
+        // until someone claims the code this bot obeys nobody, and a stray
+        // message must not trip a trigger. A zero backfill keeps a stale
+        // `/start` from before the wizard opened out of the pairing.
+        var pairingConfig = config.telegram ?? TelegramConfig()
+        pairingConfig.botToken = token
+        pairingConfig.allowedUsers = []
+        pairingConfig.rules = []
+        pairingConfig.backfillSeconds = 0
+
+        let channel = TelegramChannel(config: pairingConfig)
+        channel.armPairing(session)
+        channel.onPaired = onPaired
+        channel.onStateChange = { [weak self] state in
+            if case .error(let msg) = state { self?.presentTelegramError(msg) }
+        }
+        // Deliberately not registered with AgentRegistry: this bridge exists to
+        // receive one `/start`, and a registered channel could carry orders
+        // from a bot nobody has been allowed on yet.
+        telegramPairingChannel = channel
+        lastTelegramError = nil
+        channel.connect()
+        NSLog("[Settings] Telegram pairing bridge up")
+    }
+
+    func settingsEndTelegramPairing(_ settings: SettingsViewController) {
+        guard let channel = telegramPairingChannel else { return }
+        channel.armPairing(nil)
+        channel.disconnect()
+        telegramPairingChannel = nil
+        // Back to whatever is saved. On the wizard's success path this is the
+        // pre-pairing config and the save that follows immediately restarts the
+        // bridge again with the new one; on cancel it is the only restart.
+        restartTelegramBridge()
     }
 }
 

--- a/Sources/Core/ChatCallbackRegistry.swift
+++ b/Sources/Core/ChatCallbackRegistry.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// What a chat button stands for.
+///
+/// Every button on a chat surface resolves to one of these. `command` is the
+/// general case — the button is a line the tapper could have typed, and it runs
+/// through the same `CommandExecutor` as if they had. The card cases are the
+/// exception: a First Mate option is answered by driving the pane's TUI, not by
+/// a verb, so it names the card and the option instead.
+enum ChatCallbackAction: Equatable {
+    /// Run this line through the command language, as if it were typed.
+    case command(String)
+    /// Pick an option on a First Mate card, by its index in `action.options`.
+    case suggestionOption(orderId: String, index: Int)
+    /// Clear a First Mate card without answering it.
+    case dismissSuggestion(orderId: String)
+}
+
+/// Mints the short tokens chat buttons carry.
+///
+/// Telegram caps `callback_data` at 64 bytes and what a button means does not
+/// fit inside it: a card's id is `<worktree path>#<kind>#<pane>`, and an agent's
+/// suggested option is a whole sentence. So the button carries a token and the
+/// meaning stays here. It also keeps the wire free of anything worth reading —
+/// what travels is `k3`, not a path on this machine.
+///
+/// Deliberately memory-only. A Telegram message lives in the chat's history
+/// forever and its buttons with it, so a tap can arrive from last week; tokens
+/// die with the run, and a tap that resolves to nothing is answered as stale
+/// rather than replayed against a fleet that has moved on.
+final class ChatCallbackRegistry {
+    static let shared = ChatCallbackRegistry()
+
+    /// Enough for a long session's worth of live cards and listings. Past it the
+    /// oldest token is dropped: the buttons above it in the chat have scrolled
+    /// out of the part of history anyone still taps.
+    static let capacity = 2000
+
+    private let lock = NSLock()
+    private var actions: [String: ChatCallbackAction] = [:]
+    /// Mint order, so eviction takes the oldest.
+    private var order: [String] = []
+    private var next = 1
+
+    init() {}
+
+    /// A token for `action`, unique within this run.
+    func mint(_ action: ChatCallbackAction) -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        let token = String(next, radix: 36)
+        next += 1
+        actions[token] = action
+        order.append(token)
+        if order.count > Self.capacity {
+            let evicted = order.removeFirst()
+            actions.removeValue(forKey: evicted)
+        }
+        return token
+    }
+
+    /// What the button means, or nil once it has gone stale.
+    func action(for token: String) -> ChatCallbackAction? {
+        lock.lock()
+        defer { lock.unlock() }
+        return actions[token]
+    }
+
+    /// Retire every button belonging to a card.
+    ///
+    /// Called when the card is answered or dismissed, and it is the only thing
+    /// standing between a resolved card and a second tap: `resolve(id:)` on a
+    /// card that has already left the queue is a no-op, but the option text
+    /// would still be typed into the pane a second time. Stripping the buttons
+    /// off the message races with a tap already in flight; this does not.
+    func retire(orderId: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        let stale = actions.filter { Self.orderId(of: $0.value) == orderId }.map(\.key)
+        guard !stale.isEmpty else { return }
+        for token in stale { actions.removeValue(forKey: token) }
+        let dropped = Set(stale)
+        order.removeAll { dropped.contains($0) }
+    }
+
+    private static func orderId(of action: ChatCallbackAction) -> String? {
+        switch action {
+        case .command: return nil
+        case .suggestionOption(let orderId, _): return orderId
+        case .dismissSuggestion(let orderId): return orderId
+        }
+    }
+}

--- a/Sources/Core/Command/CommandExecutor.swift
+++ b/Sources/Core/Command/CommandExecutor.swift
@@ -19,6 +19,31 @@ struct CommandSurface: Equatable {
     }
 }
 
+/// A button offered beside a reply.
+///
+/// The command language has no idea how a surface draws one: Telegram makes it
+/// an inline keyboard, the desktop ignores it (its answer is the dashboard) and
+/// mail drops it (a mail client cannot call back). What the layer below is told
+/// is only what the button *means*.
+struct CommandButton: Equatable {
+    enum Effect: Equatable {
+        /// Run this line, as if the tapper had typed it.
+        case line(String)
+        /// Withdraw the question this reply asked. Not a verb: any other
+        /// message already withdraws a pending question, so the language never
+        /// needed one — but a button has to name what it does.
+        case cancelPending
+    }
+
+    let label: String
+    let effect: Effect
+
+    /// The common case: the button is the line it says.
+    static func line(_ label: String, _ line: String) -> CommandButton {
+        CommandButton(label: label, effect: .line(line))
+    }
+}
+
 struct CommandReply: Equatable {
     let text: String
     let isError: Bool
@@ -27,12 +52,18 @@ struct CommandReply: Equatable {
     /// The desktop drops reply text — the dashboard is its answer — except an
     /// outcome with something to act on: a PR link, a worktree held back.
     let presentsOnDesktop: Bool
+    /// Offered beside the text on surfaces that can draw buttons. Always a
+    /// shortcut for something the text already says how to type, so a surface
+    /// that drops them loses nothing.
+    let buttons: [CommandButton]
 
-    init(_ text: String, isError: Bool = false, showsOverview: Bool = false, presentsOnDesktop: Bool = false) {
+    init(_ text: String, isError: Bool = false, showsOverview: Bool = false,
+         presentsOnDesktop: Bool = false, buttons: [CommandButton] = []) {
         self.text = text
         self.isError = isError
         self.showsOverview = showsOverview
         self.presentsOnDesktop = presentsOnDesktop
+        self.buttons = buttons
     }
 
     static func error(_ text: String) -> CommandReply { CommandReply(text, isError: true) }
@@ -200,12 +231,18 @@ final class CommandExecutor {
         case .status(let scope):
             let bound = boundPane(surface, index: index)
             let text: String
+            var buttons: [CommandButton] = []
             switch scope {
-            case .panes:     text = CommandFormatter.panes(index, bound: bound)
-            case .worktrees: text = CommandFormatter.worktrees(index, bound: bound)
-            case .repos:     text = CommandFormatter.repos(index)
+            case .panes:
+                text = CommandFormatter.panes(index, bound: bound)
+                buttons = CommandFormatter.paneButtons(index, bound: bound)
+            case .worktrees:
+                text = CommandFormatter.worktrees(index, bound: bound)
+                buttons = CommandFormatter.worktreeButtons(index, bound: bound)
+            case .repos:
+                text = CommandFormatter.repos(index)
             }
-            reply(CommandReply(text, showsOverview: surface.isDesktop))
+            reply(CommandReply(text, showsOverview: surface.isDesktop, buttons: buttons))
 
         case .returnAll:
             // Only what nothing would be lost by goes without asking; the rest
@@ -425,7 +462,9 @@ final class CommandExecutor {
                                           summary: summary,
                                           expiresAt: Date().addingTimeInterval(PendingAction.lifetime)),
                             for: surface.sessionKey)
-        reply(CommandReply("\(summary)\nReply `/yes` within \(Int(PendingAction.lifetime))s to go ahead."))
+        reply(CommandReply("\(summary)\nReply `/yes` within \(Int(PendingAction.lifetime))s to go ahead.",
+                           buttons: [.line("Go ahead", "/yes"),
+                                     CommandButton(label: "Cancel", effect: .cancelPending)]))
     }
 
     private func confirmPending(surface: CommandSurface, reply: @escaping (CommandReply) -> Void) {

--- a/Sources/Core/Command/CommandFormatter.swift
+++ b/Sources/Core/Command/CommandFormatter.swift
@@ -83,6 +83,40 @@ enum CommandFormatter {
         return out.joined(separator: "\n")
     }
 
+    // MARK: - Listing buttons
+
+    /// How many buttons a listing offers. A fleet of thirty panes would bury
+    /// the listing itself under its own shortcuts, and the text above them is
+    /// complete either way — `/go #24` still works for the ones left out.
+    static let buttonLimit = 8
+
+    /// `/go` for each pane a `/status` listing showed, newest handles first.
+    /// The pane already being talked to is left out: its button would do
+    /// nothing.
+    static func paneButtons(_ index: FleetIndex, bound: PaneRef?) -> [CommandButton] {
+        index.panes
+            .filter { $0.handleKey != bound?.handleKey }
+            .sorted { $0.handle > $1.handle }
+            .prefix(buttonLimit)
+            .map { pane in
+                CommandButton.line("\(pane.status.icon) #\(pane.handle) \(pane.branch)",
+                                   "/go #\(pane.handle)")
+            }
+    }
+
+    /// `/go` for each worktree a `/status worktrees` listing showed. Worktrees
+    /// with no pane are skipped — `/go` there has nothing to talk to.
+    static func worktreeButtons(_ index: FleetIndex, bound: PaneRef?) -> [CommandButton] {
+        index.worktrees
+            .filter { $0.path != bound?.worktreePath && !index.panes(inWorktree: $0.path).isEmpty }
+            .sorted { ($0.repo.lowercased(), $0.name.lowercased()) < ($1.repo.lowercased(), $1.name.lowercased()) }
+            .prefix(buttonLimit)
+            .map { wt in
+                let label = index.label(for: wt)
+                return CommandButton.line(String(label.dropFirst()), "/go \(label)")
+            }
+    }
+
     /// Keeps one listing row to one line.
     static func truncated(_ title: String, limit: Int = 60) -> String {
         title.count <= limit ? title : "\(title.prefix(limit - 1))…"

--- a/Sources/Core/Command/CommandSpec.swift
+++ b/Sources/Core/Command/CommandSpec.swift
@@ -137,4 +137,15 @@ enum CommandSpecs {
     static var mailEntries: [(command: String, detail: String)] {
         all.filter { !$0.desktopOnly }.map { ($0.usage, $0.summary) }
     }
+
+    /// What `setMyCommands` publishes, so typing `/` in a Telegram chat lists
+    /// the verbs rather than requiring the user to have read `/help` once.
+    ///
+    /// Desktop-only verbs are left out: offering `/add` in a chat whose only
+    /// possible answer is "there is no chat equivalent" is worse than an
+    /// absence. Telegram caps a description at 256 characters, which every
+    /// summary in this table is comfortably inside.
+    static var botCommands: [(command: String, description: String)] {
+        all.filter { !$0.desktopOnly }.map { ($0.verb, $0.summary) }
+    }
 }

--- a/Sources/Core/ExternalChannel.swift
+++ b/Sources/Core/ExternalChannel.swift
@@ -26,6 +26,18 @@ struct InboundMessage {
     let metadata: [String: Any]?
 }
 
+/// A button drawn beside an outbound message.
+///
+/// `token` is minted by `ChatCallbackRegistry` and means nothing to the
+/// channel: it carries it out, and carries it back when someone taps. That is
+/// deliberate — Telegram allows 64 bytes of callback data, which is less than
+/// a card id, and what travels over the wire and sits in a chat's history
+/// forever should not be a path on this machine either.
+struct MessageButton: Equatable {
+    let label: String
+    let token: String
+}
+
 struct OutboundMessage {
     let channelId: String
     let targetChatId: String?
@@ -35,10 +47,14 @@ struct OutboundMessage {
     let replyToMessageId: String?
     let streaming: Bool
     let streamId: String?
+    /// Drawn under the message by channels that can. Always a shortcut for
+    /// something the text says how to type, so dropping them costs nothing.
+    let buttons: [MessageButton]
 
     init(channelId: String, targetChatId: String? = nil, targetUserId: String? = nil,
          content: String, format: MessageFormat = .text,
-         replyToMessageId: String? = nil, streaming: Bool = false, streamId: String? = nil) {
+         replyToMessageId: String? = nil, streaming: Bool = false, streamId: String? = nil,
+         buttons: [MessageButton] = []) {
         self.channelId = channelId
         self.targetChatId = targetChatId
         self.targetUserId = targetUserId
@@ -47,7 +63,23 @@ struct OutboundMessage {
         self.replyToMessageId = replyToMessageId
         self.streaming = streaming
         self.streamId = streamId
+        self.buttons = buttons
     }
+}
+
+/// Someone tapped a button on a message this channel sent.
+///
+/// Not an `InboundMessage`: nothing was said, and the tap carries the message
+/// it came from so the buttons can be taken off once it is handled.
+struct InboundCallback {
+    let channelId: String
+    let senderId: String
+    let senderName: String
+    let chatId: String
+    /// The message the button was attached to.
+    let messageId: String
+    /// What the button means — resolve through `ChatCallbackRegistry`.
+    let token: String
 }
 
 // MARK: - ExternalChannel Protocol
@@ -67,7 +99,18 @@ protocol ExternalChannel: AnyObject {
     /// Send a message out to the external platform
     func send(_ message: OutboundMessage)
 
+    /// Take the buttons off a message this channel already sent.
+    ///
+    /// A card that has been answered must not go on offering its options — on
+    /// the phone that message stays in the history forever. Channels that
+    /// cannot edit what they sent do nothing.
+    func retireButtons(chatId: String, messageId: String)
+
     /// Connection management
     func connect()
     func disconnect()
+}
+
+extension ExternalChannel {
+    func retireButtons(chatId: String, messageId: String) {}
 }

--- a/Sources/Core/TelegramBotAPI.swift
+++ b/Sources/Core/TelegramBotAPI.swift
@@ -212,6 +212,29 @@ final class TelegramBotAPI {
         let _: TelegramMessage = try call("sendMessage", params: params, deadline: Self.stallSeconds)
     }
 
+    /// Publish the verb table to Telegram, so typing `/` in the chat lists the
+    /// commands instead of requiring the user to have read `/help` once.
+    ///
+    /// Set at setup rather than on every connect: it is per-bot state Telegram
+    /// keeps, not per-session, and re-sending it on each launch would spend a
+    /// round trip to write what is already there.
+    func setMyCommands(_ commands: [(command: String, description: String)]) throws {
+        let payload = commands.map { ["command": $0.command, "description": $0.description] }
+        let _: Bool = try call("setMyCommands", params: ["commands": payload],
+                               deadline: Self.stallSeconds)
+    }
+
+    /// Drop any webhook registered against this bot.
+    ///
+    /// A webhook and `getUpdates` are mutually exclusive — the second one to
+    /// ask gets 409 — and a bot that was once wired to something else keeps its
+    /// webhook forever. Clearing it during setup turns a confusing "another
+    /// client is already polling" into a bot that simply works.
+    func deleteWebhook() throws {
+        let _: Bool = try call("deleteWebhook", params: ["drop_pending_updates": false],
+                               deadline: Self.stallSeconds)
+    }
+
     // MARK: - Transport
 
     private func call<T: Decodable>(_ method: String, params: [String: Any], deadline: Int) throws -> T {

--- a/Sources/Core/TelegramChannel.swift
+++ b/Sources/Core/TelegramChannel.swift
@@ -33,6 +33,13 @@ final class TelegramChannel: ExternalChannel {
 
     /// So `/status@seahelm_bot` in a group parses as `/status`.
     private(set) var botUsername: String?
+    /// Armed while the setup wizard is waiting for someone to tap Start.
+    /// Consulted *before* the allowlist, which is the whole point: the person
+    /// pairing is by definition not on it yet.
+    private var pairing: TelegramPairingSession?
+    /// Fires on the main thread when a code is claimed. The owner writes the
+    /// allowlist; the channel only reports who it was.
+    var onPaired: ((TelegramPairingResult) -> Void)?
     /// Chat each user last gave an order from, so a reply addressed to a user
     /// lands where they were talking.
     private var chatIdBySender: [String: String] = [:]
@@ -178,6 +185,15 @@ final class TelegramChannel: ExternalChannel {
         lock.unlock()
     }
 
+    /// Arm (or, with nil, disarm) pairing. Live for as long as the wizard is on
+    /// screen: a code that outlived its window would be a second, quieter
+    /// allowlist.
+    func armPairing(_ session: TelegramPairingSession?) {
+        lock.lock()
+        pairing = session
+        lock.unlock()
+    }
+
     // MARK: - Poll loop
 
     private func isCurrent(_ gen: Int) -> Bool {
@@ -266,6 +282,16 @@ final class TelegramChannel: ExternalChannel {
               !text.isEmpty else { return }
         let chatId = String(message.chat.id)
 
+        // `/start` is Telegram's own front door: the Start button sends it, and
+        // a `t.me/<bot>?start=<code>` deep link sends it with the pairing code
+        // attached. It is answered here and never reaches the verb table, which
+        // has no such verb and would only reply "unknown command".
+        if let payload = TelegramPairingCode.startPayload(
+            in: Self.stripBotMention(text, botUsername: botUsername)) {
+            handleStart(payload: payload, message: message, config: cfg)
+            return
+        }
+
         if let command = Self.command(in: message, config: cfg, botUsername: botUsername) {
             lock.lock()
             chatIdBySender[command.senderId] = chatId
@@ -289,6 +315,66 @@ final class TelegramChannel: ExternalChannel {
         }
 
         deliverSignal(message, text: text, config: cfg)
+    }
+
+    /// Answer `/start`.
+    ///
+    /// Which of the three cases applies turns on whether a code is armed, not
+    /// on who sent the message: pairing exists precisely because the sender is
+    /// a stranger to the allowlist at the moment they use it.
+    private func handleStart(payload: String, message: TelegramMessage, config cfg: TelegramConfig) {
+        // A channel post carries no user, and an allowlist entry has to name
+        // one. Nothing to pair with.
+        guard let from = message.from else { return }
+        let chatId = String(message.chat.id)
+
+        lock.lock()
+        let session = pairing
+        lock.unlock()
+
+        if let session {
+            if !payload.isEmpty {
+                guard session.claim(payload) else {
+                    // Wrong, spent or expired — but a code *is* armed and this
+                    // person is looking at a QR that just failed them, so say
+                    // so rather than leave them tapping Start again.
+                    reply(chatId, "That pairing code has expired or was already used. "
+                                + "Generate a new one in seahelm ▸ Settings ▸ Telegram.")
+                    return
+                }
+                let result = TelegramPairingResult(userId: String(from.id),
+                                                   displayName: from.displayName,
+                                                   chatId: chatId)
+                NSLog("[Telegram] Paired with \(from.displayName) (\(from.id)) in chat \(chatId)")
+                reply(chatId, "**Paired.** This chat can command the fleet now.\n\n"
+                            + "`/status` lists what is running, `/help` lists the commands, "
+                            + "and anything without a slash goes straight to the agent you are talking to.")
+                DispatchQueue.main.async { [weak self] in self?.onPaired?(result) }
+                return
+            }
+            if !cfg.allows(user: from) {
+                // Found the bot without the deep link — an easy thing to do,
+                // since Telegram opens a Start button on any bot you search
+                // for. Point them at the code rather than stonewall.
+                reply(chatId, "Send me the 8-character pairing code shown in "
+                            + "seahelm ▸ Settings ▸ Telegram to connect this chat.")
+                return
+            }
+        }
+
+        // A bare Start from someone already trusted gets the usual Telegram
+        // greeting. From anyone else, silence: an unpaired bot must not confirm
+        // to a stranger that it is attached to a working fleet.
+        if cfg.allows(user: from) {
+            reply(chatId, "**seahelm** is connected. `/status` lists the fleet, `/help` lists the commands.")
+        } else {
+            NSLog("[Telegram] Ignoring /start from unlisted user \(from.displayName) (\(from.id))")
+        }
+    }
+
+    private func reply(_ chatId: String, _ markdown: String) {
+        send(OutboundMessage(channelId: channelId, targetChatId: chatId,
+                             content: markdown, format: .markdown))
     }
 
     /// A message that is not an order may still be work: a monitoring channel

--- a/Sources/Core/TelegramPairing.swift
+++ b/Sources/Core/TelegramPairing.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Security
+
+/// The result of a successful pairing: who tapped Start, and where.
+struct TelegramPairingResult: Equatable {
+    /// Telegram user id as a string — what `allowed_users` stores.
+    let userId: String
+    /// `@username`, or a first name, or the id: what to show in Settings.
+    let displayName: String
+    /// The chat the `/start` arrived in. In a private chat this equals the
+    /// user id, but reading it off the message rather than assuming means a
+    /// pairing done from a group still names a chat notifications can reach.
+    let chatId: String
+}
+
+/// A one-time code that turns "whoever taps Start" into the bot's owner.
+///
+/// The allowlist is the only thing between a stranger and the fleet, and it
+/// used to be typed by hand: find @userinfobot, ask it for your numeric id,
+/// copy the digits across, and separately work out what a chat id is. Pairing
+/// replaces all of that with a code the user carries *to* the bot — whoever
+/// sends it back is, by construction, the person holding this Mac, and the
+/// message they send carries both ids for free.
+///
+/// The code rides in a `t.me/<bot>?start=<code>` deep link, so its alphabet is
+/// what Telegram accepts in a start payload (`A-Z a-z 0-9 _ -`) and its length
+/// stays far inside the 64-character limit. Ambiguous glyphs are left out so
+/// the same code can be read off the screen and typed by hand — the fallback
+/// when the QR is on the wrong side of the room.
+enum TelegramPairingCode {
+    /// Crockford-ish: no `0`/`O`, no `1`/`I`/`L`. 31 symbols left, which is not
+    /// a power of two, so the draw below rejects rather than folds — a plain
+    /// `% 31` would make the first eight letters a ninth more likely than the
+    /// rest, and there is no reason to hand that away.
+    static let alphabet = Array("ABCDEFGHJKMNPQRSTUVWXYZ23456789")
+    static let length = 8
+
+    static func generate() -> String {
+        // The largest multiple of the alphabet that fits in a byte; anything
+        // at or above it is discarded so every symbol is equally likely.
+        let ceiling = UInt8(256 - (256 % alphabet.count))
+        var picked = ""
+        picked.reserveCapacity(length)
+        while picked.count < length {
+            var bytes = [UInt8](repeating: 0, count: length)
+            let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+            precondition(status == errSecSuccess)
+            for byte in bytes where byte < ceiling && picked.count < length {
+                picked.append(alphabet[Int(byte) % alphabet.count])
+            }
+        }
+        return picked
+    }
+
+    /// Uppercased, with the separators people insert when copying by eye
+    /// (spaces, dashes) dropped. Anything outside the alphabet is dropped too,
+    /// so a code pasted with stray punctuation still matches.
+    static func normalize(_ raw: String) -> String {
+        String(raw.uppercased().filter { alphabet.contains($0) })
+    }
+
+    static func isValidFormat(_ raw: String) -> Bool {
+        normalize(raw).count == length
+    }
+
+    /// Constant-time compare, so a code cannot be recovered a character at a
+    /// time by timing the replies. Cheap here and the habit is worth keeping.
+    static func matches(_ expected: String, _ candidate: String) -> Bool {
+        let a = Array(normalize(expected).utf8)
+        let b = Array(normalize(candidate).utf8)
+        guard a.count == length, b.count == length else { return false }
+        var diff: UInt8 = 0
+        for (x, y) in zip(a, b) { diff |= x ^ y }
+        return diff == 0
+    }
+
+    /// The payload of a `/start` command, or nil when the text is not one.
+    ///
+    /// Telegram delivers a deep link's payload as an ordinary argument —
+    /// tapping `t.me/foo_bot?start=ABC` sends the literal text `/start ABC` —
+    /// so there is nothing to unwrap. The bot-mention suffix (`/start@foo_bot`,
+    /// how a group disambiguates between bots) is stripped by the caller
+    /// before this sees it. Returns an empty string for a bare `/start`, which
+    /// is a real case: it is what the Start button sends with no deep link.
+    static func startPayload(in text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed == "/start" || trimmed.hasPrefix("/start ") else { return nil }
+        return String(trimmed.dropFirst("/start".count))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The deep link to put behind a QR code. `username` is the bot's, without
+    /// the leading `@`.
+    static func deepLink(botUsername: String, code: String) -> String {
+        "https://t.me/\(botUsername)?start=\(normalize(code))"
+    }
+}
+
+/// The armed half: one live code, with an expiry, good for exactly one pairing.
+///
+/// Armed only while the setup wizard is on screen waiting. A code that lived
+/// forever would be a second, quieter allowlist — anyone who found the bot and
+/// guessed eight characters would be in — so it dies on use and on a timer.
+final class TelegramPairingSession {
+    /// Long enough to walk to a phone and unlock it, short enough that leaving
+    /// Settings open over lunch does not leave the door open with it.
+    static let defaultTTL: TimeInterval = 10 * 60
+
+    private let lock = NSLock()
+    private var currentCode: String
+    private var expiry: Date
+    private var consumed = false
+    private let ttl: TimeInterval
+
+    init(ttl: TimeInterval = TelegramPairingSession.defaultTTL,
+         code: String = TelegramPairingCode.generate(),
+         now: Date = Date()) {
+        self.ttl = ttl
+        self.currentCode = code
+        self.expiry = now.addingTimeInterval(ttl)
+    }
+
+    var code: String {
+        lock.lock(); defer { lock.unlock() }
+        return currentCode
+    }
+
+    var expiresAt: Date {
+        lock.lock(); defer { lock.unlock() }
+        return expiry
+    }
+
+    func isExpired(now: Date = Date()) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return consumed || now >= expiry
+    }
+
+    /// New code, new clock. The old one stops working immediately.
+    @discardableResult
+    func refresh(now: Date = Date()) -> String {
+        lock.lock(); defer { lock.unlock() }
+        currentCode = TelegramPairingCode.generate()
+        expiry = now.addingTimeInterval(ttl)
+        consumed = false
+        return currentCode
+    }
+
+    /// Verify and spend in one step. A second caller with the same code —
+    /// someone forwarding the link, a retry — gets false, so pairing cannot be
+    /// replayed into a second allowlist entry.
+    func claim(_ candidate: String, now: Date = Date()) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard !consumed, now < expiry else { return false }
+        guard TelegramPairingCode.matches(currentCode, candidate) else { return false }
+        consumed = true
+        return true
+    }
+}

--- a/Sources/UI/Onboarding/OnboardingKit.swift
+++ b/Sources/UI/Onboarding/OnboardingKit.swift
@@ -234,14 +234,24 @@ final class OnboardingPrimaryButton: NSButton, OnboardingThemeReactive {
     var text = "" { didSet { applyTheme() } }
     var fontSize: CGFloat = 13.5 { didSet { applyTheme() } }
 
+    /// Draws no bezel: a Return `keyEquivalent` otherwise makes AppKit paint the
+    /// default-button chrome under our layer fill, which peeks out past the pill.
+    private final class PillCell: NSButtonCell {
+        override func drawBezel(withFrame cellFrame: NSRect, in controlView: NSView) {}
+    }
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
+        let pill = PillCell()
+        pill.isBordered = false
+        pill.backgroundColor = .clear
+        pill.highlightsBy = []
+        pill.showsStateBy = []
+        cell = pill
         isBordered = false
         focusRingType = .none
+        alignment = .center
         wantsLayer = true
-        // Custom `draw(_:)` must repaint when the layer is backed, or AppKit
-        // keeps the cell's bezel and our fill fight each other.
-        layerContentsRedrawPolicy = .onSetNeedsDisplay
         layer?.cornerRadius = 9
         layer?.masksToBounds = true
         translatesAutoresizingMaskIntoConstraints = false
@@ -255,7 +265,7 @@ final class OnboardingPrimaryButton: NSButton, OnboardingThemeReactive {
 
     /// Borderless buttons hug the title; pad so the pill does not clip the label.
     override var intrinsicContentSize: NSSize {
-        var size = attributedTitle.size()
+        var size = super.intrinsicContentSize
         size.width += 28
         size.height = 34
         return size
@@ -278,18 +288,6 @@ final class OnboardingPrimaryButton: NSButton, OnboardingThemeReactive {
         applyTheme()
     }
 
-    /// Skip `super.draw`: a Return `keyEquivalent` makes AppKit paint the
-    /// default-button bezel under our layer fill. That bezel uses a different
-    /// corner radius, so it peeks out as blue tabs on either end of the pill.
-    override func draw(_ dirtyRect: NSRect) {
-        let titleSize = attributedTitle.size()
-        let origin = NSPoint(
-            x: ((bounds.width - titleSize.width) / 2).rounded(.down),
-            y: ((bounds.height - titleSize.height) / 2).rounded(.down)
-        )
-        attributedTitle.draw(at: origin)
-    }
-
     func applyTheme() {
         let ink = OnboardingStyle.inkOnAccent(for: effectiveAppearance)
         let fill = isEnabled
@@ -308,7 +306,6 @@ final class OnboardingPrimaryButton: NSButton, OnboardingThemeReactive {
         }
         attributedTitle = composed
         invalidateIntrinsicContentSize()
-        needsDisplay = true
     }
 }
 

--- a/Sources/UI/Onboarding/OnboardingKit.swift
+++ b/Sources/UI/Onboarding/OnboardingKit.swift
@@ -237,14 +237,29 @@ final class OnboardingPrimaryButton: NSButton, OnboardingThemeReactive {
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         isBordered = false
+        focusRingType = .none
         wantsLayer = true
+        // Custom `draw(_:)` must repaint when the layer is backed, or AppKit
+        // keeps the cell's bezel and our fill fight each other.
+        layerContentsRedrawPolicy = .onSetNeedsDisplay
         layer?.cornerRadius = 9
+        layer?.masksToBounds = true
         translatesAutoresizingMaskIntoConstraints = false
         applyTheme()
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
+
+    override var isEnabled: Bool { didSet { applyTheme() } }
+
+    /// Borderless buttons hug the title; pad so the pill does not clip the label.
+    override var intrinsicContentSize: NSSize {
+        var size = attributedTitle.size()
+        size.width += 28
+        size.height = 34
+        return size
+    }
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
@@ -261,6 +276,18 @@ final class OnboardingPrimaryButton: NSButton, OnboardingThemeReactive {
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
         applyTheme()
+    }
+
+    /// Skip `super.draw`: a Return `keyEquivalent` makes AppKit paint the
+    /// default-button bezel under our layer fill. That bezel uses a different
+    /// corner radius, so it peeks out as blue tabs on either end of the pill.
+    override func draw(_ dirtyRect: NSRect) {
+        let titleSize = attributedTitle.size()
+        let origin = NSPoint(
+            x: ((bounds.width - titleSize.width) / 2).rounded(.down),
+            y: ((bounds.height - titleSize.height) / 2).rounded(.down)
+        )
+        attributedTitle.draw(at: origin)
     }
 
     func applyTheme() {
@@ -280,6 +307,8 @@ final class OnboardingPrimaryButton: NSButton, OnboardingThemeReactive {
             ]))
         }
         attributedTitle = composed
+        invalidateIntrinsicContentSize()
+        needsDisplay = true
     }
 }
 

--- a/Sources/UI/QRCodeRenderer.swift
+++ b/Sources/UI/QRCodeRenderer.swift
@@ -1,0 +1,118 @@
+import AppKit
+import CoreImage
+import CoreImage.CIFilterBuiltins
+
+/// QR codes, drawn locally.
+///
+/// Nothing here talks to a service: a QR generator that round-trips the payload
+/// through someone's API would publish the pairing link it is meant to keep
+/// between this Mac and its owner's phone. CoreImage has shipped the encoder
+/// since 10.9.
+enum QRCodeRenderer {
+    /// A QR for `string`, sized to `points` and drawn in `foreground` on
+    /// `background`.
+    ///
+    /// The generator emits one pixel per module, so the image is scaled up by a
+    /// whole number with interpolation switched off — anything else feathers the
+    /// module edges, and a blurry QR is a QR a phone gives up on.
+    static func image(for string: String,
+                      points: CGFloat,
+                      foreground: NSColor = .black,
+                      background: NSColor = .white) -> NSImage? {
+        guard !string.isEmpty else { return nil }
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+        // Medium recovers ~15% of the symbol. The link is short, so the extra
+        // modules cost nothing, and a screen photographed at an angle needs it.
+        filter.correctionLevel = "M"
+        guard let coreImage = filter.outputImage else { return nil }
+
+        let moduleCount = max(coreImage.extent.width, 1)
+        // Round up so the whole code always fills the requested box, then let
+        // the NSImage size do the final (still integral-module) scaling.
+        let scale = max(1, (points / moduleCount).rounded(.up))
+        let scaled = coreImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+
+        let rep = NSCIImageRep(ciImage: scaled)
+        let source = NSImage(size: rep.size)
+        source.addRepresentation(rep)
+
+        // The generator's output is black-on-transparent. Tinting through
+        // CIFalseColor would work, but drawing it as a mask keeps the colors as
+        // resolved `NSColor`s, so a theme change repaints correctly.
+        let output = NSImage(size: NSSize(width: points, height: points), flipped: false) { rect in
+            background.setFill()
+            rect.fill()
+            NSGraphicsContext.current?.imageInterpolation = .none
+            source.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1)
+            foreground.setFill()
+            rect.fill(using: .sourceAtop)
+            return true
+        }
+        return output
+    }
+}
+
+/// An `NSImageView` that re-renders its QR when the appearance flips.
+///
+/// A QR needs real contrast in both themes and cannot simply be tinted: the
+/// quiet zone and the light modules are part of the symbol, so the background
+/// has to be painted too. Keeping the payload here and redrawing on
+/// `viewDidChangeEffectiveAppearance` is the only way the code stays scannable
+/// after a switch to dark mode.
+final class QRCodeView: NSImageView {
+    var payload: String = "" {
+        didSet { redraw() }
+    }
+    /// Side length in points. The view is square and pins itself to it.
+    var side: CGFloat = 180 {
+        didSet {
+            sideConstraints.forEach { $0.constant = side }
+            redraw()
+        }
+    }
+
+    private var sideConstraints: [NSLayoutConstraint] = []
+
+    init(side: CGFloat = 180) {
+        self.side = side
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        imageScaling = .scaleProportionallyUpOrDown
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.masksToBounds = true
+        sideConstraints = [
+            widthAnchor.constraint(equalToConstant: side),
+            heightAnchor.constraint(equalToConstant: side),
+        ]
+        NSLayoutConstraint.activate(sideConstraints)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        redraw()
+    }
+
+    private func redraw() {
+        guard !payload.isEmpty else {
+            image = nil
+            return
+        }
+        // Resolve against this view's appearance, not the app's: a sheet can
+        // carry its own.
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            // Not pure black/white — a paper-white card in a dark sheet is a
+            // flashbulb, and phones scan a soft contrast pair perfectly well.
+            let dark = self.effectiveAppearance.isDark
+            self.image = QRCodeRenderer.image(
+                for: self.payload,
+                points: self.side * (self.window?.backingScaleFactor ?? 2),
+                foreground: dark ? NSColor(white: 0.06, alpha: 1) : NSColor(white: 0.08, alpha: 1),
+                background: dark ? NSColor(white: 0.88, alpha: 1) : .white)
+        }
+    }
+}

--- a/Sources/UI/QRCodeRenderer.swift
+++ b/Sources/UI/QRCodeRenderer.swift
@@ -25,31 +25,40 @@ enum QRCodeRenderer {
         // Medium recovers ~15% of the symbol. The link is short, so the extra
         // modules cost nothing, and a screen photographed at an angle needs it.
         filter.correctionLevel = "M"
-        guard let coreImage = filter.outputImage else { return nil }
+        guard let raw = filter.outputImage else { return nil }
 
-        let moduleCount = max(coreImage.extent.width, 1)
+        let moduleCount = max(raw.extent.width, 1)
         // Round up so the whole code always fills the requested box, then let
         // the NSImage size do the final (still integral-module) scaling.
         let scale = max(1, (points / moduleCount).rounded(.up))
-        let scaled = coreImage.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        let scaled = raw.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
 
-        let rep = NSCIImageRep(ciImage: scaled)
-        let source = NSImage(size: rep.size)
-        source.addRepresentation(rep)
+        // The generator is black modules on transparent. Flatten onto white so
+        // `CIFalseColor` can map black→foreground and white→background — the
+        // earlier AppKit path painted the background first then `sourceAtop`'d
+        // the whole rect with foreground, which turned the card into a solid
+        // black square.
+        let white = CIImage(color: .white).cropped(to: scaled.extent)
+        let opaque = scaled.composited(over: white)
+        let colorize = CIFilter.falseColor()
+        colorize.inputImage = opaque
+        colorize.color0 = CIColor(color: foreground) ?? .black
+        colorize.color1 = CIColor(color: background) ?? .white
+        guard let colored = colorize.outputImage?.cropped(to: scaled.extent) else { return nil }
 
-        // The generator's output is black-on-transparent. Tinting through
-        // CIFalseColor would work, but drawing it as a mask keeps the colors as
-        // resolved `NSColor`s, so a theme change repaints correctly.
-        let output = NSImage(size: NSSize(width: points, height: points), flipped: false) { rect in
-            background.setFill()
-            rect.fill()
+        // Rasterize through CIContext. `NSCIImageRep` + `NSImage.draw` was
+        // unreliable for the transparent quiet zone and made the tint bug above
+        // harder to see in isolation.
+        let ciContext = CIContext(options: nil)
+        guard let cgImage = ciContext.createCGImage(colored, from: scaled.extent) else { return nil }
+
+        let size = NSSize(width: points, height: points)
+        return NSImage(size: size, flipped: false) { rect in
             NSGraphicsContext.current?.imageInterpolation = .none
-            source.draw(in: rect, from: .zero, operation: .sourceOver, fraction: 1)
-            foreground.setFill()
-            rect.fill(using: .sourceAtop)
+            NSGraphicsContext.current?.cgContext.interpolationQuality = .none
+            NSGraphicsContext.current?.cgContext.draw(cgImage, in: rect)
             return true
         }
-        return output
     }
 }
 

--- a/Sources/UI/Settings/SettingsViewController.swift
+++ b/Sources/UI/Settings/SettingsViewController.swift
@@ -28,6 +28,22 @@ protocol SettingsDelegate: AnyObject {
     /// Whether the Host Gateway listener is actually up, so the page reports what
     /// happened rather than what was asked for.
     func settingsHostGatewayListening(_ settings: SettingsViewController) -> Bool
+
+    /// Bring a Telegram bridge up on `token` with `session` armed, so the setup
+    /// wizard's QR can be claimed. Nothing is persisted: the wizard writes the
+    /// config through `settingsDidUpdateConfig` like every other change.
+    ///
+    /// Pairing needs a live poller and Telegram allows exactly one per bot, so
+    /// the wizard borrows the app's channel rather than opening a second one
+    /// that would collide with it (409).
+    func settings(_ settings: SettingsViewController,
+                  beginTelegramPairing token: String,
+                  session: TelegramPairingSession,
+                  onPaired: @escaping (TelegramPairingResult) -> Void)
+
+    /// Drop the pairing bridge and put back whatever the saved config asks for.
+    /// Safe to call when no pairing is running.
+    func settingsEndTelegramPairing(_ settings: SettingsViewController)
 }
 
 /// Optional halves of the protocol: only the main window can answer them, and
@@ -47,6 +63,11 @@ extension SettingsDelegate {
     func settingsPaneTargets(_ settings: SettingsViewController) -> [PaneSnapshot] { [] }
     func settings(_ settings: SettingsViewController, connectGmailAccount email: String) {}
     func settingsHostGatewayListening(_ settings: SettingsViewController) -> Bool { false }
+    func settings(_ settings: SettingsViewController,
+                  beginTelegramPairing token: String,
+                  session: TelegramPairingSession,
+                  onPaired: @escaping (TelegramPairingResult) -> Void) {}
+    func settingsEndTelegramPairing(_ settings: SettingsViewController) {}
 }
 
 /// Settings, as a sidebar of pages built from `SettingsChrome` groups.
@@ -113,6 +134,9 @@ class SettingsViewController: NSViewController {
     private lazy var telegramAutoConnectToggle = SettingsControls.toggle(
         on: config.telegram?.resolvedAutoConnect ?? true, target: self, action: #selector(controlChanged))
     private let telegramStatusLabel = NSTextField(labelWithString: "")
+    private let telegramSetupSummary = NSTextField(labelWithString: "")
+    private lazy var telegramSetupButton = SettingsControls.button(
+        "Set up Telegram\u{2026}", target: self, action: #selector(telegramSetupClicked))
     private lazy var telegramRulesView = TelegramRulesView(rules: config.telegram?.resolvedRules ?? [])
     private let gmailAccountField = SettingsTextField()
     private let gmailAliasLabel = NSTextField(labelWithString: "")
@@ -460,7 +484,30 @@ class SettingsViewController: NSViewController {
         telegramRulesView.panes = settingsDelegate?.settingsPaneTargets(self) ?? []
         telegramRulesView.onChange = { [weak self] _ in self?.applyChanges() }
 
+        telegramSetupSummary.font = NSFont.systemFont(ofSize: 11)
+        telegramSetupSummary.textColor = Theme.textSecondary
+        telegramSetupSummary.lineBreakMode = .byWordWrapping
+        telegramSetupSummary.maximumNumberOfLines = 2
+        telegramSetupSummary.preferredMaxLayoutWidth = 460
+        telegramSetupSummary.translatesAutoresizingMaskIntoConstraints = false
+        telegramSetupButton.setAccessibilityIdentifier("settings.telegram.setup")
+        refreshTelegramSetupSummary()
+
+        let setupStack = NSStackView(views: [telegramSetupSummary, telegramSetupButton])
+        setupStack.orientation = .vertical
+        setupStack.alignment = .leading
+        setupStack.spacing = 8
+
         return [
+            // First, because it is what almost everyone should use. The fields
+            // below are the same values by hand, kept for a config edited from
+            // a script or a second account added without re-pairing.
+            SettingsGroupView(title: "Setup", rows: [
+                SettingsRow.stacked(nil,
+                                    subtitle: "Walks through creating a bot with @BotFather, checks the token, "
+                                            + "and pairs your Telegram account by QR code \u{2014} no user IDs to look up.",
+                                    content: setupStack),
+            ]),
             SettingsGroupView(title: "Bot", rows: [
                 SettingsRow.make("Bot token",
                                  subtitle: "Create a bot with @BotFather and paste its token here. Kept in config.json.",
@@ -473,6 +520,8 @@ class SettingsViewController: NSViewController {
                                  subtitle: "Chat id where agent-finished notifications go. Empty means the first numeric allowed user, or failing that the chat your last command came from.",
                                  control: telegramDefaultChatField),
                 SettingsRow.make("Connect at launch", control: telegramAutoConnectToggle),
+                SettingsRow.make("In a group",
+                                 subtitle: "Send a slash command: /status, /help. Telegram's privacy mode hands a bot only the group messages that begin with a slash, so \u{201C}@yourbot /status\u{201D} never arrives at all \u{2014} put the mention last instead, /status@yourbot, when several bots share the group. Plain prose is an order in a private chat only; in a group it stays conversation."),
                 SettingsRow.stacked(nil, content: statusStack),
             ]),
             SettingsGroupView(title: "Triggers", rows: [
@@ -662,6 +711,81 @@ class SettingsViewController: NSViewController {
             field.target = self
             field.action = #selector(controlChanged)
         }
+    }
+
+    // MARK: - Telegram setup wizard
+
+    private func refreshTelegramSetupSummary() {
+        let cfg = config.telegram
+        let paired = cfg?.allowedUsers.filter { !$0.isEmpty }.count ?? 0
+        switch (cfg?.resolvedBotToken != nil, paired) {
+        case (false, _):
+            telegramSetupSummary.stringValue = "Not set up yet."
+            telegramSetupButton.title = "Set up Telegram\u{2026}"
+        case (true, 0):
+            // The state that used to be silent and baffling: a valid token, a
+            // bridge that connects, and a bot that answers nobody.
+            telegramSetupSummary.stringValue =
+                "A bot token is saved, but nobody is allowed to command it yet."
+            telegramSetupButton.title = "Pair an account\u{2026}"
+        case (true, let count):
+            telegramSetupSummary.stringValue = count == 1
+                ? "Paired with 1 account."
+                : "Paired with \(count) accounts."
+            telegramSetupButton.title = "Pair another account\u{2026}"
+        }
+    }
+
+    @objc private func telegramSetupClicked() {
+        let services = TelegramSetupServices(
+            beginPairing: { [weak self] token, session, onPaired in
+                guard let self else { return }
+                self.settingsDelegate?.settings(self, beginTelegramPairing: token,
+                                                session: session, onPaired: onPaired)
+            },
+            endPairing: { [weak self] in
+                guard let self else { return }
+                self.settingsDelegate?.settingsEndTelegramPairing(self)
+            })
+
+        let wizard = TelegramSetupWizard(services: services)
+        wizard.onFinish = { [weak self] result in self?.applyTelegramSetup(result) }
+        presentAsSheet(wizard)
+    }
+
+    /// Fold a finished pairing into the editable config and save it.
+    ///
+    /// Whether the allowlist is replaced or added to turns on the bot: pairing
+    /// against the same token again is someone adding a teammate's phone, and
+    /// wiping their own id would lock them out of the bot they just shared. A
+    /// different token is a different bot, where the old ids mean nothing.
+    private func applyTelegramSetup(_ result: TelegramSetupResult) {
+        let sameBot = config.telegram?.resolvedBotToken == result.token
+        var users = sameBot
+            ? telegramUsersView.string
+                .split(whereSeparator: \.isNewline)
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            : []
+        if !users.contains(where: { TelegramConfig.normalize($0) == result.userId }) {
+            users.append(result.userId)
+        }
+
+        telegramTokenField.stringValue = result.token
+        telegramUsersView.string = users.joined(separator: "\n")
+        // Only claim the notification chat when nothing else has it: on a
+        // second pairing that chat belongs to whoever set the bot up first.
+        let existingChat = telegramDefaultChatField.stringValue.trimmingCharacters(in: .whitespaces)
+        if !sameBot || existingChat.isEmpty {
+            telegramDefaultChatField.stringValue = result.chatId
+        }
+        telegramAutoConnectToggle.state = result.autoConnect ? .on : .off
+        telegramStatusLabel.stringValue =
+            "Paired with \(result.displayName). Send /status from Telegram to check."
+        telegramStatusLabel.textColor = Theme.textSecondary
+
+        applyChanges()
+        refreshTelegramSetupSummary()
     }
 
     /// `getMe` is the cheapest call that proves a token: it needs no chat, and

--- a/Sources/UI/Settings/TelegramSetupWizard.swift
+++ b/Sources/UI/Settings/TelegramSetupWizard.swift
@@ -1,0 +1,740 @@
+import AppKit
+
+/// What the wizard hands back when it finishes.
+struct TelegramSetupResult: Equatable {
+    let token: String
+    /// The paired Telegram user id, as `allowed_users` stores it.
+    let userId: String
+    /// `@username` or first name — for the confirmation line, not for config.
+    let displayName: String
+    /// The chat the pairing happened in; where notifications go.
+    let chatId: String
+    let autoConnect: Bool
+}
+
+/// The two things the wizard cannot do for itself: bring a bridge up on a token
+/// that is not in the saved config yet, and take it back down again.
+///
+/// Pairing has to run on a *live* channel, because only a channel is polling
+/// `getUpdates`, and two pollers on one token collide with 409. So rather than
+/// grow a second poll loop here, the wizard borrows the app's one.
+struct TelegramSetupServices {
+    let beginPairing: (_ token: String,
+                       _ session: TelegramPairingSession,
+                       _ onPaired: @escaping (TelegramPairingResult) -> Void) -> Void
+    let endPairing: () -> Void
+}
+
+/// Guided Telegram setup: create a bot, paste its token, scan to pair, done.
+///
+/// The flow this replaces was seven steps across two apps, and two of them —
+/// "ask @userinfobot for your numeric id" and "work out what a chat id is" —
+/// were asking the user to do a lookup the bot itself performs for free the
+/// moment they send it anything. Pairing collapses those into a QR code.
+final class TelegramSetupWizard: NSViewController {
+    enum Step: Int, CaseIterable {
+        case createBot, token, pair, done
+
+        var title: String {
+            switch self {
+            case .createBot: return "Create your bot"
+            case .token: return "Paste the token"
+            case .pair: return "Scan to connect"
+            case .done: return "Ready"
+            }
+        }
+    }
+
+    var onFinish: ((TelegramSetupResult) -> Void)?
+    var onCancel: (() -> Void)?
+
+    private let services: TelegramSetupServices
+    private var step: Step = .createBot { didSet { render() } }
+
+    // Collected state
+    private var token = ""
+    private var botUsername: String?
+    private var botDisplayName: String?
+    private var pairResult: TelegramPairingResult?
+    private var session: TelegramPairingSession?
+    private var autoConnect = true
+
+    // Chrome
+    private let dots = NSStackView()
+    private let titleLabel = OnboardingStyle.label("", size: 19, weight: .semibold)
+    private let content = NSView()
+    private let backButton = OnboardingSecondaryButton(text: "Back")
+    private let cancelButton = OnboardingSecondaryButton(text: "Cancel")
+    private let primaryButton = OnboardingPrimaryButton()
+
+    // Step 2
+    private let tokenTextView = NSTextView()
+    private let tokenStatus = OnboardingStatusPill()
+    private var validateWork: DispatchWorkItem?
+    /// Bumped per validation so a slow reply for an old token cannot overwrite
+    /// the verdict on the one now in the box.
+    private var validateGeneration = 0
+
+    // Step 3
+    private let qrView = QRCodeView(side: 168)
+    private let codeLabel = OnboardingStyle.monoLabel("", size: 19, weight: .semibold,
+                                                      color: OnboardingStyle.textPrimary)
+    private let pairStatus = OnboardingStatusPill()
+    private let expiryLabel = OnboardingStyle.label("", size: 11,
+                                                    color: OnboardingStyle.textFaint)
+    private var expiryTimer: Timer?
+
+    init(services: TelegramSetupServices) {
+        self.services = services
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    deinit {
+        expiryTimer?.invalidate()
+        validateWork?.cancel()
+    }
+
+    // MARK: - Layout
+
+    override func loadView() {
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 560, height: 560))
+        root.wantsLayer = true
+        view = root
+
+        for i in 0..<Step.allCases.count {
+            let dot = NSView()
+            dot.wantsLayer = true
+            dot.layer?.cornerRadius = 3
+            dot.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                dot.heightAnchor.constraint(equalToConstant: 6),
+                dot.widthAnchor.constraint(equalToConstant: i == 0 ? 18 : 6),
+            ])
+            dots.addArrangedSubview(dot)
+        }
+        dots.orientation = .horizontal
+        dots.spacing = 5
+        dots.translatesAutoresizingMaskIntoConstraints = false
+
+        content.translatesAutoresizingMaskIntoConstraints = false
+
+        backButton.target = self
+        backButton.action = #selector(backClicked)
+        cancelButton.target = self
+        cancelButton.action = #selector(cancelClicked)
+        primaryButton.target = self
+        primaryButton.action = #selector(primaryClicked)
+        primaryButton.keyEquivalent = "\r"
+        primaryButton.keyEquivalentModifierMask = .command
+        primaryButton.heightAnchor.constraint(equalToConstant: 34).isActive = true
+
+        let footer = NSStackView(views: [cancelButton, backButton, Self.spacer(), primaryButton])
+        footer.orientation = .horizontal
+        footer.spacing = 8
+        footer.translatesAutoresizingMaskIntoConstraints = false
+
+        for v in [dots, titleLabel, content, footer] as [NSView] { root.addSubview(v) }
+
+        NSLayoutConstraint.activate([
+            dots.topAnchor.constraint(equalTo: root.topAnchor, constant: 26),
+            dots.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 28),
+
+            titleLabel.topAnchor.constraint(equalTo: dots.bottomAnchor, constant: 14),
+            titleLabel.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 28),
+            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: root.trailingAnchor, constant: -28),
+
+            content.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 16),
+            content.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 28),
+            content.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -28),
+
+            footer.topAnchor.constraint(greaterThanOrEqualTo: content.bottomAnchor, constant: 16),
+            footer.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 28),
+            footer.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -28),
+            footer.bottomAnchor.constraint(equalTo: root.bottomAnchor, constant: -22),
+        ])
+
+        preferredContentSize = NSSize(width: 560, height: 560)
+        render()
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        view.window?.makeFirstResponder(primaryButton)
+    }
+
+    /// Belt and braces: the sheet can also go away with the Settings window,
+    /// and an armed code must not outlive the screen showing it. The owner's
+    /// `endPairing` is idempotent.
+    override func viewDidDisappear() {
+        super.viewDidDisappear()
+        expiryTimer?.invalidate()
+        services.endPairing()
+    }
+
+    // MARK: - Rendering
+
+    private func render() {
+        titleLabel.stringValue = step.title
+        renderDots()
+
+        content.subviews.forEach { $0.removeFromSuperview() }
+        let body: NSView
+        switch step {
+        case .createBot: body = buildCreateBotStep()
+        case .token: body = buildTokenStep()
+        case .pair: body = buildPairStep()
+        case .done: body = buildDoneStep()
+        }
+        body.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(body)
+        NSLayoutConstraint.activate([
+            body.topAnchor.constraint(equalTo: content.topAnchor),
+            body.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            body.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            body.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+        ])
+
+        backButton.isHidden = step == .createBot
+        // Pairing has no "continue": the phone advances the step, so a button
+        // that only ever sat there disabled would read as something broken.
+        primaryButton.isHidden = step == .pair
+        switch step {
+        case .createBot: primaryButton.text = "I have a token"
+        case .token: primaryButton.text = "Continue"
+        case .pair: primaryButton.text = ""
+        case .done: primaryButton.text = "Done"
+        }
+        primaryButton.isEnabled = step != .token || botUsername != nil
+        cancelButton.text = step == .done ? "Close" : "Cancel"
+    }
+
+    private func renderDots() {
+        for (index, dot) in dots.arrangedSubviews.enumerated() {
+            let done = index <= step.rawValue
+            dot.layer?.backgroundColor = view.resolvedCGColor(
+                done ? OnboardingStyle.accent : OnboardingStyle.stroke)
+            // The current step's dot stretches into a capsule, so the position
+            // in the flow reads without counting.
+            for c in dot.constraints where c.firstAttribute == .width {
+                c.constant = index == step.rawValue ? 18 : 6
+            }
+        }
+    }
+
+    // MARK: - Step 1: create the bot
+
+    private func buildCreateBotStep() -> NSView {
+        let blurb = OnboardingStyle.wrappingLabel(
+            "Telegram makes bots, not seahelm — @BotFather is the bot that makes bots. "
+            + "It takes about a minute, and the bot is yours: its token stays on this Mac "
+            + "and no traffic goes through us.", size: 12.5)
+
+        let panel = OnboardingPanel()
+        panel.showsSelectionGlow = false
+        let rows = NSStackView(views: [
+            instructionRow(1, "Open @BotFather in Telegram."),
+            instructionRow(2, "Send it ", mono: "/newbot", trailing: "."),
+            instructionRow(3, "Give the bot a display name — anything, e.g. “My Fleet”."),
+            instructionRow(4, "Give it a username ending in ", mono: "bot",
+                           trailing: ", e.g. matt_fleet_bot."),
+            instructionRow(5, "It replies with a token. Copy the whole message."),
+        ])
+        rows.orientation = .vertical
+        rows.alignment = .leading
+        rows.spacing = 9
+        rows.translatesAutoresizingMaskIntoConstraints = false
+        panel.addSubview(rows)
+        NSLayoutConstraint.activate([
+            rows.topAnchor.constraint(equalTo: panel.topAnchor, constant: 16),
+            rows.leadingAnchor.constraint(equalTo: panel.leadingAnchor, constant: 16),
+            rows.trailingAnchor.constraint(equalTo: panel.trailingAnchor, constant: -16),
+            rows.bottomAnchor.constraint(equalTo: panel.bottomAnchor, constant: -16),
+        ])
+
+        let open = OnboardingSecondaryButton(text: "Open @BotFather", symbol: "arrow.up.forward.app")
+        open.target = self
+        open.action = #selector(openBotFatherClicked)
+
+        let hint = OnboardingStyle.label("Copies /newbot to the clipboard on the way.",
+                                         size: 11, color: OnboardingStyle.textFaint)
+
+        let openRow = NSStackView(views: [open, hint])
+        openRow.orientation = .horizontal
+        openRow.spacing = 10
+        openRow.alignment = .centerY
+
+        return verticalStack([blurb, panel, openRow], spacing: 16)
+    }
+
+    // MARK: - Step 2: the token
+
+    private func buildTokenStep() -> NSView {
+        let blurb = OnboardingStyle.wrappingLabel(
+            "Paste BotFather's reply — the whole message is fine, the token will be picked "
+            + "out of it. It is checked against Telegram as soon as it looks complete.",
+            size: 12.5)
+
+        tokenTextView.font = AppFont.mono(size: 12, weight: .regular)
+        tokenTextView.isRichText = false
+        tokenTextView.isAutomaticQuoteSubstitutionEnabled = false
+        tokenTextView.isAutomaticDashSubstitutionEnabled = false
+        tokenTextView.drawsBackground = false
+        tokenTextView.textColor = OnboardingStyle.textPrimary
+        tokenTextView.textContainerInset = NSSize(width: 8, height: 8)
+        tokenTextView.delegate = self
+        tokenTextView.setAccessibilityIdentifier("telegram.setup.token")
+        // A pasted BotFather reply is several lines; let the view grow and wrap
+        // inside the scroller rather than scroll sideways off the token.
+        tokenTextView.minSize = NSSize(width: 0, height: 0)
+        tokenTextView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude,
+                                       height: CGFloat.greatestFiniteMagnitude)
+        tokenTextView.isVerticallyResizable = true
+        tokenTextView.isHorizontallyResizable = false
+        tokenTextView.autoresizingMask = [.width]
+        tokenTextView.textContainer?.widthTracksTextView = true
+
+        let scroll = NSScrollView()
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .noBorder
+        scroll.drawsBackground = false
+        scroll.documentView = tokenTextView
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+
+        let box = OnboardingPanel()
+        box.showsSelectionGlow = false
+        box.addSubview(scroll)
+        NSLayoutConstraint.activate([
+            box.heightAnchor.constraint(equalToConstant: 86),
+            scroll.topAnchor.constraint(equalTo: box.topAnchor, constant: 1),
+            scroll.leadingAnchor.constraint(equalTo: box.leadingAnchor, constant: 1),
+            scroll.trailingAnchor.constraint(equalTo: box.trailingAnchor, constant: -1),
+            scroll.bottomAnchor.constraint(equalTo: box.bottomAnchor, constant: -1),
+        ])
+
+        let paste = OnboardingSecondaryButton(text: "Paste", symbol: "doc.on.clipboard")
+        paste.target = self
+        paste.action = #selector(pasteTokenClicked)
+
+        let statusRow = NSStackView(views: [paste, tokenStatus, Self.spacer()])
+        statusRow.orientation = .horizontal
+        statusRow.spacing = 10
+        statusRow.alignment = .centerY
+
+        // Nothing typed yet is not a state worth a pill; it would only ever say
+        // "waiting for input" beside an empty box.
+        tokenStatus.isHidden = tokenTextView.string.trimmingCharacters(
+            in: .whitespacesAndNewlines).isEmpty
+
+        return verticalStack([blurb, box, statusRow], spacing: 14)
+    }
+
+    // MARK: - Step 3: pair
+
+    private func buildPairStep() -> NSView {
+        let session = session ?? TelegramPairingSession()
+        self.session = session
+
+        let blurb = OnboardingStyle.wrappingLabel(
+            "Point your phone's camera at the code. Telegram opens on your bot with a Start "
+            + "button — tap it, and this Mac learns who you are. Nobody else can use the bot.",
+            size: 12.5)
+
+        qrView.payload = deepLink(code: session.code)
+
+        let orLabel = OnboardingStyle.label("Or send this code to \(botHandle):", size: 11.5,
+                                            color: OnboardingStyle.textSecondary)
+        codeLabel.stringValue = formatted(session.code)
+
+        let openTelegram = OnboardingSecondaryButton(text: "Open in Telegram",
+                                                     symbol: "arrow.up.forward.app")
+        openTelegram.target = self
+        openTelegram.action = #selector(openDeepLinkClicked)
+
+        let newCode = OnboardingLinkButton(title: "New code", size: 11.5)
+        newCode.target = self
+        newCode.action = #selector(newCodeClicked)
+
+        let expiryRow = NSStackView(views: [expiryLabel, newCode])
+        expiryRow.orientation = .horizontal
+        expiryRow.spacing = 8
+        expiryRow.alignment = .centerY
+
+        let side = NSStackView(views: [orLabel, codeLabel, openTelegram, expiryRow])
+        side.orientation = .vertical
+        side.alignment = .leading
+        side.spacing = 10
+
+        let columns = NSStackView(views: [qrView, side])
+        columns.orientation = .horizontal
+        columns.alignment = .top
+        columns.spacing = 22
+
+        pairStatus.state = .pending("Waiting for you to tap Start…")
+
+        startPairing(session: session)
+        startExpiryTimer()
+
+        return verticalStack([blurb, columns, pairStatus], spacing: 18)
+    }
+
+    // MARK: - Step 4: done
+
+    private func buildDoneStep() -> NSView {
+        let who = pairResult?.displayName ?? "your account"
+        let headline = OnboardingStyle.wrappingLabel(
+            "\(botHandle) is paired with \(who). Agent notifications go to that chat, and "
+            + "anything you send it steers the fleet.", size: 12.5)
+
+        let panel = OnboardingPanel()
+        panel.showsSelectionGlow = false
+        let rows = NSStackView(views: [
+            instructionRow(nil, "Send ", mono: "/status", trailing: " to see what is running."),
+            instructionRow(nil, "Type ", mono: "/", trailing: " for the command menu — it is published to Telegram."),
+            instructionRow(nil, "In a group, only slash commands reach the bot: ",
+                           mono: "/status@\(botUsername ?? "yourbot")", trailing: "."),
+        ])
+        rows.orientation = .vertical
+        rows.alignment = .leading
+        rows.spacing = 9
+        rows.translatesAutoresizingMaskIntoConstraints = false
+        panel.addSubview(rows)
+        NSLayoutConstraint.activate([
+            rows.topAnchor.constraint(equalTo: panel.topAnchor, constant: 16),
+            rows.leadingAnchor.constraint(equalTo: panel.leadingAnchor, constant: 16),
+            rows.trailingAnchor.constraint(equalTo: panel.trailingAnchor, constant: -16),
+            rows.bottomAnchor.constraint(equalTo: panel.bottomAnchor, constant: -16),
+        ])
+
+        let toggleRow = OnboardingToggleRow(
+            title: "Connect at launch",
+            subtitle: "Bring the bridge up whenever seahelm starts.",
+            symbol: "bolt.horizontal",
+            tint: { OnboardingStyle.accent })
+        toggleRow.isOn = autoConnect
+        toggleRow.toggle.target = self
+        toggleRow.toggle.action = #selector(autoConnectChanged(_:))
+
+        return verticalStack([headline, panel, toggleRow], spacing: 16)
+    }
+
+    // MARK: - Pairing
+
+    private func startPairing(session: TelegramPairingSession) {
+        services.beginPairing(token, session) { [weak self] result in
+            guard let self else { return }
+            self.pairResult = result
+            self.pairStatus.state = .ok("Paired with \(result.displayName)")
+            self.expiryTimer?.invalidate()
+            self.publishCommandMenu()
+            // A beat on the green pill, so the step that just succeeded is seen
+            // to have succeeded rather than vanishing under the next one.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
+                guard let self, self.step == .pair else { return }
+                self.step = .done
+            }
+        }
+    }
+
+    private func startExpiryTimer() {
+        expiryTimer?.invalidate()
+        let timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            self?.tickExpiry()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        expiryTimer = timer
+        tickExpiry()
+    }
+
+    private func tickExpiry() {
+        guard let session, step == .pair else { return }
+        let remaining = session.expiresAt.timeIntervalSinceNow
+        guard remaining > 0 else {
+            expiryLabel.stringValue = "Code expired."
+            pairStatus.state = .failed("Code expired — generate a new one.")
+            expiryTimer?.invalidate()
+            return
+        }
+        let minutes = Int(remaining) / 60
+        let seconds = Int(remaining) % 60
+        expiryLabel.stringValue = String(format: "Expires in %d:%02d", minutes, seconds)
+    }
+
+    /// Publish the verb table so `/` opens a menu in the chat. Best effort: a
+    /// failure here costs discoverability, not function, and the user is
+    /// finished either way.
+    private func publishCommandMenu() {
+        let token = self.token
+        DispatchQueue.global(qos: .utility).async {
+            let api = TelegramBotAPI(token: token)
+            do {
+                try api.setMyCommands(CommandSpecs.botCommands)
+            } catch {
+                NSLog("[Telegram] setMyCommands failed: \(error.localizedDescription)")
+            }
+            api.invalidate()
+        }
+    }
+
+    // MARK: - Token validation
+
+    private func scheduleValidation() {
+        validateWork?.cancel()
+        tokenStatus.isHidden = tokenTextView.string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        botUsername = nil
+        primaryButton.isEnabled = false
+
+        guard let candidate = Self.extractToken(from: tokenTextView.string) else {
+            if !tokenStatus.isHidden {
+                tokenStatus.state = .pending("Looking for a token like 123456789:AAF…")
+            }
+            return
+        }
+        tokenStatus.state = .pending("Checking with Telegram…")
+        let work = DispatchWorkItem { [weak self] in self?.validate(candidate) }
+        validateWork = work
+        // Typing (or pasting a line at a time) should not fire a round trip per
+        // keystroke; the pause is short enough that a paste feels immediate.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35, execute: work)
+    }
+
+    private func validate(_ candidate: String) {
+        validateGeneration += 1
+        let generation = validateGeneration
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let api = TelegramBotAPI(token: candidate)
+            let outcome = Result { try api.getMe() }
+            // A bot wired to a webhook by something else answers `getMe` and
+            // then refuses to be polled (409). Clearing it here turns a
+            // baffling failure at the pairing step into no failure at all.
+            if case .success = outcome { try? api.deleteWebhook() }
+            api.invalidate()
+            DispatchQueue.main.async {
+                guard let self, generation == self.validateGeneration else { return }
+                switch outcome {
+                case .success(let me):
+                    self.token = candidate
+                    self.botUsername = me.username
+                    self.botDisplayName = me.firstName
+                    self.tokenStatus.state = .ok("Connected as \(self.botHandle)")
+                    self.primaryButton.isEnabled = true
+                case .failure(let error):
+                    self.tokenStatus.state = .failed(error.localizedDescription)
+                    self.primaryButton.isEnabled = false
+                }
+            }
+        }
+    }
+
+    /// Pull a bot token out of whatever was pasted. BotFather's reply is a
+    /// paragraph with the token in the middle of it, and asking people to
+    /// select exactly the token is asking for a truncated paste.
+    static func extractToken(from raw: String) -> String? {
+        let pattern = "[0-9]{5,16}:[A-Za-z0-9_-]{30,}"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(raw.startIndex..<raw.endIndex, in: raw)
+        guard let match = regex.firstMatch(in: raw, range: range),
+              let matched = Range(match.range, in: raw) else { return nil }
+        return String(raw[matched])
+    }
+
+    // MARK: - Actions
+
+    @objc private func primaryClicked() {
+        switch step {
+        case .createBot:
+            step = .token
+        case .token:
+            guard botUsername != nil else { return }
+            step = .pair
+        case .pair:
+            break
+        case .done:
+            finish()
+        }
+    }
+
+    @objc private func backClicked() {
+        switch step {
+        case .createBot:
+            break
+        case .token:
+            step = .createBot
+        case .pair:
+            // Leaving the step disarms the code: it exists only while its QR is
+            // on screen.
+            services.endPairing()
+            expiryTimer?.invalidate()
+            session = nil
+            step = .token
+        case .done:
+            step = .pair
+        }
+    }
+
+    @objc private func cancelClicked() {
+        // `done` reaches here as "Close": pairing already happened and writing
+        // it down is the only thing left, so closing saves rather than discards.
+        if step == .done {
+            finish()
+            return
+        }
+        services.endPairing()
+        expiryTimer?.invalidate()
+        onCancel?()
+        dismiss(nil)
+    }
+
+    private func finish() {
+        services.endPairing()
+        expiryTimer?.invalidate()
+        guard let result = pairResult else {
+            dismiss(nil)
+            return
+        }
+        onFinish?(TelegramSetupResult(token: token,
+                                      userId: result.userId,
+                                      displayName: result.displayName,
+                                      chatId: result.chatId,
+                                      autoConnect: autoConnect))
+        dismiss(nil)
+    }
+
+    @objc private func autoConnectChanged(_ sender: NSSwitch) {
+        autoConnect = sender.state == .on
+    }
+
+    @objc private func openBotFatherClicked() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("/newbot", forType: .string)
+        // The https link rather than `tg://`: it opens the app when Telegram is
+        // installed and the web client when it is not, where `tg://` would fail
+        // with nothing on screen to explain it.
+        if let url = URL(string: "https://t.me/BotFather") { NSWorkspace.shared.open(url) }
+    }
+
+    @objc private func openDeepLinkClicked() {
+        guard let session, let url = URL(string: deepLink(code: session.code)) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    @objc private func newCodeClicked() {
+        guard let session else { return }
+        let next = session.refresh()
+        qrView.payload = deepLink(code: next)
+        codeLabel.stringValue = formatted(next)
+        pairStatus.state = .pending("Waiting for you to tap Start…")
+        startExpiryTimer()
+    }
+
+    @objc private func pasteTokenClicked() {
+        guard let pasted = NSPasteboard.general.string(forType: .string) else { return }
+        tokenTextView.string = pasted
+        scheduleValidation()
+    }
+
+    // MARK: - Helpers
+
+    private var botHandle: String {
+        if let botUsername, !botUsername.isEmpty { return "@\(botUsername)" }
+        return botDisplayName ?? "your bot"
+    }
+
+    private func deepLink(code: String) -> String {
+        guard let botUsername, !botUsername.isEmpty else { return "" }
+        return TelegramPairingCode.deepLink(botUsername: botUsername, code: code)
+    }
+
+    /// `ABCD 2345` — grouped, because an eight-character code read off a screen
+    /// and typed into a phone is read in halves.
+    private func formatted(_ code: String) -> String {
+        guard code.count == 8 else { return code }
+        let mid = code.index(code.startIndex, offsetBy: 4)
+        return "\(code[..<mid]) \(code[mid...])"
+    }
+
+    /// Vertical stack whose block-level children (prose, panels, the toggle
+    /// row) span the full width while inline rows of buttons keep hugging their
+    /// content.
+    private func verticalStack(_ views: [NSView], spacing: CGFloat) -> NSView {
+        let stack = NSStackView(views: views)
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = spacing
+        for view in views where view is NSTextField || view is OnboardingPanel
+            || view is OnboardingToggleRow {
+            view.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        }
+        return stack
+    }
+
+    /// A stack view divider that soaks up the slack, so what follows it is
+    /// pushed to the trailing edge.
+    private static func spacer() -> NSView {
+        let view = NSView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.setContentHuggingPriority(.init(1), for: .horizontal)
+        view.setContentCompressionResistancePriority(.init(1), for: .horizontal)
+        return view
+    }
+
+    /// `1  Send /newbot.` — the number in an accent circle, the sentence beside
+    /// it, with an optional mono run in the middle for the literal to type.
+    private func instructionRow(_ number: Int?, _ leading: String,
+                                mono: String? = nil, trailing: String = "") -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.alignment = .firstBaseline
+        row.spacing = 9
+        row.translatesAutoresizingMaskIntoConstraints = false
+
+        let marker: NSTextField
+        if let number {
+            marker = OnboardingStyle.monoLabel("\(number)", size: 11.5, weight: .semibold,
+                                               color: OnboardingStyle.accent)
+        } else {
+            marker = OnboardingStyle.label("•", size: 12.5, color: OnboardingStyle.accent)
+        }
+        marker.setContentHuggingPriority(.required, for: .horizontal)
+        marker.widthAnchor.constraint(equalToConstant: 12).isActive = true
+
+        let text = NSTextField(labelWithAttributedString: sentence(leading, mono: mono,
+                                                                   trailing: trailing))
+        text.translatesAutoresizingMaskIntoConstraints = false
+        text.lineBreakMode = .byWordWrapping
+        text.maximumNumberOfLines = 3
+        text.preferredMaxLayoutWidth = 430
+
+        row.addArrangedSubview(marker)
+        row.addArrangedSubview(text)
+        return row
+    }
+
+    private func sentence(_ leading: String, mono: String?, trailing: String) -> NSAttributedString {
+        let body: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12.5),
+            .foregroundColor: OnboardingStyle.textSecondary,
+        ]
+        let code: [NSAttributedString.Key: Any] = [
+            .font: AppFont.mono(size: 12, weight: .medium),
+            .foregroundColor: OnboardingStyle.textPrimary,
+        ]
+        let out = NSMutableAttributedString(string: leading, attributes: body)
+        if let mono {
+            out.append(NSAttributedString(string: mono, attributes: code))
+            out.append(NSAttributedString(string: trailing, attributes: body))
+        }
+        return out
+    }
+}
+
+// MARK: - NSTextViewDelegate
+
+extension TelegramSetupWizard: NSTextViewDelegate {
+    func textDidChange(_ notification: Notification) {
+        guard (notification.object as? NSTextView) === tokenTextView else { return }
+        scheduleValidation()
+    }
+}

--- a/Tests/ChatCallbackRegistryTests.swift
+++ b/Tests/ChatCallbackRegistryTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import seahelm
+
+final class ChatCallbackRegistryTests: XCTestCase {
+
+    func testMintedTokenResolvesBackToItsAction() {
+        let registry = ChatCallbackRegistry()
+        let token = registry.mint(.command("/go #3"))
+        XCTAssertEqual(registry.action(for: token), .command("/go #3"))
+    }
+
+    func testTokensAreDistinctAndShortEnoughForTelegram() {
+        let registry = ChatCallbackRegistry()
+        let tokens = (0..<500).map { registry.mint(.command("/order #\($0) hi")) }
+        XCTAssertEqual(Set(tokens).count, tokens.count)
+        // `callback_data` is capped at 64 bytes, and the token is all of it.
+        XCTAssertTrue(tokens.allSatisfy { $0.utf8.count <= 64 })
+    }
+
+    func testUnknownTokenIsStaleRatherThanFatal() {
+        let registry = ChatCallbackRegistry()
+        XCTAssertNil(registry.action(for: "nope"))
+    }
+
+    /// A card that has been answered must not be answerable again — the option
+    /// text would be typed into the pane twice.
+    func testRetireDropsEveryButtonOnThatCard() {
+        let registry = ChatCallbackRegistry()
+        let first = registry.mint(.suggestionOption(orderId: "card-1", index: 0))
+        let second = registry.mint(.suggestionOption(orderId: "card-1", index: 1))
+        let dismiss = registry.mint(.dismissSuggestion(orderId: "card-1"))
+        let other = registry.mint(.suggestionOption(orderId: "card-2", index: 0))
+        let command = registry.mint(.command("/status"))
+
+        registry.retire(orderId: "card-1")
+
+        XCTAssertNil(registry.action(for: first))
+        XCTAssertNil(registry.action(for: second))
+        XCTAssertNil(registry.action(for: dismiss))
+        XCTAssertEqual(registry.action(for: other), .suggestionOption(orderId: "card-2", index: 0))
+        XCTAssertEqual(registry.action(for: command), .command("/status"))
+    }
+
+    func testOldestTokensAreEvictedPastCapacity() {
+        let registry = ChatCallbackRegistry()
+        let oldest = registry.mint(.command("/status"))
+        for i in 0..<ChatCallbackRegistry.capacity {
+            _ = registry.mint(.command("/order #\(i) hi"))
+        }
+        XCTAssertNil(registry.action(for: oldest))
+    }
+
+    /// Retiring must shrink the eviction queue too, or a long-lived session
+    /// evicts live tokens to make room for ones it already dropped.
+    func testRetireFreesCapacity() {
+        let registry = ChatCallbackRegistry()
+        let keeper = registry.mint(.command("/status"))
+        for i in 0..<(ChatCallbackRegistry.capacity - 1) {
+            _ = registry.mint(.suggestionOption(orderId: "card-\(i)", index: 0))
+        }
+        for i in 0..<(ChatCallbackRegistry.capacity - 1) {
+            registry.retire(orderId: "card-\(i)")
+        }
+        for i in 0..<(ChatCallbackRegistry.capacity - 1) {
+            _ = registry.mint(.command("/order #\(i) hi"))
+        }
+        XCTAssertEqual(registry.action(for: keeper), .command("/status"))
+    }
+}

--- a/Tests/CommandFormatterTests.swift
+++ b/Tests/CommandFormatterTests.swift
@@ -179,4 +179,54 @@ final class CommandFormatterTests: XCTestCase {
         XCTAssertFalse(CommandSpecs.menu.contains { $0.name == "yes" }, "the Helm line has sheets, not /yes")
         XCTAssertTrue(CommandSpecs.menu.contains { $0.name == "new" })
     }
+    // MARK: - Listing buttons
+
+    /// The button and the printed handle must mean the same pane: a phone taps
+    /// what a laptop types.
+    func testEveryPaneButtonIsALineTheParserReadsBack() {
+        let buttons = CommandFormatter.paneButtons(index, bound: nil)
+        XCTAssertEqual(buttons.count, index.panes.count)
+        for button in buttons {
+            guard case .line(let line) = button.effect else { return XCTFail("not a line: \(button)") }
+            guard case .go(.pane(let pane))? = try? CommandParser.parse(line, index: index).get().command else {
+                return XCTFail("did not parse to a pane: \(line)")
+            }
+            XCTAssertTrue(button.label.contains("#\(pane.handle)"), button.label)
+        }
+    }
+
+    func testThePaneAlreadyBoundGetsNoButton() {
+        let lines = CommandFormatter.paneButtons(index, bound: CommandFixture.paneB).map(\.effect)
+        XCTAssertFalse(lines.contains(.line("/go #7")), "\(lines)")
+        XCTAssertTrue(lines.contains(.line("/go #3")), "\(lines)")
+    }
+
+    /// A big fleet would bury its own listing under shortcuts; the text above
+    /// still names every pane.
+    func testButtonsAreCapped() {
+        let panes = (1...30).map {
+            PaneRef(handle: $0, handleKey: "k\($0)", id: "\($0)", project: "p", branch: "b\($0)",
+                    worktreePath: "/p/b\($0)", type: "Claude", title: "")
+        }
+        let big = FleetIndex(panes: panes)
+        XCTAssertEqual(CommandFormatter.paneButtons(big, bound: nil).count, CommandFormatter.buttonLimit)
+    }
+
+    /// `/go @somewhere-with-no-pane` has nothing to talk to, so it is not offered.
+    func testWorktreeButtonsSkipTheOnesWithNoPane() {
+        let buttons = CommandFormatter.worktreeButtons(index, bound: nil)
+        XCTAssertEqual(buttons.map(\.label).sorted(), ["beta/main", "feat-x"])
+        for button in buttons {
+            guard case .line(let line) = button.effect else { return XCTFail("not a line: \(button)") }
+            guard case .go(.worktree)? = try? CommandParser.parse(line, index: index).get().command else {
+                return XCTFail("did not parse to a worktree: \(line)")
+            }
+        }
+    }
+
+    func testWorktreeButtonsSkipTheOneAlreadyHere() {
+        let buttons = CommandFormatter.worktreeButtons(index, bound: CommandFixture.paneB)
+        XCTAssertEqual(buttons.map(\.label), ["beta/main"])
+    }
+
 }

--- a/Tests/QRCodeRendererTests.swift
+++ b/Tests/QRCodeRendererTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import seahelm
+
+final class QRCodeRendererTests: XCTestCase {
+    func testImageHasDarkAndLightModules() {
+        let image = QRCodeRenderer.image(
+            for: "https://t.me/SeahelmBot?start=ABCDEFGH",
+            points: 168,
+            foreground: NSColor(white: 0.06, alpha: 1),
+            background: NSColor(white: 0.88, alpha: 1))
+        XCTAssertNotNil(image)
+
+        guard let tiff = image?.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff) else {
+            return XCTFail("expected a bitmap")
+        }
+
+        var dark = 0
+        var light = 0
+        for y in 0..<bitmap.pixelsHigh {
+            for x in 0..<bitmap.pixelsWide {
+                guard let color = bitmap.colorAt(x: x, y: y)?
+                    .usingColorSpace(.deviceRGB) else { continue }
+                if color.redComponent < 0.2 {
+                    dark += 1
+                } else if color.redComponent > 0.7 {
+                    light += 1
+                }
+            }
+        }
+
+        // A solid black square (the old sourceAtop bug) has light == 0.
+        XCTAssertGreaterThan(dark, 1000, "expected dark modules")
+        XCTAssertGreaterThan(light, 1000, "expected light quiet zone / modules")
+    }
+
+    func testEmptyPayloadReturnsNil() {
+        XCTAssertNil(QRCodeRenderer.image(for: "", points: 168))
+    }
+}

--- a/Tests/TelegramPairingTests.swift
+++ b/Tests/TelegramPairingTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import seahelm
+
+final class TelegramPairingTests: XCTestCase {
+
+    // MARK: - Code shape
+
+    func testGeneratedCodeIsEightCharactersFromTheAlphabet() {
+        for _ in 0..<200 {
+            let code = TelegramPairingCode.generate()
+            XCTAssertEqual(code.count, TelegramPairingCode.length)
+            XCTAssertTrue(code.allSatisfy { TelegramPairingCode.alphabet.contains($0) })
+        }
+    }
+
+    /// The whole code travels in a `?start=` payload, whose legal characters
+    /// are `A-Z a-z 0-9 _ -`. A code that needed escaping would arrive as
+    /// something else.
+    func testAlphabetIsDeepLinkSafeAndUnambiguous() {
+        let legal = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
+        XCTAssertTrue(TelegramPairingCode.alphabet.allSatisfy { legal.contains($0) })
+        for confusable in "01OIL" {
+            XCTAssertFalse(TelegramPairingCode.alphabet.contains(confusable),
+                           "\(confusable) reads as another character when typed off a screen")
+        }
+    }
+
+    func testNormalizeStripsCaseAndSeparators() {
+        XCTAssertEqual(TelegramPairingCode.normalize("abcd 2345"), "ABCD2345")
+        XCTAssertEqual(TelegramPairingCode.normalize("ABCD-2345"), "ABCD2345")
+        XCTAssertEqual(TelegramPairingCode.normalize("  abcd2345  "), "ABCD2345")
+    }
+
+    func testMatchesIgnoresFormattingButNotContent() {
+        XCTAssertTrue(TelegramPairingCode.matches("ABCD2345", "abcd 2345"))
+        XCTAssertFalse(TelegramPairingCode.matches("ABCD2345", "ABCD2346"))
+        XCTAssertFalse(TelegramPairingCode.matches("ABCD2345", "ABCD234"))
+        XCTAssertFalse(TelegramPairingCode.matches("ABCD2345", ""))
+    }
+
+    // MARK: - /start parsing
+
+    func testStartPayloadReadsTheDeepLinkArgument() {
+        XCTAssertEqual(TelegramPairingCode.startPayload(in: "/start ABCD2345"), "ABCD2345")
+        XCTAssertEqual(TelegramPairingCode.startPayload(in: "  /start ABCD2345  "), "ABCD2345")
+    }
+
+    /// The Start button on a bot with no deep link sends a bare `/start`. That
+    /// is a real message the channel has to answer, so it parses as an empty
+    /// payload rather than as "not a start command".
+    func testBareStartIsAnEmptyPayloadNotNil() {
+        XCTAssertEqual(TelegramPairingCode.startPayload(in: "/start"), "")
+    }
+
+    func testNonStartTextIsNotAPayload() {
+        XCTAssertNil(TelegramPairingCode.startPayload(in: "/status"))
+        XCTAssertNil(TelegramPairingCode.startPayload(in: "start ABCD2345"))
+        XCTAssertNil(TelegramPairingCode.startPayload(in: "/started something"))
+        XCTAssertNil(TelegramPairingCode.startPayload(in: "please /start it"))
+    }
+
+    /// In a group Telegram delivers `/start@my_bot <payload>`; the channel
+    /// strips the suffix before parsing, and the two together must survive it.
+    func testGroupStartWithBotSuffixParsesAfterStripping() {
+        let stripped = TelegramChannel.stripBotMention("/start@my_bot ABCD2345",
+                                                       botUsername: "my_bot")
+        XCTAssertEqual(TelegramPairingCode.startPayload(in: stripped), "ABCD2345")
+    }
+
+    func testDeepLinkNormalizesTheCode() {
+        XCTAssertEqual(TelegramPairingCode.deepLink(botUsername: "my_bot", code: "abcd 2345"),
+                       "https://t.me/my_bot?start=ABCD2345")
+    }
+
+    // MARK: - Session
+
+    func testClaimSucceedsOnceAndOnlyOnce() {
+        let session = TelegramPairingSession(code: "ABCD2345")
+        XCTAssertTrue(session.claim("abcd2345"))
+        // A forwarded link, or a retry, must not buy a second allowlist entry.
+        XCTAssertFalse(session.claim("abcd2345"))
+    }
+
+    func testClaimRejectsTheWrongCodeWithoutSpendingTheSession() {
+        let session = TelegramPairingSession(code: "ABCD2345")
+        XCTAssertFalse(session.claim("ZZZZ9999"))
+        XCTAssertTrue(session.claim("ABCD2345"))
+    }
+
+    func testExpiredCodeCannotBeClaimed() {
+        let start = Date()
+        let session = TelegramPairingSession(ttl: 60, code: "ABCD2345", now: start)
+        XCTAssertFalse(session.claim("ABCD2345", now: start.addingTimeInterval(61)))
+        XCTAssertTrue(session.isExpired(now: start.addingTimeInterval(61)))
+        XCTAssertFalse(session.isExpired(now: start.addingTimeInterval(59)))
+    }
+
+    func testRefreshReplacesTheCodeAndRearmsAConsumedSession() {
+        let session = TelegramPairingSession(code: "ABCD2345")
+        XCTAssertTrue(session.claim("ABCD2345"))
+        let next = session.refresh()
+        XCTAssertNotEqual(next, "ABCD2345")
+        XCTAssertFalse(session.isExpired())
+        XCTAssertFalse(session.claim("ABCD2345"), "the old code must die with the refresh")
+        XCTAssertTrue(session.claim(next))
+    }
+
+    // MARK: - Token extraction
+
+    /// BotFather answers with a paragraph, and asking for exactly the token is
+    /// asking for a truncated paste.
+    func testTokenIsFoundInsideBotFathersWholeReply() {
+        let reply = """
+        Done! Congratulations on your new bot. You will find it at t.me/my_fleet_bot.
+
+        Use this token to access the HTTP API:
+        123456789:AAHkm-3xQ7zPQvWq2rT8nB1cD4eF5gH6iJk
+
+        Keep your token secure and store it safely.
+        """
+        XCTAssertEqual(TelegramSetupWizard.extractToken(from: reply),
+                       "123456789:AAHkm-3xQ7zPQvWq2rT8nB1cD4eF5gH6iJk")
+    }
+
+    func testBareTokenIsAcceptedUnchanged() {
+        let token = "987654321:BBHkm-3xQ7zPQvWq2rT8nB1cD4eF5gH6iJk"
+        XCTAssertEqual(TelegramSetupWizard.extractToken(from: "  \(token)\n"), token)
+    }
+
+    func testPartialOrAbsentTokenIsRejected() {
+        XCTAssertNil(TelegramSetupWizard.extractToken(from: ""))
+        XCTAssertNil(TelegramSetupWizard.extractToken(from: "123456789:"))
+        // Half a token pasted mid-copy: the secret is 35 characters, and a
+        // short tail would only fail later against Telegram.
+        XCTAssertNil(TelegramSetupWizard.extractToken(from: "123456789:AAHkm-3xQ7z"))
+        XCTAssertNil(TelegramSetupWizard.extractToken(from: "no token here at all"))
+    }
+
+    // MARK: - Published command menu
+
+    /// `setMyCommands` is rejected wholesale if any entry is malformed, so the
+    /// verb table has to satisfy Telegram's shape before it is sent.
+    func testBotCommandsSatisfyTelegramsConstraints() {
+        let commands = CommandSpecs.botCommands
+        XCTAssertFalse(commands.isEmpty)
+        XCTAssertLessThanOrEqual(commands.count, 100)
+        for entry in commands {
+            XCTAssertTrue((1...32).contains(entry.command.count), entry.command)
+            XCTAssertTrue(entry.command.allSatisfy { $0.isLowercase && $0.isLetter || $0.isNumber || $0 == "_" },
+                          entry.command)
+            XCTAssertTrue((1...256).contains(entry.description.count), entry.command)
+        }
+        // Desktop-only verbs would list a command whose only answer in a chat
+        // is that it does not work there.
+        XCTAssertFalse(commands.contains { $0.command == "add" })
+    }
+}

--- a/docs/command-surfaces.md
+++ b/docs/command-surfaces.md
@@ -11,6 +11,14 @@
 | 邮件 | `mail:<thread_id>` | 这个线程用 `/go` 绑定的 pane | 回 `/yes`，或命令末尾加 `force`（推荐，邮件往返慢） |
 | First Mate（侧栏的舰队总览） | 无输入框 | 不适用 | Island 卡片上的按钮 |
 
+### Telegram：私聊 vs 群聊
+
+- **私聊**里任何一行都是命令：裸文本发给绑定的 pane，`/…` 走动词表。
+- **群里只有 `/命令` 算命令**，裸文本是闲聊——共享群里随口一句话不该驱动 agent（`TelegramChannel.command`）。
+- 群里的命令**必须以 `/` 开头**。Telegram 的 privacy mode 默认开着（`getMe` 里 `can_read_all_group_messages: false`），bot 在群里只收得到以斜杠开头的消息、对它自己消息的回复、以及服务消息；`@yourbot /status` 这种把提及写在前面的形式 **Telegram 根本不会投递**，seahelm 这边连日志都不会有。群里有多个 bot 时用后缀形式 `/status@yourbot`，`TelegramChannel.stripBotMention` 会把后缀去掉。
+- 只有要用 Triggers（让 bot 读群里其他人的普通消息去触发 agent）时，才需要在 @BotFather 里 `/setprivacy` → Disable，并且**把 bot 移出群再重新加回去**才生效。即便如此 seahelm 在群里仍然只把 `/命令` 当命令，其余走规则匹配。
+- 白名单（`allowed_users`）按发消息的**用户**判定，与在私聊还是群里无关；不在白名单的人发的 `/命令` 会被忽略。
+
 三个文字入口共用同一个 `CommandExecutor`，差别只在确认方式和"当前"的定义。First Mate 是侧栏的舰队总览加上背后的监督者，不接受文字命令；监督者发起的动作以卡片形式出现在 Island 里，下表最后一列写的是它会不会自己做这件事。目前 Island 只渲染 suggestNextOrder 一类卡片；integrationReport 会进队列，但没有界面把它画出来。
 
 ## 矩阵

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		004A9A98C4F160DD44D877A1 /* StationReparentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C0192916DE1D56E68048E /* StationReparentTests.swift */; };
 		00F46EEC83808A01C3104099 /* NotificationHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6378708EA7D9DC4EA6D7D108 /* NotificationHistoryTests.swift */; };
 		010013ADD3241CB34AD1A70C /* MailPaneRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F4FC4D61D58DD56DB8E9FE /* MailPaneRouter.swift */; };
+		0143F464496E2C474444F9AA /* QRCodeRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879C879A37859B0876866139 /* QRCodeRendererTests.swift */; };
 		01BC534B1823141012EAAAE3 /* SplitContainerRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B42EEB25FF49236DBABA03 /* SplitContainerRecoveryTests.swift */; };
 		0202D5F27E405DFF0764DBA3 /* TelegramBridgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59CF8253BD7CAF318D05885C /* TelegramBridgeTests.swift */; };
 		029DC163355449B1C4B3BE23 /* SuggestOrderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4237377AB298C49CC68D6D /* SuggestOrderTests.swift */; };
@@ -743,6 +744,7 @@
 		85D2312DE47C6FDA0B8652EE /* LayoutNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutNodeTests.swift; sourceTree = "<group>"; };
 		869B26072C7A6CF51E54A50A /* ActivityEventPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityEventPipelineTests.swift; sourceTree = "<group>"; };
 		8704C54160BF8CD4FE29B9D6 /* IslandModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandModel.swift; sourceTree = "<group>"; };
+		879C879A37859B0876866139 /* QRCodeRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeRendererTests.swift; sourceTree = "<group>"; };
 		87CF73B862D4CB3AA19021D9 /* SuggestGuidanceWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestGuidanceWriterTests.swift; sourceTree = "<group>"; };
 		87DE87C61D1D418F812C8795 /* OnboardingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindowController.swift; sourceTree = "<group>"; };
 		887D8D47490B9D11BC6072DA /* JetBrainsMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Regular.ttf"; sourceTree = "<group>"; };
@@ -1514,6 +1516,7 @@
 				68134AF6F747CFF2862FC31F /* PRReviewCoordinatorLifetimeTests.swift */,
 				9626FD6C7EE99EAEC76D6443 /* PRURLParsingTests.swift */,
 				97C4FA6FDE7FEC53DDB662BD /* PtyGridAbsorbTests.swift */,
+				879C879A37859B0876866139 /* QRCodeRendererTests.swift */,
 				82C1E60B8144F4FB489FADD2 /* RegionFocusControllerTests.swift */,
 				AE4CA714BD0B18293FBD6216 /* RemoteMirroringTests.swift */,
 				5B4CB5436AAB9C042D5AF800 /* ReturnToPortTests.swift */,
@@ -2071,6 +2074,7 @@
 				AD2BB97C703A9CEAA447467C /* ProcessProbeTests.swift in Sources */,
 				8BB5F6D554A6F5BE68613FBA /* ProcessRunnerTests.swift in Sources */,
 				844747226335348450B94EEA /* PtyGridAbsorbTests.swift in Sources */,
+				0143F464496E2C474444F9AA /* QRCodeRendererTests.swift in Sources */,
 				8AB6456ED364F85D037EBE00 /* RegionFocusControllerTests.swift in Sources */,
 				F0F527252C6EC20636C126EA /* RemoteMirroringTests.swift in Sources */,
 				C309311CA5316E705F68CA77 /* ReturnToPortTests.swift in Sources */,

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		08C794DACF3DFA5DA3086EC5 /* FirstMateActionPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE109A6863FFA98DF4B192C7 /* FirstMateActionPayloadTests.swift */; };
 		09951F094DE67BE6FBB9DF05 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1E9300BD737DC3B94C1AF3 /* OnboardingTests.swift */; };
 		0ACBFB116D839F9A3BC9DD7C /* TelegramConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78FEF7EF31BF2E3DD44AD5F /* TelegramConfig.swift */; };
+		0AE7E3F52B1D7EFFF5D01E6A /* ChatCallbackRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81F38890EF85FE22F83ED385 /* ChatCallbackRegistry.swift */; };
 		0B486DC8922CD428C8D48A90 /* CursorSessionTitleLookupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201D21B0CA40F70C2EDF3073 /* CursorSessionTitleLookupTests.swift */; };
 		0C553E03E27CDC10711D9EDD /* NewBranchDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1768F75790892B5D280CBC0 /* NewBranchDialog.swift */; };
 		0DA6D2D48F320DFB8671C67C /* ClaudeStatuslineBridgeInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26EFCABEFB8EEA92A8B6FA13 /* ClaudeStatuslineBridgeInstaller.swift */; };
@@ -122,6 +123,7 @@
 		47229EE74F8F3BEA93AB0B6A /* TelegramRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC6460413988FF775BDA1B3 /* TelegramRuleTests.swift */; };
 		476D67C49BFE7D8093D880F3 /* QuitConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3016038B5EAC23288651C6 /* QuitConfirmation.swift */; };
 		478A900B42820F9CAC0829BF /* ghostty in Resources */ = {isa = PBXBuildFile; fileRef = 3C22FD399E95F8A453F40C3A /* ghostty */; };
+		478BA84CC6F98EA5F7F73B73 /* QRCodeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D89A6016405AEDB17C3FB5E /* QRCodeRenderer.swift */; };
 		489D78C033D8B6E4A47DD497 /* UsageSummaryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B417FD281AFB3860433F468F /* UsageSummaryStoreTests.swift */; };
 		498DDC59CBB6DB32CB865CDC /* PasteRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4110371EE0D93ADF67AEE009 /* PasteRegressionTests.swift */; };
 		4B4B7E9CF98D494F5C2F76FB /* AddWorktreePopoverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520082A00702435AC8280D60 /* AddWorktreePopoverTests.swift */; };
@@ -211,10 +213,12 @@
 		73F49C74243F62BBA37A2D6B /* ChromeTitlebarRegionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75EE0AFE306266CD4A4EE940 /* ChromeTitlebarRegionTests.swift */; };
 		756AC63650FCD59FB6D44243 /* JetBrainsMono-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F5C834279572F6B0C73A94B6 /* JetBrainsMono-Medium.ttf */; };
 		75772A087B197B7F7050BC43 /* WorktreeShellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1FA2EB699654E9A701124D1 /* WorktreeShellActions.swift */; };
+		75D489DADDF9A46F3AA3F96D /* TelegramPairing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B24B841AC2BEE7F645B456 /* TelegramPairing.swift */; };
 		75DF92B7A3EDC695B4BA5E9B /* WorktreeTitleResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BDC0C3284F3CAF4BD18C62 /* WorktreeTitleResolverTests.swift */; };
 		76643B134F9F8AD9043E641F /* CommandExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279D7C3E9D73B8BD1B898E23 /* CommandExecutor.swift */; };
 		7839409D46CC0B8E4810B869 /* WorktreeCreatorEnvCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A028D76F177CA1C4379BC3 /* WorktreeCreatorEnvCopyTests.swift */; };
 		785DB0B4417DD04E94CD58AD /* HostGatewayDecisionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09525B8D6C093323B62D10B /* HostGatewayDecisionsTests.swift */; };
+		7906BA09A1F8FE6C728AD72C /* TelegramSetupWizard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4705665C97FD7F9A95FDFC /* TelegramSetupWizard.swift */; };
 		79F532FA70B21691FB226AF8 /* GitHubDiffAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3492399099DDDAE527C6CA /* GitHubDiffAdapter.swift */; };
 		7A34C1A6124339C30D0EC84C /* PRListCellLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC46DE31056D710E7F3BF1E2 /* PRListCellLayoutTests.swift */; };
 		7A4F6892F9AE56EF60508D89 /* FirstMateConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08FEEAC5D86CEE353749EA /* FirstMateConfigTests.swift */; };
@@ -259,6 +263,7 @@
 		8F0624099E494AEDE963E0CC /* FirstMateEvaluateOutcomeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4089897C96C2E4E3E151DDD2 /* FirstMateEvaluateOutcomeTests.swift */; };
 		8FE5D1705C06DDB664FF7C94 /* Manifests in Resources */ = {isa = PBXBuildFile; fileRef = A94DAD757D9F452B11283244 /* Manifests */; };
 		90650F907FCC7FB24383A44D /* HooksChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A7E8E322E5A353D4457DBC /* HooksChannel.swift */; };
+		9095B660E7047E1815E67212 /* TelegramPairingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89AF451E1FC9B6E21F9B67A6 /* TelegramPairingTests.swift */; };
 		913DBD2B1D15867351B0DEE0 /* TerminalEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D90518E8BFCA59E2D344513 /* TerminalEnvironment.swift */; };
 		91AD0153C909A0DF726EE6A1 /* ManifestEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304981CB302BEC6B00289258 /* ManifestEngineTests.swift */; };
 		91AE9A595CB36E54847C8274 /* GlobalKeymapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F339357674536CA6736266 /* GlobalKeymapTests.swift */; };
@@ -397,6 +402,7 @@
 		D47B59C29F15D7B8911BF0F1 /* ActivityEventPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869B26072C7A6CF51E54A50A /* ActivityEventPipelineTests.swift */; };
 		D498FA22D507E98139DE451B /* SeahelmSkillInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBA707703AD383C078C3DFC3 /* SeahelmSkillInstallerTests.swift */; };
 		D4ABC34B40C85BDA5145EAAC /* PRURLParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9626FD6C7EE99EAEC76D6443 /* PRURLParsingTests.swift */; };
+		D5072D2BFED814BD0F50480B /* StationZmxAttachCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D5A1561C750420360DFCDC1 /* StationZmxAttachCommandTests.swift */; };
 		D561B55100D9032AC7C173E5 /* FileContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC4A1C262ABBDCDACB560CD /* FileContentView.swift */; };
 		D5E1195B106F29ACCB59D516 /* LayoutNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9854E3679A7AF9524F5077 /* LayoutNode.swift */; };
 		D63952B04D839AFBF04F5FC1 /* SeahelmCliInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB13F37078B010D666F6E81E /* SeahelmCliInstallerTests.swift */; };
@@ -431,6 +437,7 @@
 		E544B32F3C81016430ADB0A3 /* ShortcutHintBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A33515B716406497BF7E74 /* ShortcutHintBarTests.swift */; };
 		E7AB85089D6CD9A1AF14B3CF /* OverviewFocusModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376AB999E829F6B1298D7B05 /* OverviewFocusModelTests.swift */; };
 		E855FF11BD4FE2723AE442AD /* WorktreeSidePanelViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F011748A6A508BC66F267E /* WorktreeSidePanelViewControllerTests.swift */; };
+		E898E9379622EC8D16777977 /* ChatCallbackRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DB279E827314DBFA97331B /* ChatCallbackRegistryTests.swift */; };
 		E8C1145BA4D57B8698F87941 /* ProjectColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE2B74AFEED5F242C1B2763 /* ProjectColor.swift */; };
 		E8E41A017C3C9EAA42E5CB40 /* WorktreeReturnPlannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48EF7634B86F69D2FCA6759 /* WorktreeReturnPlannerTests.swift */; };
 		E9339C5A896240727780948E /* ChromeLayoutState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C63D5B14013E417D6AC3E33 /* ChromeLayoutState.swift */; };
@@ -497,6 +504,7 @@
 /* Begin PBXFileReference section */
 		00C7F59E202B984E1E81797E /* DashboardOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardOverviewView.swift; sourceTree = "<group>"; };
 		0105E0FAF9CFF482771DB785 /* WindowChromeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowChromeController.swift; sourceTree = "<group>"; };
+		01DB279E827314DBFA97331B /* ChatCallbackRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCallbackRegistryTests.swift; sourceTree = "<group>"; };
 		03C5A891709AE9B5E02D084E /* SeahelmSuggestInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmSuggestInstallerTests.swift; sourceTree = "<group>"; };
 		03EF8621D5464BAE7F393215 /* WrappedPathAtClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrappedPathAtClickTests.swift; sourceTree = "<group>"; };
 		04AB034D22AB8AD81A9FA9DD /* IslandShapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandShapes.swift; sourceTree = "<group>"; };
@@ -508,6 +516,7 @@
 		09698EDB6719D1778DF79D4B /* SeahelmControlDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmControlDataSource.swift; sourceTree = "<group>"; };
 		09F9C5F9EE967F8B87332014 /* IntegrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		0A25DADE8C435CBAA6E78BAB /* ThemedBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedBackgroundView.swift; sourceTree = "<group>"; };
+		0B4705665C97FD7F9A95FDFC /* TelegramSetupWizard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelegramSetupWizard.swift; sourceTree = "<group>"; };
 		0BC6460413988FF775BDA1B3 /* TelegramRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelegramRuleTests.swift; sourceTree = "<group>"; };
 		0BE2B74AFEED5F242C1B2763 /* ProjectColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectColor.swift; sourceTree = "<group>"; };
 		0C2BF20167E8DC36DDF09077 /* WorktreeSidePanelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSidePanelViewController.swift; sourceTree = "<group>"; };
@@ -602,6 +611,7 @@
 		3F67CBC84404085C3483C910 /* TestViewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestViewHelpers.swift; sourceTree = "<group>"; };
 		3FC94EE653B0D0F418057A15 /* HostGatewaySessionBackpressureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewaySessionBackpressureTests.swift; sourceTree = "<group>"; };
 		4089897C96C2E4E3E151DDD2 /* FirstMateEvaluateOutcomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateEvaluateOutcomeTests.swift; sourceTree = "<group>"; };
+		40B24B841AC2BEE7F645B456 /* TelegramPairing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelegramPairing.swift; sourceTree = "<group>"; };
 		40CAD3E9929AC9E5E32EBA9F /* Station.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Station.swift; sourceTree = "<group>"; };
 		4110371EE0D93ADF67AEE009 /* PasteRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteRegressionTests.swift; sourceTree = "<group>"; };
 		424F903BA02536FB4F76731C /* ManifestStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManifestStore.swift; sourceTree = "<group>"; };
@@ -683,6 +693,7 @@
 		6A912279D16E32ED9BADB27B /* UsageSummaryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageSummaryStore.swift; sourceTree = "<group>"; };
 		6C1E76E23951B9F8DB873E3C /* WorktreePathIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreePathIndexTests.swift; sourceTree = "<group>"; };
 		6C827E67B268966037EEDC48 /* AgentSessionRefTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionRefTests.swift; sourceTree = "<group>"; };
+		6D5A1561C750420360DFCDC1 /* StationZmxAttachCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationZmxAttachCommandTests.swift; sourceTree = "<group>"; };
 		6D9670C14DA62CDEE9828F5C /* StationRegistryConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationRegistryConcurrencyTests.swift; sourceTree = "<group>"; };
 		6D98DA93A28B692784539710 /* seahelmTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = seahelmTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E1906E0816DDA737033BBF1 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
@@ -724,6 +735,7 @@
 		8106508B943DF9C7053C6A11 /* GmailOAuthCallbackPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GmailOAuthCallbackPage.swift; sourceTree = "<group>"; };
 		810968D6A752BC9C5B9C5F27 /* WorktreeDeleterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDeleterTests.swift; sourceTree = "<group>"; };
 		811DF1463E1F5D6EFC56F68A /* IntegrationStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationStatusStore.swift; sourceTree = "<group>"; };
+		81F38890EF85FE22F83ED385 /* ChatCallbackRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatCallbackRegistry.swift; sourceTree = "<group>"; };
 		826B5E1EB796AA82415B329F /* OSC133ParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSC133ParserTests.swift; sourceTree = "<group>"; };
 		82C1E60B8144F4FB489FADD2 /* RegionFocusControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionFocusControllerTests.swift; sourceTree = "<group>"; };
 		849C6707188E7E90997D691A /* SplitTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitTree.swift; sourceTree = "<group>"; };
@@ -735,6 +747,7 @@
 		87DE87C61D1D418F812C8795 /* OnboardingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindowController.swift; sourceTree = "<group>"; };
 		887D8D47490B9D11BC6072DA /* JetBrainsMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Regular.ttf"; sourceTree = "<group>"; };
 		898667576494F56F48D87207 /* CommandParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandParser.swift; sourceTree = "<group>"; };
+		89AF451E1FC9B6E21F9B67A6 /* TelegramPairingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelegramPairingTests.swift; sourceTree = "<group>"; };
 		8AF31BD8D110A45D923D8B7D /* SplitContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitContainerView.swift; sourceTree = "<group>"; };
 		8CF331BF96A89F1DC3E9C1BD /* PRListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRListView.swift; sourceTree = "<group>"; };
 		8D716EF8AB2E7C89A0D9DBEB /* HookDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HookDecoder.swift; sourceTree = "<group>"; };
@@ -764,6 +777,7 @@
 		99EAA5845DC0E1B3FD6DD1E8 /* CodexUsageSummaryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageSummaryProviderTests.swift; sourceTree = "<group>"; };
 		9A9E6A0A2CF3F54AA987F20A /* OSC133Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSC133Parser.swift; sourceTree = "<group>"; };
 		9B96BFA805FFD64725FFB924 /* NotificationHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHistory.swift; sourceTree = "<group>"; };
+		9D89A6016405AEDB17C3FB5E /* QRCodeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeRenderer.swift; sourceTree = "<group>"; };
 		9DA8AD6F8AC7CDE47F86245A /* WorktreeReturnRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeReturnRunnerTests.swift; sourceTree = "<group>"; };
 		9DFC7C439D7D5CB85100DB4D /* SettingsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPage.swift; sourceTree = "<group>"; };
 		9E2691E78106330B779373C2 /* StatusDetectorActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusDetectorActivityTests.swift; sourceTree = "<group>"; };
@@ -1014,6 +1028,7 @@
 				055E765E62830F8CD924C76F /* AgentStatus.swift */,
 				AEC631B07301756615C755E6 /* AgentType.swift */,
 				BF702127762EBDF898385B56 /* Analytics.swift */,
+				81F38890EF85FE22F83ED385 /* ChatCallbackRegistry.swift */,
 				2D90204521BAE476A8EF340E /* ClaudeHooksSetup.swift */,
 				26EFCABEFB8EEA92A8B6FA13 /* ClaudeStatuslineBridgeInstaller.swift */,
 				A51B009382FE3586E735355D /* CodexHooksSetup.swift */,
@@ -1100,6 +1115,7 @@
 				371F0BC6C00D849566000118 /* TelegramChannel.swift */,
 				A78FEF7EF31BF2E3DD44AD5F /* TelegramConfig.swift */,
 				367C0A6616137695AEDA9D74 /* TelegramFormatter.swift */,
+				40B24B841AC2BEE7F645B456 /* TelegramPairing.swift */,
 				AFC635E261560E69EFA29FEE /* TelegramRule.swift */,
 				5C8C29ABAFC62F8A953F2CD9 /* TelegramRuleCoalescer.swift */,
 				3D90518E8BFCA59E2D344513 /* TerminalEnvironment.swift */,
@@ -1267,6 +1283,7 @@
 				C537B2B1B68C50EF9685736B /* SettingsViewController.swift */,
 				5FE8A11E17EFB437EEA5C2A2 /* SettingsWindowController.swift */,
 				588A37DABECC74B634A5E45A /* TelegramRulesView.swift */,
+				0B4705665C97FD7F9A95FDFC /* TelegramSetupWizard.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -1411,6 +1428,7 @@
 				7F4985A21CB0E9D8B4708E26 /* AgentRegistryWebhookPathTests.swift */,
 				6C827E67B268966037EEDC48 /* AgentSessionRefTests.swift */,
 				F4D445453693B8D5A3D088F1 /* AgentTypeTests.swift */,
+				01DB279E827314DBFA97331B /* ChatCallbackRegistryTests.swift */,
 				5E88C517CE4270179492479E /* ChoiceOptionParserTests.swift */,
 				38FD43578EB5A227077BAA11 /* ChromeCollapseAnimationTests.swift */,
 				4890F1362CCDACF15E685662 /* ChromeLayoutMetricsTests.swift */,
@@ -1520,6 +1538,7 @@
 				1C0F7D7F30A3F031DC191AFF /* StationHealthCheckTests.swift */,
 				6D9670C14DA62CDEE9828F5C /* StationRegistryConcurrencyTests.swift */,
 				EB9C0192916DE1D56E68048E /* StationReparentTests.swift */,
+				6D5A1561C750420360DFCDC1 /* StationZmxAttachCommandTests.swift */,
 				176DD9C40844C7ECA03950E6 /* StatusBarViewTests.swift */,
 				9E2691E78106330B779373C2 /* StatusDetectorActivityTests.swift */,
 				7598CDC2F8E33DD35632FAB7 /* StatusDetectorTests.swift */,
@@ -1532,6 +1551,7 @@
 				DC183C3A20588D380EF62682 /* TabSelectionTests.swift */,
 				249CA31487C12997605E1512 /* TaskProgressParserTests.swift */,
 				59CF8253BD7CAF318D05885C /* TelegramBridgeTests.swift */,
+				89AF451E1FC9B6E21F9B67A6 /* TelegramPairingTests.swift */,
 				D2A3B9CBE08762DDD19AA2C5 /* TelegramRuleCoalescerTests.swift */,
 				A8152F9618985364E35ACB50 /* TelegramRuleTargetTests.swift */,
 				0BC6460413988FF775BDA1B3 /* TelegramRuleTests.swift */,
@@ -1653,6 +1673,7 @@
 		DB76F06849D052EB4429046C /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				9D89A6016405AEDB17C3FB5E /* QRCodeRenderer.swift */,
 				DCB8806B236D6D54F4202827 /* Chrome */,
 				A84945D9E40FF351B77B5E07 /* Dashboard */,
 				F3D414E27A71140AA8827C7F /* Dialog */,
@@ -1964,6 +1985,7 @@
 				7AD64F51F6EE5BA663EEF30D /* AgentRegistryWebhookPathTests.swift in Sources */,
 				F18F39D20F1D77592272356C /* AgentSessionRefTests.swift in Sources */,
 				53D46BF1B3E00A35B53A86C4 /* AgentTypeTests.swift in Sources */,
+				E898E9379622EC8D16777977 /* ChatCallbackRegistryTests.swift in Sources */,
 				9F3608916964651FE502DAD3 /* ChoiceOptionParserTests.swift in Sources */,
 				3D18A10A7522058688B2A1F7 /* ChromeCollapseAnimationTests.swift in Sources */,
 				12B626905E1B75F6419CD452 /* ChromeLayoutMetricsTests.swift in Sources */,
@@ -2073,6 +2095,7 @@
 				FB6A28074D9ADC1B5DB97F53 /* StationHealthCheckTests.swift in Sources */,
 				6C822061BD36C74213F5D43B /* StationRegistryConcurrencyTests.swift in Sources */,
 				004A9A98C4F160DD44D877A1 /* StationReparentTests.swift in Sources */,
+				D5072D2BFED814BD0F50480B /* StationZmxAttachCommandTests.swift in Sources */,
 				3D646290FE05FFC7FE24794B /* StatusBarViewTests.swift in Sources */,
 				C94539AC393B4AA9EB7D4BFC /* StatusDetectorActivityTests.swift in Sources */,
 				E0D71AAD78443B2E6D4BB573 /* StatusDetectorTests.swift in Sources */,
@@ -2085,6 +2108,7 @@
 				65BBAC7799C70383810BFEE3 /* TabSelectionTests.swift in Sources */,
 				B658CA193508F17D6F6BA66D /* TaskProgressParserTests.swift in Sources */,
 				0202D5F27E405DFF0764DBA3 /* TelegramBridgeTests.swift in Sources */,
+				9095B660E7047E1815E67212 /* TelegramPairingTests.swift in Sources */,
 				A30993302260CC1F5B1F7179 /* TelegramRuleCoalescerTests.swift in Sources */,
 				33FD30DC361BCDE94308706C /* TelegramRuleTargetTests.swift in Sources */,
 				47229EE74F8F3BEA93AB0B6A /* TelegramRuleTests.swift in Sources */,
@@ -2171,6 +2195,7 @@
 				12702A1B7B7DD78FD49D65D5 /* AppFont.swift in Sources */,
 				646692CC7C11231CC40284EC /* Array+SafeIndex.swift in Sources */,
 				7BDCC195CBE9B564845BB8D3 /* CenterOverlayView.swift in Sources */,
+				0AE7E3F52B1D7EFFF5D01E6A /* ChatCallbackRegistry.swift in Sources */,
 				72EA963BA7948ECBF5DABF5C /* ChoiceOptionParser.swift in Sources */,
 				3BE5AE4B30540C9F80527B7F /* ChromeDividerView.swift in Sources */,
 				DCD355D8BE1EF13AECD21332 /* ChromeHeaderDelegate.swift in Sources */,
@@ -2323,6 +2348,7 @@
 				DEDCDC483983AFA6EE444A63 /* ProcessProbe.swift in Sources */,
 				07D61705F36F11CF9B8CF316 /* ProcessRunner.swift in Sources */,
 				E8C1145BA4D57B8698F87941 /* ProjectColor.swift in Sources */,
+				478BA84CC6F98EA5F7F73B73 /* QRCodeRenderer.swift in Sources */,
 				9E70B1DBD63DBC4873DC38EB /* QuickSwitcherViewController.swift in Sources */,
 				476D67C49BFE7D8093D880F3 /* QuitConfirmation.swift in Sources */,
 				DD26E727E1605031773062C1 /* Region.swift in Sources */,
@@ -2363,9 +2389,11 @@
 				FC2829917F91412C222E569F /* TelegramChannel.swift in Sources */,
 				0ACBFB116D839F9A3BC9DD7C /* TelegramConfig.swift in Sources */,
 				B27CC6F1E02F01BDF914C664 /* TelegramFormatter.swift in Sources */,
+				75D489DADDF9A46F3AA3F96D /* TelegramPairing.swift in Sources */,
 				BBC84EA31C8C52BCB30F54B1 /* TelegramRule.swift in Sources */,
 				18BBDCD41186F44EFEBC6950 /* TelegramRuleCoalescer.swift in Sources */,
 				CE2F476AAE8E4F1A63F506EC /* TelegramRulesView.swift in Sources */,
+				7906BA09A1F8FE6C728AD72C /* TelegramSetupWizard.swift in Sources */,
 				0658FAE09BDFAD7932B01617 /* TerminalCoordinator.swift in Sources */,
 				913DBD2B1D15867351B0DEE0 /* TerminalEnvironment.swift in Sources */,
 				AD608FF60D293BA96BCB01B8 /* TerminalHeaderView.swift in Sources */,
@@ -2451,7 +2479,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.57;
+				MARKETING_VERSION = 2.0.58;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",
@@ -2688,7 +2716,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.57;
+				MARKETING_VERSION = 2.0.58;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",


### PR DESCRIPTION
## Summary
- Add a guided Telegram setup wizard (BotFather → token → QR/`t.me` deep-link pairing) so users no longer hand-type numeric user/chat ids into the allowlist.
- Pairing runs on a temporary bridge that owns the bot’s single poll slot (avoids 409), then restores the saved channel; `/start` with an armed code claims ownership.
- Command replies can carry buttons; Telegram renders them as inline keyboards via short tokens from `ChatCallbackRegistry` (status listings, `/yes` confirms), without putting machine paths on the wire.

## Test plan
- [ ] Settings → Telegram → **Set up Telegram…**: create/paste token, scan QR (or type the 8-char code), confirm allowlist + chat id are written and the bridge reconnects
- [ ] Cancel mid-wizard: pairing bridge tears down and the previous Telegram config comes back
- [ ] From a paired private chat: `/status` shows tapable pane/worktree shortcuts; `/yes` confirm offers Go ahead / Cancel
- [ ] Stale button after app restart resolves as expired (memory-only registry)
- [ ] Unit: `TelegramPairingTests`, `ChatCallbackRegistryTests`, `CommandFormatterTests`
- [ ] `xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug -skipPackagePluginValidation -skipMacroValidation test -only-testing:seahelmTests/TelegramPairingTests -only-testing:seahelmTests/ChatCallbackRegistryTests -only-testing:seahelmTests/CommandFormatterTests`


Made with [Cursor](https://cursor.com)