### PR TITLE
fix: persist telegram / host gateway across config saves

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -466,6 +466,10 @@ class MainWindowController: NSWindowController {
     /// config.
     @objc func showSettings() {
         if let existing = settingsWindowController {
+            // Reused windows still hold the SettingsVC's private Config copy from
+            // first open — refresh so a telegram token written after that open
+            // (or restored from disk via merge-on-write) shows up.
+            existing.reload(config: config)
             existing.show()
             return
         }

--- a/Sources/Core/Config.swift
+++ b/Sources/Core/Config.swift
@@ -261,6 +261,35 @@ struct Config: Codable {
     private static let saveQueue = DispatchQueue(label: "com.seahelm.config-save", qos: .utility)
     private static let pendingSaveLock = NSLock()
     private static var pendingSaveWorkItem: DispatchWorkItem?
+    /// The config the pending debounced write will persist. Kept so a later
+    /// `save()` from a stale coordinator copy can keep secrets (telegram token,
+    /// gmail, mqtt) that this writer never carried.
+    private static var pendingSaveConfig: Config?
+    /// Identity of the currently scheduled debounced write — used so a finishing
+    /// write does not clear a newer pendingSaveConfig.
+    private static var pendingSaveGeneration = UUID()
+
+    /// Fields owned by Settings (and similar) that a layout/activity save must
+    /// not erase. `nil` on the writer means "I never heard of this", not "clear
+    /// it" — a deliberate clear writes an empty struct (non-nil).
+    func preservingSettingsOwnedSecrets(from other: Config?) -> Config {
+        guard let other else { return self }
+        var out = self
+        if out.telegram == nil { out.telegram = other.telegram }
+        if out.gmailMail == nil { out.gmailMail = other.gmailMail }
+        if out.pairing == nil { out.pairing = other.pairing }
+        if out.hostGateway == nil { out.hostGateway = other.hostGateway }
+        return out
+    }
+
+    /// Disk snapshot for merge-on-write. Nil when the file is missing or undecodable —
+    /// callers then write `self` as-is.
+    private static func diskSnapshot() -> Config? {
+        guard FileManager.default.fileExists(atPath: configPath.path),
+              let data = try? Data(contentsOf: configPath),
+              let disk = try? JSONDecoder().decode(Config.self, from: data) else { return nil }
+        return disk
+    }
 
     /// Synchronous write. Use when a later `Config.load()` on this same turn of
     /// the run loop must observe the change — the debounced `save()` would still
@@ -270,12 +299,17 @@ struct Config: Codable {
         Config.pendingSaveLock.lock()
         Config.pendingSaveWorkItem?.cancel()
         Config.pendingSaveWorkItem = nil
+        let pending = Config.pendingSaveConfig
+        Config.pendingSaveConfig = nil
+        Config.pendingSaveGeneration = UUID()
         Config.pendingSaveLock.unlock()
+        let toWrite = preservingSettingsOwnedSecrets(from: pending)
+            .preservingSettingsOwnedSecrets(from: Config.diskSnapshot())
         do {
             try FileManager.default.createDirectory(at: Config.configDir, withIntermediateDirectories: true)
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            try encoder.encode(self).write(to: Config.configPath, options: .atomic)
+            try encoder.encode(toWrite).write(to: Config.configPath, options: .atomic)
         } catch {
             NSLog("Failed to save config: \(error)")
         }
@@ -289,21 +323,41 @@ struct Config: Codable {
         // Debounced async save: coalesces rapid saves into a single write.
         // The pending-item swap is lock-protected — save() has many call sites
         // and an unsynchronized cancel/reassign race can drop a save.
-        let configCopy = self
+        //
+        // Merge secrets from the canceled pending write *and* from disk so a
+        // TerminalCoordinator layout save (Config is a value type per owner)
+        // cannot wipe a Telegram token Settings just scheduled.
+        Config.pendingSaveLock.lock()
+        let previousPending = Config.pendingSaveConfig
+        Config.pendingSaveLock.unlock()
+        let configCopy = preservingSettingsOwnedSecrets(from: previousPending)
+            .preservingSettingsOwnedSecrets(from: Config.diskSnapshot())
+        let generation = UUID()
         let workItem = DispatchWorkItem {
             do {
                 try FileManager.default.createDirectory(at: Config.configDir, withIntermediateDirectories: true)
                 let encoder = JSONEncoder()
                 encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-                let data = try encoder.encode(configCopy)
+                // Re-merge disk at write time: another saveNow may have landed
+                // secrets since this item was scheduled.
+                let toWrite = configCopy.preservingSettingsOwnedSecrets(from: Config.diskSnapshot())
+                let data = try encoder.encode(toWrite)
                 try data.write(to: Config.configPath, options: .atomic)
             } catch {
                 NSLog("Failed to save config: \(error)")
             }
+            Config.pendingSaveLock.lock()
+            if Config.pendingSaveGeneration == generation {
+                Config.pendingSaveWorkItem = nil
+                Config.pendingSaveConfig = nil
+            }
+            Config.pendingSaveLock.unlock()
         }
         Config.pendingSaveLock.lock()
         Config.pendingSaveWorkItem?.cancel()
         Config.pendingSaveWorkItem = workItem
+        Config.pendingSaveConfig = configCopy
+        Config.pendingSaveGeneration = generation
         Config.pendingSaveLock.unlock()
         Config.saveQueue.asyncAfter(deadline: .now() + 0.3, execute: workItem)
     }

--- a/Sources/UI/Settings/SettingsViewController.swift
+++ b/Sources/UI/Settings/SettingsViewController.swift
@@ -822,7 +822,10 @@ class SettingsViewController: NSViewController {
                 from: config.hostGateway)
         }
 
-        config.save()
+        // Flush immediately. Config is a value type per coordinator; a later
+        // debounced layout save from a stale copy used to cancel this write and
+        // persist without telegram / gmail / gateway.
+        config.saveNow()
         settingsDelegate?.settingsDidUpdateConfig(self, config: config)
     }
 
@@ -845,6 +848,31 @@ class SettingsViewController: NSViewController {
     func commitPendingEdits() {
         view.window?.makeFirstResponder(nil)   // force-ends field editing
         applyChanges()
+    }
+
+    /// Replace the editable copy when Settings is reused (⌘, again). Syncs any
+    /// already-built page controls so a later apply does not write stale blanks
+    /// over secrets that landed after this window was first opened.
+    func reload(config: Config) {
+        self.config = config
+        workspacePaths = config.workspacePaths
+        if isViewLoaded {
+            pathListView.reloadData()
+        }
+        if pages["telegram"] != nil {
+            let cfg = config.telegram
+            telegramTokenField.stringValue = cfg?.botToken ?? ""
+            telegramUsersView.string = (cfg?.allowedUsers ?? []).joined(separator: "\n")
+            telegramDefaultChatField.stringValue = cfg?.defaultChatId ?? ""
+            telegramAutoConnectToggle.state = (cfg?.resolvedAutoConnect ?? true) ? .on : .off
+            // Rules editor has no public setter; leaving it alone is fine — apply
+            // still reads `telegramRulesView.rules`, and a token wipe is the bug.
+        }
+        if pages["gmail"] != nil {
+            gmailAccountField.stringValue = config.gmailMail?.accountEmail ?? ""
+            gmailAllowedSendersField.stringValue = (config.gmailMail?.allowedSenders ?? []).joined(separator: ", ")
+            gmailEnabledToggle.state = (config.gmailMail?.enabled ?? false) ? .on : .off
+        }
     }
 }
 

--- a/Sources/UI/Settings/SettingsWindowController.swift
+++ b/Sources/UI/Settings/SettingsWindowController.swift
@@ -43,6 +43,11 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    /// Replace the editable config when the window is reused (⌘, again).
+    func reload(config: Config) {
+        settingsViewController.reload(config: config)
+    }
+
     /// A field still being edited has not fired its action yet, and closing the
     /// window would drop it. Commit first.
     func windowWillClose(_ notification: Notification) {

--- a/Tests/ConfigTests.swift
+++ b/Tests/ConfigTests.swift
@@ -536,4 +536,56 @@ final class ConfigTests: XCTestCase {
         XCTAssertFalse(out.contains("broker.example.com"), out)
         XCTAssertFalse(out.contains("ws_path"), out)
     }
+
+    // MARK: - Settings-owned secrets vs stale writers
+
+    /// A layout/activity save carries `telegram == nil` because that coordinator
+    /// never opened Settings. Nil means "unknown", not "clear" — keep the other.
+    func testPreservingSecretsKeepsTelegramFromOtherCopy() {
+        var writer = Config()
+        writer.workspacePaths = ["/tmp/a"]
+        writer.telegram = nil
+
+        var disk = Config()
+        disk.telegram = TelegramConfig(botToken: "1:AA", allowedUsers: ["42"],
+                                       defaultChatId: "42", autoConnect: true)
+
+        let merged = writer.preservingSettingsOwnedSecrets(from: disk)
+        XCTAssertEqual(merged.telegram?.botToken, "1:AA")
+        XCTAssertEqual(merged.telegram?.allowedUsers, ["42"])
+        XCTAssertEqual(merged.workspacePaths, ["/tmp/a"])
+    }
+
+    /// Clearing Settings writes an empty `TelegramConfig` (non-nil). That must
+    /// not be restored from an older disk snapshot.
+    func testPreservingSecretsDoesNotRestoreDeliberateTelegramClear() {
+        var writer = Config()
+        writer.telegram = TelegramConfig(botToken: nil, allowedUsers: [],
+                                         defaultChatId: nil, autoConnect: false)
+
+        var disk = Config()
+        disk.telegram = TelegramConfig(botToken: "1:AA", allowedUsers: ["42"])
+
+        let merged = writer.preservingSettingsOwnedSecrets(from: disk)
+        XCTAssertEqual(merged.telegram?.botToken, nil)
+        XCTAssertEqual(merged.telegram?.allowedUsers, [])
+        XCTAssertEqual(merged.telegram?.autoConnect, false)
+    }
+
+    /// TelegramConfig only has a custom decoder; encoding must still emit
+    /// `bot_token` or a save looks successful while the file never stores it.
+    func testTelegramConfigRoundTripsThroughJSON() throws {
+        var config = Config()
+        config.telegram = TelegramConfig(botToken: "123:ABC", allowedUsers: ["9"],
+                                         defaultChatId: "9", autoConnect: true)
+        let data = try JSONEncoder().encode(config)
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertTrue(json.contains("\"telegram\""), json)
+        XCTAssertTrue(json.contains("\"bot_token\""), json)
+        XCTAssertTrue(json.contains("123:ABC"), json)
+
+        let decoded = try JSONDecoder().decode(Config.self, from: data)
+        XCTAssertEqual(decoded.telegram?.botToken, "123:ABC")
+        XCTAssertEqual(decoded.telegram?.allowedUsers, ["9"])
+    }
 }


### PR DESCRIPTION
## Summary
- Settings-owned optional blocks (`telegram`, `host_gateway`, `gmail_mail`, `mqtt`) were wiped when a stale coordinator `Config` copy debounced-saved over them — same root cause as Telegram and Host Gateway appearing to “turn off” after relaunch.
- Settings now flushes with `saveNow()`; `save`/`saveNow` keep those fields from the pending write and from disk when the writer carries `nil` (a deliberate clear still writes a non-nil empty/disabled struct).
- Reopening Settings reloads the live config into a reused window so blank fields cannot re-clobber secrets.

## Test plan
- [ ] Settings → Telegram: set token + allowlist, switch worktrees / split a pane (trigger layout saves), quit and relaunch — `~/.config/seahelm/config.json` still has `telegram`
- [ ] Settings → Pairing: enable Host Gateway (port 2783, public URL), same churn + relaunch — `host_gateway.enabled` stays true and `:2783` listens after start
- [ ] Deliberately clear Telegram fields / disable gateway — stays cleared after relaunch (not restored from an old disk snapshot)
- [ ] `xcodebuild … test -only-testing:seahelmTests/ConfigTests` (new preserve + telegram round-trip cases)


Made with [Cursor](https://cursor.com)