### PR TITLE
fix: /return slash-branch labels + Delete/Return pending feedback

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -77,6 +77,9 @@ class MainWindowController: NSWindowController {
     /// Nil when the bridge is unconfigured or was started by AppDelegate and
     /// never reconfigured — `unregisterChannel("telegram")` covers that case.
     private var telegramChannel: TelegramChannel?
+    /// Fleet row lit while a context-menu `/return` is assessing. Cleared when
+    /// a sheet appears, the command fails, or the tear-down finishes.
+    private var pendingReturnPath: String?
     /// One executor for every surface: the Helm line, Telegram and mail all
     /// run their lines through it, so a command means one thing everywhere.
     private lazy var commandExecutor = CommandExecutor(host: self, sessions: tabCoordinator.commandSessions)
@@ -1982,7 +1985,17 @@ extension MainWindowController: DashboardDelegate {
             NSSound.beep()
             return
         }
-        submitBridgeCommand("/return \(index.label(for: wt))")
+        pendingReturnPath = wt.path
+        dashboardVC?.setWorktreePending(path: wt.path, pending: true)
+        submitBridgeCommand("/return \(index.label(for: wt))") { [weak self] outcome in
+            if case .failed = outcome { self?.clearPendingReturn() }
+        }
+    }
+
+    private func clearPendingReturn() {
+        guard let path = pendingReturnPath else { return }
+        pendingReturnPath = nil
+        dashboardVC?.setWorktreePending(path: path, pending: false)
     }
 
     func dashboardDidRequestAddProject() {
@@ -2820,8 +2833,15 @@ extension MainWindowController: CommandHost {
             DispatchQueue.main.async {
                 guard let self else { return }
                 if outcome.deletesWorktree {
+                    // Row pending through the tear-down; clears when git finishes.
+                    self.pendingReturnPath = nil
                     self.terminalCoordinator.deleteWorktreeWithoutConfirm(
-                        path: path, branch: branch, deleteBranch: outcome.deletesBranch, force: true)
+                        path: path, branch: branch, deleteBranch: outcome.deletesBranch, force: true
+                    ) { [weak self] pending in
+                        self?.dashboardVC?.setWorktreePending(path: path, pending: pending)
+                    }
+                } else {
+                    self.clearPendingReturn()
                 }
                 completion(outcome)
             }
@@ -2901,6 +2921,8 @@ extension MainWindowController: CommandHost {
 
     /// The desktop's `/yes`: one sheet, same wording as the chat question.
     func confirm(_ summary: String, completion: @escaping (Bool) -> Void) {
+        // A confirmation sheet replaces the row spinner as feedback.
+        clearPendingReturn()
         guard let window else {
             completion(false)
             return

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -1632,7 +1632,10 @@ class TabCoordinator {
             NSSound.beep()
             return
         }
-        terminalCoordinator.confirmAndDeleteWorktree(item.info, window: window)
+        let worktreePath = item.info.path
+        terminalCoordinator.confirmAndDeleteWorktree(item.info, window: window) { [weak self] pending in
+            self?.dashboardVC?.setWorktreePending(path: worktreePath, pending: pending)
+        }
     }
 
     // MARK: - New Branch Integration

--- a/Sources/App/TerminalCoordinator.swift
+++ b/Sources/App/TerminalCoordinator.swift
@@ -534,7 +534,12 @@ class TerminalCoordinator {
     /// gets one sheet that names it, and a confirmed delete is a forced one.
     /// See `WorktreeDeleteAssessment` for why there is no sheet on the safe
     /// path.
-    func confirmAndDeleteWorktree(_ info: WorktreeInfo, window: NSWindow?) {
+    ///
+    /// `onPendingChange` lights the fleet row while assessment (a `git fetch`
+    /// that can take seconds) or the delete itself is in flight — without it
+    /// the click reads as a no-op until a sheet finally appears.
+    func confirmAndDeleteWorktree(_ info: WorktreeInfo, window: NSWindow?,
+                                  onPendingChange: ((Bool) -> Void)? = nil) {
         guard !info.isMainWorktree else { return }
         guard let window else { return }
         // Same rule as `/return`: a worktree with an agent at work is not
@@ -557,8 +562,10 @@ class TerminalCoordinator {
             ? IntegrationWorktreeStore.shared.lastPublishedCommit(forCheckout: info.path)
             : nil
 
+        onPendingChange?(true)
         // Several synchronous git subprocesses (up to a 5s timeout each on a
-        // wedged repo) — run them off the main thread, then decide.
+        // wedged repo, plus a fetch of the base) — run them off the main
+        // thread, then decide.
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             let repoPath = WorktreeDiscovery.findRepoRoot(from: info.path) ?? info.path
             let assessment = isIntegration
@@ -566,24 +573,31 @@ class TerminalCoordinator {
                 : WorktreeDeleter.assessDeletion(worktreePath: info.path, repoPath: repoPath,
                                                  branchName: info.branch, refreshBase: true)
             DispatchQueue.main.async {
-                guard let self else { return }
+                guard let self else {
+                    onPendingChange?(false)
+                    return
+                }
                 if assessment.isSafe {
-                    // The assessment established the branch's commits are on
-                    // trunk or upstream, so `-D`: git's own `-d` only consults
-                    // the upstream and would keep a PR-merged branch with one
-                    // unpushed commit for no reason.
+                    // Keep the row lit through the delete itself.
                     self.performDeleteWorktree(info, repoPath: repoPath,
                                                deleteBranch: assessment.deletesBranch,
-                                               force: false, forceBranch: true)
+                                               force: false, forceBranch: true) {
+                        onPendingChange?(false)
+                    }
                 } else {
-                    self.presentDeleteConfirmation(info, window: window, repoPath: repoPath, assessment: assessment)
+                    // The sheet is the feedback now; clear the spinner so the
+                    // row does not keep pulsing behind the modal.
+                    onPendingChange?(false)
+                    self.presentDeleteConfirmation(info, window: window, repoPath: repoPath,
+                                                   assessment: assessment, onPendingChange: onPendingChange)
                 }
             }
         }
     }
 
     private func presentDeleteConfirmation(_ info: WorktreeInfo, window: NSWindow,
-                                           repoPath: String, assessment: WorktreeDeleteAssessment) {
+                                           repoPath: String, assessment: WorktreeDeleteAssessment,
+                                           onPendingChange: ((Bool) -> Void)? = nil) {
         let alert = NSAlert()
         alert.alertStyle = .critical
         alert.messageText = "Delete worktree \u{201C}\(info.displayName)\u{201D}?"
@@ -594,16 +608,21 @@ class TerminalCoordinator {
 
         alert.beginSheetModal(for: window) { [weak self] response in
             guard let self, response == .alertFirstButtonReturn else { return }
+            onPendingChange?(true)
             self.performDeleteWorktree(info, repoPath: repoPath,
-                                       deleteBranch: assessment.deletesBranch, force: true)
+                                       deleteBranch: assessment.deletesBranch, force: true) {
+                onPendingChange?(false)
+            }
         }
     }
 
     /// Delete a worktree without the confirm alert — the caller already asked
     /// (`/return`, through its plan). Does full surface teardown.
     func deleteWorktreeWithoutConfirm(path: String, branch: String,
-                                      deleteBranch: Bool = false, force: Bool = false) {
+                                      deleteBranch: Bool = false, force: Bool = false,
+                                      onPendingChange: ((Bool) -> Void)? = nil) {
         let info = WorktreeInfo(path: path, branch: branch, commitHash: "", isMainWorktree: false)
+        onPendingChange?(true)
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             let repoPath = WorktreeDiscovery.findRepoRoot(from: path) ?? path
             // If the caller didn't request force, check for uncommitted changes and
@@ -611,13 +630,16 @@ class TerminalCoordinator {
             let shouldForce = force || WorktreeDeleter.hasUncommittedChanges(worktreePath: path)
             DispatchQueue.main.async {
                 self?.performDeleteWorktree(info, repoPath: repoPath,
-                                            deleteBranch: deleteBranch, force: shouldForce)
+                                            deleteBranch: deleteBranch, force: shouldForce) {
+                    onPendingChange?(false)
+                }
             }
         }
     }
 
     private func performDeleteWorktree(_ info: WorktreeInfo, repoPath: String, deleteBranch: Bool,
-                                       force: Bool, forceBranch: Bool? = nil) {
+                                       force: Bool, forceBranch: Bool? = nil,
+                                       completion: (() -> Void)? = nil) {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             do {
                 let result = try WorktreeDeleter.deleteWorktree(
@@ -629,6 +651,7 @@ class TerminalCoordinator {
                     forceBranch: forceBranch
                 )
                 DispatchQueue.main.async {
+                    defer { completion?() }
                     guard let self else { return }
                     self.finalizeDeletedWorktree(info)
                     if let warning = result.branchWarning {
@@ -637,6 +660,7 @@ class TerminalCoordinator {
                 }
             } catch {
                 DispatchQueue.main.async {
+                    defer { completion?() }
                     self?.presentDeleteError(error)
                 }
             }

--- a/Sources/Core/Command/CommandExecutor.swift
+++ b/Sources/Core/Command/CommandExecutor.swift
@@ -35,7 +35,11 @@ struct CommandReply: Equatable {
         self.presentsOnDesktop = presentsOnDesktop
     }
 
-    static func error(_ text: String) -> CommandReply { CommandReply(text, isError: true) }
+    /// Errors surface on the desktop too: a right-click Return that fails to
+    /// parse or is refused used to only beep, which reads as "nothing happened".
+    static func error(_ text: String) -> CommandReply {
+        CommandReply(text, isError: true, presentsOnDesktop: true)
+    }
 }
 
 /// The side effects a command can have. Implemented by the app layer; a test

--- a/Sources/Core/Command/FleetIndex.swift
+++ b/Sources/Core/Command/FleetIndex.swift
@@ -117,30 +117,46 @@ struct FleetIndex: Equatable {
     /// `name`, or `repo/name` when several repos carry it. Case-insensitive, as
     /// these are typed from memory. Matching is on `WorktreeRef.name`, so a
     /// detached checkout answers to its directory.
+    ///
+    /// Branch names often contain `/` (`fix/foo`, `task/bar`). Those must match
+    /// as a whole name before we treat the first slash as a repo separator —
+    /// otherwise the label `@fix/foo` (emitted when the branch is unique) is
+    /// re-parsed as repo `fix` + branch `foo` and `/return` from the row menu
+    /// fails with only a beep on the desktop.
     func worktree(named name: String) -> Result<WorktreeRef, CommandError> {
         let needle = name.lowercased()
-        if let slash = needle.firstIndex(of: "/") {
-            let repo = needle[..<slash]
-            let branch = needle[needle.index(after: slash)...]
-            if let hit = worktrees.first(where: {
-                $0.repo.lowercased() == repo && $0.name.lowercased() == branch
-            }) {
-                return .success(hit)
-            }
-            return .failure(.unknownWorktree(name))
+
+        let exact = worktrees.filter { $0.name.lowercased() == needle }
+        switch exact.count {
+        case 1:
+            return .success(exact[0])
+        case let n where n > 1:
+            return .failure(.ambiguousWorktree(name, exact.map { "\($0.repo)/\($0.name)" }))
+        default:
+            break
         }
 
-        let hits = worktrees.filter { $0.name.lowercased() == needle }
-        switch hits.count {
-        case 0:
-            // Naming a repo where a worktree is expected is the one mistake the
-            // old `/return` grammar invited; say what the name actually is.
-            return .failure(repo(named: name) != nil ? .repoNotWorktree(name) : .unknownWorktree(name))
-        case 1:
-            return .success(hits[0])
-        default:
-            return .failure(.ambiguousWorktree(name, hits.map { "\($0.repo)/\($0.name)" }))
+        if let slash = needle.firstIndex(of: "/") {
+            let repoPart = String(needle[..<slash])
+            let branchPart = String(needle[needle.index(after: slash)...])
+            // Only the disambiguated `@repo/branch` form — and only when the
+            // left side is actually a repo we know, so a mistyped
+            // `@fix/typo` does not get a second, confusing miss.
+            let knownRepo = worktrees.contains { $0.repo.lowercased() == repoPart }
+                || repo(named: repoPart) != nil
+            if knownRepo {
+                if let hit = worktrees.first(where: {
+                    $0.repo.lowercased() == repoPart && $0.name.lowercased() == branchPart
+                }) {
+                    return .success(hit)
+                }
+                return .failure(.unknownWorktree(name))
+            }
         }
+
+        // Naming a repo where a worktree is expected is the one mistake the
+        // old `/return` grammar invited; say what the name actually is.
+        return .failure(repo(named: name) != nil ? .repoNotWorktree(name) : .unknownWorktree(name))
     }
 
     /// `@name`, or `@repo/name` when the bare one would be ambiguous.

--- a/Sources/UI/Dashboard/DashboardOverviewView.swift
+++ b/Sources/UI/Dashboard/DashboardOverviewView.swift
@@ -40,6 +40,9 @@ final class DashboardOverviewView: NSView {
     var onDeleteWorktree: ((String) -> Void)?
     /// The row's Return — `/return @worktree` by another route.
     var onReturnWorktree: ((String) -> Void)?
+    /// Worktree paths whose Delete/Return is in flight. Survives a full list
+    /// rebuild so a status poll mid-fetch does not extinguish the spinner.
+    private var pendingWorktreePaths: Set<String> = []
     /// Move a repo's integration checkout back onto origin/main. Only offered
     /// on rows that are one.
     var onResetIntegration: ((String) -> Void)?
@@ -557,6 +560,7 @@ final class DashboardOverviewView: NSView {
                 row.onHoverChanged = { [weak self] row, entered in
                     self?.rowHoverChanged(row, entered: entered)
                 }
+                row.setPending(pendingWorktreePaths.contains(pane.worktreePath))
                 rowsBox.addArrangedSubview(row)
                 row.widthAnchor.constraint(equalTo: rowsBox.widthAnchor).isActive = true
                 orderedRows.append((groupedItem.id, groupedItem.path))
@@ -592,6 +596,8 @@ final class DashboardOverviewView: NSView {
             selectedRow.scrollToVisible(selectedRow.bounds)
             revealedRowID = selectedId
         }
+        // Drop pending marks for rows that left the fleet (deleted mid-fetch).
+        pendingWorktreePaths = pendingWorktreePaths.intersection(Set(panesByPath.keys))
         #if DEBUG
         recordTelemetry(kind: "full",
                         elapsedMs: elapsedMilliseconds(since: start),
@@ -636,6 +642,7 @@ final class DashboardOverviewView: NSView {
                 if let row = rowViewsByID[item.id] {
                     row.update(pane: pane, status: item.status, selected: item.id == selectedId,
                                isIntegration: item.isIntegration)
+                    row.setPending(pendingWorktreePaths.contains(pane.worktreePath))
                 }
                 if groupingMode == .pane, pane.panes.count > 1 {
                     for paneInfo in pane.panes {
@@ -668,6 +675,25 @@ final class DashboardOverviewView: NSView {
               rowCount, fullRenderCount, fullAvg, incrementalUpdateCount, incrementalAvg, kind, elapsedMs)
     }
     #endif
+
+    /// Show (or clear) the in-flight spinner on a worktree row. Assessment and
+    /// delete both take wall-clock time; without this the click looks dead.
+    func setWorktreePending(_ path: String, pending: Bool) {
+        if pending {
+            pendingWorktreePaths.insert(path)
+        } else {
+            pendingWorktreePaths.remove(path)
+        }
+        if let row = rowViewsByID[path] {
+            row.setPending(pending)
+            return
+        }
+        // Row id is the path, but a rebuild may still be keyed under a prior
+        // spelling; fall back to a scan.
+        for (id, row) in rowViewsByID where id == path || row.worktreePathForPending == path {
+            row.setPending(pending)
+        }
+    }
 
     /// Move the highlight to `id` in place, cross-fading between the two rows and
     /// scrolling the new one into view.
@@ -1031,6 +1057,9 @@ final class DashboardOverviewView: NSView {
         private let showsRepository: Bool
         private let staticDot: NSTextField
         private let runningDot: SpinnerDotView
+        /// Shown while Delete/Return is assessing or tearing the worktree down —
+        /// a muted spinner so it is not mistaken for an agent that is running.
+        private let busySpinner: SpinnerDotView
         private let titleLabel: NSTextField
         private let timeLabel: NSTextField
         private let branchLabel: NSTextField
@@ -1040,8 +1069,11 @@ final class DashboardOverviewView: NSView {
         /// Whether the pointer is currently inside, so a selection change can
         /// repaint without losing the hover tint on the row being left behind.
         private var hovered = false
+        private var pending = false
+        private var lastStatus: AgentStatus = .unknown
 
         private static let cornerRadius: CGFloat = 8
+        private static let pendingPulseKey = "seahelm.pendingPulse"
         /// One beat, matched to the fleet list's other selection feedback.
         static let selectionFadeDuration: CFTimeInterval = 0.18
         private static let highlightFill = NSColor(name: nil) { appearance in
@@ -1087,6 +1119,7 @@ final class DashboardOverviewView: NSView {
             // incremental updates), so pin it to `.running`'s colour rather than
             // whatever status happened to be current at construction time.
             self.runningDot = SpinnerDotView(color: AgentStatus.running.color)
+            self.busySpinner = SpinnerDotView(color: DashboardOverviewView.inkDim)
             self.titleLabel = Self.label(pane.currentPaneTitle, DashboardOverviewView.ink, 12)
             self.timeLabel = Self.label(pane.currentPaneRunTime, DashboardOverviewView.inkFaint, 10)
             let branch = pane.thread.isEmpty ? pane.name : pane.thread
@@ -1117,6 +1150,9 @@ final class DashboardOverviewView: NSView {
             staticDot.setContentCompressionResistancePriority(.required, for: .horizontal)
             runningDot.setContentHuggingPriority(.required, for: .horizontal)
             runningDot.setContentCompressionResistancePriority(.required, for: .horizontal)
+            busySpinner.setContentHuggingPriority(.required, for: .horizontal)
+            busySpinner.setContentCompressionResistancePriority(.required, for: .horizontal)
+            busySpinner.isHidden = true
             titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             timeLabel.setContentHuggingPriority(.required, for: .horizontal)
 
@@ -1163,6 +1199,7 @@ final class DashboardOverviewView: NSView {
 
             addSubview(staticDot)
             addSubview(runningDot)
+            addSubview(busySpinner)
             addSubview(textCol)
             NSLayoutConstraint.activate([
                 textCol.leadingAnchor.constraint(equalTo: staticDot.trailingAnchor, constant: 7),
@@ -1174,6 +1211,8 @@ final class DashboardOverviewView: NSView {
                 staticDot.centerYAnchor.constraint(equalTo: line1.centerYAnchor),
                 runningDot.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
                 runningDot.centerYAnchor.constraint(equalTo: line1.centerYAnchor),
+                busySpinner.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
+                busySpinner.centerYAnchor.constraint(equalTo: line1.centerYAnchor),
 
                 line1.widthAnchor.constraint(equalTo: textCol.widthAnchor),
                 line2.widthAnchor.constraint(equalTo: textCol.widthAnchor),
@@ -1181,6 +1220,9 @@ final class DashboardOverviewView: NSView {
             applyContent(pane: pane, status: status)
         }
         required init?(coder: NSCoder) { fatalError() }
+
+        /// Path the pending set matches against after a rebuild.
+        var worktreePathForPending: String { path }
 
         /// Compact git summary "+adds −dels  ↑ahead↓behind", colored. Empty when
         /// there are no changes and no divergence (or stats not yet resolved).
@@ -1276,9 +1318,40 @@ final class DashboardOverviewView: NSView {
             }
             Self.setText(staticDot, status.glyph)
             if staticDot.textColor != status.color { staticDot.textColor = status.color }
-            // `isHidden` also invalidates display unconditionally.
-            if staticDot.isHidden != (status == .running) { staticDot.isHidden = status == .running }
-            if runningDot.isHidden != (status != .running) { runningDot.isHidden = status != .running }
+            lastStatus = status
+            applyDotVisibility()
+        }
+
+        /// Status vs busy: only one of the three leading marks is visible.
+        private func applyDotVisibility() {
+            if pending {
+                if !staticDot.isHidden { staticDot.isHidden = true }
+                if !runningDot.isHidden { runningDot.isHidden = true }
+                if busySpinner.isHidden { busySpinner.isHidden = false }
+            } else {
+                if !busySpinner.isHidden { busySpinner.isHidden = true }
+                let running = lastStatus == .running
+                if staticDot.isHidden != running { staticDot.isHidden = running }
+                if runningDot.isHidden != !running { runningDot.isHidden = !running }
+            }
+        }
+
+        /// Assessment / delete in flight: muted spinner, dimmed labels, soft pulse.
+        func setPending(_ isPending: Bool) {
+            guard pending != isPending else { return }
+            pending = isPending
+            applyDotVisibility()
+            let alpha: CGFloat = isPending ? 0.55 : 1
+            for view in [titleLabel, timeLabel, branchLabel, gitLabel, paneCountLabel] as [NSView] {
+                view.alphaValue = alpha
+            }
+            repositoryLabel?.alphaValue = alpha
+            if isPending {
+                startPendingPulse()
+            } else {
+                stopPendingPulse()
+                applyBackground(hovered: hovered)
+            }
         }
 
         override func mouseDown(with event: NSEvent) { onTap?(path) }
@@ -1320,10 +1393,14 @@ final class DashboardOverviewView: NSView {
             deleteItem.target = self
             deleteItem.toolTip = "Remove the worktree and its branch."
                 + " Asks first if uncommitted changes or unmerged commits would be lost."
+            deleteItem.isEnabled = !pending && !isMainWorktree
             menu.addItem(deleteItem)
             if isMainWorktree {
                 deleteItem.isEnabled = false
                 deleteItem.toolTip = "Main worktree cannot be deleted."
+            }
+            if pending {
+                returnItem.isEnabled = false
             }
             return menu
         }
@@ -1341,9 +1418,15 @@ final class DashboardOverviewView: NSView {
 
         @objc private func copyPathAction() { WorktreeShellActions.copyPath(path) }
 
-        @objc private func deleteAction() { onDelete?(path) }
+        @objc private func deleteAction() {
+            guard !pending else { return }
+            onDelete?(path)
+        }
 
-        @objc private func returnAction() { onReturn?(path) }
+        @objc private func returnAction() {
+            guard !pending else { return }
+            onReturn?(path)
+        }
 
         @objc private func resetIntegrationAction() { onResetIntegration?(path) }
 
@@ -1383,6 +1466,8 @@ final class DashboardOverviewView: NSView {
 
         private func applyBackground(hovered: Bool) {
             self.hovered = hovered
+            // Pending pulse owns the fill while assessment/delete runs.
+            guard !pending else { return }
             if selected {
                 layer?.backgroundColor = resolvedCGColor(Self.highlightFill)
             } else if hovered {
@@ -1392,9 +1477,35 @@ final class DashboardOverviewView: NSView {
             }
         }
 
+        private func startPendingPulse() {
+            layer?.removeAnimation(forKey: "selectionFade")
+            guard layer?.animation(forKey: Self.pendingPulseKey) == nil else { return }
+            let soft = resolvedCGColor(Self.hoverFill)
+            let strong = resolvedCGColor(Self.highlightFill)
+            layer?.backgroundColor = soft
+            guard !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion else { return }
+            let pulse = CABasicAnimation(keyPath: "backgroundColor")
+            pulse.fromValue = soft
+            pulse.toValue = strong
+            pulse.duration = 0.75
+            pulse.autoreverses = true
+            pulse.repeatCount = .infinity
+            pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            layer?.add(pulse, forKey: Self.pendingPulseKey)
+        }
+
+        private func stopPendingPulse() {
+            layer?.removeAnimation(forKey: Self.pendingPulseKey)
+        }
+
         override func viewDidChangeEffectiveAppearance() {
             super.viewDidChangeEffectiveAppearance()
-            applyBackground(hovered: hovered)
+            if pending {
+                stopPendingPulse()
+                startPendingPulse()
+            } else {
+                applyBackground(hovered: hovered)
+            }
         }
 
         var isHoveredForTesting: Bool { hovered }

--- a/Sources/UI/Dashboard/DashboardViewController.swift
+++ b/Sources/UI/Dashboard/DashboardViewController.swift
@@ -407,6 +407,13 @@ class DashboardViewController: NSViewController {
 
     // MARK: - Public API
 
+    /// Light the fleet row while Delete (or Return's tear-down) is assessing or
+    /// removing the worktree — a `git fetch` can sit for seconds with nothing
+    /// else on screen.
+    func setWorktreePending(path: String, pending: Bool) {
+        overviewView.setWorktreePending(path, pending: pending)
+    }
+
     /// `changedWorktreePath` narrows the in-place refresh to one card when the
     /// caller knows only that worktree's status changed; nil refreshes all cards.
     func updatePanes(_ newPanes: [WorktreeRowInfo], changedWorktreePath: String? = nil) {

--- a/Tests/CommandParserTests.swift
+++ b/Tests/CommandParserTests.swift
@@ -152,6 +152,43 @@ final class CommandParserTests: XCTestCase {
                        .success(ParsedLine(.returnWorktree(CommandFixture.featX), force: true)))
     }
 
+    /// Branch names with `/` are common (`fix/…`, `feat/…`). The row menu builds
+    /// `/return @fix/foo` from `label(for:)`; that must resolve to the branch,
+    /// not to a fictional repo named `fix`.
+    func testReturnResolvesBranchNamesThatContainSlashes() {
+        let slashBranch = WorktreeRef(repo: "alpha", branch: "fix/foreign-worktree-path",
+                                      path: "/tmp/wt2")
+        let index = FleetIndex(panes: [CommandFixture.paneA, CommandFixture.paneB, CommandFixture.paneC],
+                               worktrees: [CommandFixture.alphaMain, CommandFixture.featX,
+                                           CommandFixture.betaMain, CommandFixture.fixY, slashBranch],
+                               repos: [CommandFixture.alpha, CommandFixture.beta])
+        let label = index.label(for: slashBranch)
+        XCTAssertEqual(label, "@fix/foreign-worktree-path",
+                       "a unique slash-branch keeps the short label")
+        let parsed = CommandParser.parse("/return \(label)", index: index)
+        guard case .success(let line) = parsed,
+              case .returnWorktree(let wt) = line.command else {
+            return XCTFail("expected return of slash-branch, got \(parsed)")
+        }
+        XCTAssertEqual(wt.path, slashBranch.path)
+    }
+
+    /// When two repos share a slash-branch name, the disambiguated
+    /// `@repo/fix/foo` form still has to round-trip (first slash = repo).
+    func testReturnResolvesDisambiguatedSlashBranch() {
+        let a = WorktreeRef(repo: "alpha", branch: "fix/shared", path: "/a/fix-shared")
+        let b = WorktreeRef(repo: "beta", branch: "fix/shared", path: "/b/fix-shared")
+        let index = FleetIndex(panes: [], worktrees: [a, b],
+                               repos: [CommandFixture.alpha, CommandFixture.beta])
+        XCTAssertEqual(index.label(for: a), "@alpha/fix/shared")
+        let parsed = CommandParser.parse("/return @alpha/fix/shared", index: index)
+        guard case .success(let line) = parsed,
+              case .returnWorktree(let wt) = line.command else {
+            return XCTFail("expected disambiguated return, got \(parsed)")
+        }
+        XCTAssertEqual(wt.path, a.path)
+    }
+
     /// The old `/return @repo` overload is gone: a repo name says so.
     func testReturnRefusesARepoAndMain() {
         XCTAssertEqual(error("/return @alpha"), .repoNotWorktree("alpha"))


### PR DESCRIPTION
## Summary
- Branch names like `fix/foreign-worktree-path` produce the short label `@fix/…`. Parsing used to split on the first `/` and look for a repo named `fix`, so right-click **Return…** failed with only a beep. Prefer an exact name match before the `@repo/branch` disambiguator.
- Desktop command errors now present a sheet, so a refused/failed Return is visible.
- Delete/Return assessment can `git fetch` for seconds with no UI — the fleet row now shows a muted spinner and soft pulse until a confirm sheet appears or the tear-down finishes.

## Test plan
- [ ] Right-click **Return…** on a slash-branch worktree (e.g. `fix/foreign-worktree-path`) — should assess and delete/confirm, not silent-fail
- [ ] Right-click **Delete** on a worktree — row should pulse/spin immediately while fetch runs, then sheet or removal
- [ ] Cancel the delete confirm sheet — spinner clears
- [ ] `/return @alpha/main` still refuses a main worktree with a visible alert
- [x] `CommandParserTests` slash-branch cases