### PR TITLE
Phone-side approvals, an honest integration marker, and splits that inherit cwd

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -288,15 +288,22 @@ class MainWindowController: NSWindowController {
             guard let self, self.islandController.model.isOpened else { return false }
             return self.islandController.model.orders.contains { $0.action.terminalID == terminalID }
         }
-        // Every desktop banner also goes to whatever chat channels are registered,
-        // so a phone hears "agent finished" without seahelm owning a transport or
-        // push certificate. No-op until a channel is registered.
-        NotificationManager.shared.onDeliverExternal = { [weak self] status, title, subtitle, body, terminalID in
+        // Pane-status banners go to Telegram with binding awareness: after
+        // `/go #n` that chat only hears #n, not the rest of the fleet. Other
+        // external channels still get every event.
+        //
+        // `bannerSuppressed` means the user is looking at this very pane, so
+        // the audiences that hear the whole fleet stay quiet — a phone ping for
+        // something already on screen is noise. It does not silence a chat
+        // bound to the pane: that conversation is happening away from this
+        // desk, and its own order's answer must reach it.
+        NotificationManager.shared.onDeliverExternal = { [weak self] status, title, subtitle, body, terminalID, bannerSuppressed in
             let text = "\(status.icon) **\(title)**\n\(subtitle)\n\n\(body)"
-            AgentRegistry.shared.broadcast(text, format: .markdown)
-            // A chat that bound itself to this pane hears it too, not only the
-            // configured default — that is what binding is for.
-            self?.notifyBoundSessions(terminalID: terminalID, text: text)
+            if !bannerSuppressed {
+                AgentRegistry.shared.broadcast(text, format: .markdown, excluding: ["telegram"])
+            }
+            self?.notifyTelegramSessions(terminalID: terminalID, text: text,
+                                         fleetSilenced: bannerSuppressed)
         }
         // Not `tabCoordinator.commandRoute` here: that coordinator's own
         // initializer reads `statusPublisher`, and two lazy vars that reach
@@ -3006,16 +3013,31 @@ extension MainWindowController: CommandHost {
         alert.beginSheetModal(for: window) { completion($0 == .alertFirstButtonReturn) }
     }
 
-    /// Telegram chats bound to this pane get the notification in their own
-    /// thread. Mail threads have their own observer for the same edge.
-    private func notifyBoundSessions(terminalID: String, text: String) {
-        guard !terminalID.isEmpty, let pane = AgentRegistry.shared.pane(for: terminalID) else { return }
-        let key = PaneHandleRegistry.key(sessionKey: pane.station?.paneSessionKey ?? "", paneId: pane.id)
-        let defaultChat = config.telegram?.resolvedDefaultChatId
-        for session in tabCoordinator.commandSessions.sessions(boundToPaneKey: key)
-        where session.surface == "telegram" && session.id != defaultChat {
+    /// Telegram delivery for a pane-status banner. Bound chats hear only their
+    /// pane; the default / last-order chat hears the whole fleet while unbound.
+    ///
+    /// `fleetSilenced` drops the fleet-wide listeners for this one event — the
+    /// desktop already showed it. Chats bound to the pane are never dropped.
+    private func notifyTelegramSessions(terminalID: String, text: String, fleetSilenced: Bool = false) {
+        let paneKey: String?
+        if !terminalID.isEmpty, let pane = AgentRegistry.shared.pane(for: terminalID) {
+            paneKey = PaneHandleRegistry.key(sessionKey: pane.station?.paneSessionKey ?? "",
+                                             paneId: pane.id)
+        } else {
+            paneKey = nil
+        }
+        var fleet: [String] = []
+        if !fleetSilenced {
+            if let chat = config.telegram?.resolvedDefaultChatId { fleet.append(chat) }
+            if let chat = telegramChannel?.fleetNotifyChatId, !fleet.contains(chat) {
+                fleet.append(chat)
+            }
+        }
+        let chats = tabCoordinator.commandSessions.telegramChatsToNotify(
+            paneKey: paneKey, fleetListenerChatIds: fleet)
+        for chatId in chats {
             AgentRegistry.shared.pushToChannel("telegram", message: OutboundMessage(
-                channelId: "telegram", targetChatId: session.id, content: text, format: .markdown))
+                channelId: "telegram", targetChatId: chatId, content: text, format: .markdown))
         }
     }
 }

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -1167,6 +1167,11 @@ dashboard.stationManager = terminalCoordinator.stationManager
                         )
                     }
                 case .failure(let error):
+                    // Recorded as well as reported. A round that threw wrote
+                    // nothing here, so First Mate went on showing the last good
+                    // round and read as an integration that was still current.
+                    IntegrationStatusStore.shared.set(
+                        .failed(error.localizedDescription), forWorktree: integrationPath)
                     self?.enqueueIntegrationReport(
                         "Integration failed: \(error.localizedDescription)",
                         repoPath: repoPath,
@@ -2993,6 +2998,8 @@ extension MainWindowController: CommandHost {
                     }
                     completion(report.summary, report.isHeld)
                 case .failure(let error):
+                    IntegrationStatusStore.shared.set(
+                        .failed(error.localizedDescription), forWorktree: integrationPath)
                     completion("Integration failed: \(error.localizedDescription)", false)
                 }
             }

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -105,6 +105,17 @@ class MainWindowController: NSWindowController {
     /// separately from `islandSeenSuggestions`: the island's set is also advanced by
     /// its 10s fallback timer, which would eat the "new order" edge this needs.
     private var revealedSuggestions = SuggestionSeenSet()
+    /// Cards already mirrored to chat. Its own set: a card the island has shown
+    /// still has to reach the phone, and the phone must not be sent the same
+    /// question twice because the desktop happened to re-pop it.
+    private var chatSeenCards = SuggestionSeenSet()
+    /// Where each card's buttons are drawn right now, so they can be taken down
+    /// when the card goes — answered on the Mac, or the agent moved past it.
+    private var cardButtonMessages: [String: [ChatNoticeBook.Ref]] = [:]
+    /// The last thing said about a pane in each chat. An agent's suggested next
+    /// steps are added to that message as buttons rather than arriving as a
+    /// second message repeating the words it already carries.
+    private var noticeBook = ChatNoticeBook()
 
     // Terminal management
     /// GitHub token 解析，来源优先级：
@@ -314,6 +325,9 @@ class MainWindowController: NSWindowController {
         }
         AgentRegistry.shared.ruleTriggerRoute = { [weak self] prompt, target in
             self?.dispatchRuleTrigger(prompt: prompt, target: target) ?? false
+        }
+        AgentRegistry.shared.callbackRoute = { [weak self] callback in
+            self?.handleChatCallback(callback)
         }
         statusAggregator.delegate = self
         statusAggregator.seedLastActivity(persistedActivityMap())
@@ -2310,6 +2324,8 @@ extension MainWindowController {
         // Notification Center's job. Frontmost, this yields to the First Mate
         // sidebar only for a card that sidebar is actually showing — a
         // suggestion raised in a worktree that isn't on screen pops here.
+        publishCardsToChat(tabCoordinator.pendingOrders.all())
+
         let fresh = islandSeenSuggestions.absorb(orders)
         if !fresh.isEmpty, !model.isOpened {
             let targetVisible = fresh.allSatisfy {
@@ -3037,7 +3053,243 @@ extension MainWindowController: CommandHost {
             paneKey: paneKey, fleetListenerChatIds: fleet)
         for chatId in chats {
             AgentRegistry.shared.pushToChannel("telegram", message: OutboundMessage(
-                channelId: "telegram", targetChatId: chatId, content: text, format: .markdown))
+                channelId: "telegram", targetChatId: chatId, content: text, format: .markdown)
+            ) { [weak self] messageId in
+                // Remembered so an agent's next-step options, which land a beat
+                // after this, can be added to it as buttons.
+                guard !terminalID.isEmpty, let messageId else { return }
+                DispatchQueue.main.async {
+                    self?.rememberNotice(terminalID: terminalID, chatId: chatId, messageId: messageId)
+                }
+            }
         }
+    }
+}
+
+
+// MARK: - Chat cards
+
+extension MainWindowController {
+    /// One message per card, and only when there is something to say.
+    ///
+    /// Both kinds of card carry options, but they earn their place on a phone
+    /// differently:
+    ///
+    ///   - A **question** is a stop. The pane sits at its prompt until someone
+    ///     picks, and until this existed the only place to pick was this Mac,
+    ///     which made every approval a walk back to the desk. It gets a message
+    ///     of its own.
+    ///   - A **suggestion** is an offer, and its words have already been sent:
+    ///     the card's summary and the completion notice are both the agent's
+    ///     final prose. So it gets no message — its options are added to that
+    ///     notice as buttons. No notice, no buttons: if the completion was
+    ///     never worth telling the phone about, neither are its next steps.
+    ///
+    /// A suggestion whose notice has not come back with an id yet is left out
+    /// of the seen set rather than dropped, so the next pass picks it up.
+    func publishCardsToChat(_ orders: [PendingOrder]) {
+        retireVanishedCardButtons(live: Set(orders.map(\.id)))
+
+        let attachable = orders.filter { order in
+            guard !(order.action.options ?? []).isEmpty else { return false }
+            return FirstMateAction.isQuestionPayload(order.action.payload)
+                || !noticeBook.recent(pane: order.action.terminalID).isEmpty
+        }
+        for order in chatSeenCards.absorb(attachable) {
+            if FirstMateAction.isQuestionPayload(order.action.payload) {
+                sendCardToChat(order)
+            } else {
+                attachOptionsToNotice(order)
+            }
+        }
+    }
+
+    /// Add a suggestion's options to the completion notice they belong under.
+    private func attachOptionsToNotice(_ order: PendingOrder) {
+        let targets = noticeBook.recent(pane: order.action.terminalID)
+        guard !targets.isEmpty else { return }
+        let buttons = optionButtons(for: order)
+        for target in targets {
+            AgentRegistry.shared.setButtons(channelId: "telegram", chatId: target.chatId,
+                                            messageId: target.messageId, buttons: buttons)
+        }
+        cardButtonMessages[order.id] = targets
+    }
+
+    func rememberNotice(terminalID: String, chatId: String, messageId: String) {
+        noticeBook.record(pane: terminalID, chatId: chatId, messageId: messageId)
+    }
+
+    /// Take the buttons off cards that have left the queue, and forget notices
+    /// too old to attach to. Runs on the island's refresh, which is the only
+    /// place that sees the queue as a whole.
+    private func retireVanishedCardButtons(live: Set<String>) {
+        for orderId in cardButtonMessages.keys where !live.contains(orderId) {
+            retireCardButtons(orderId)
+        }
+        noticeBook.prune()
+    }
+
+    /// Take one card's buttons down everywhere they were drawn — answering it
+    /// in one chat must not leave it on offer in another.
+    private func retireCardButtons(_ orderId: String) {
+        for ref in cardButtonMessages.removeValue(forKey: orderId) ?? [] {
+            AgentRegistry.shared.setButtons(channelId: "telegram", chatId: ref.chatId,
+                                            messageId: ref.messageId, buttons: [])
+        }
+    }
+
+    /// The card's options as buttons. `dismissable` adds a way to clear a card
+    /// without answering it — worth offering on a question, which otherwise
+    /// sits there, and not on a suggestion, where not tapping *is* declining.
+    private func optionButtons(for order: PendingOrder, dismissable: Bool = false) -> [MessageButton] {
+        // Minted once and shared by every chat the card reaches: a token says
+        // what the button means, not who tapped it.
+        var buttons = (order.action.options ?? []).enumerated().map { index, label in
+            MessageButton(label: label, token: ChatCallbackRegistry.shared.mint(
+                .suggestionOption(orderId: order.id, index: index)))
+        }
+        if dismissable {
+            buttons.append(MessageButton(label: "Leave it waiting",
+                                         token: ChatCallbackRegistry.shared.mint(
+                                            .dismissSuggestion(orderId: order.id))))
+        }
+        return buttons
+    }
+
+    private func sendCardToChat(_ order: PendingOrder) {
+        let pane = AgentRegistry.shared.pane(for: order.action.terminalID)
+        let paneKey = pane.map {
+            PaneHandleRegistry.key(sessionKey: $0.station?.paneSessionKey ?? "", paneId: $0.id)
+        }
+        // Unlike a completion notice, a card is not silenced by `/go`. Binding
+        // says "route my conversation to #12"; it does not say "don't tell me
+        // when the fleet stops". A blocked agent is the one thing that never
+        // resolves itself, and a chat bound to another pane is still the only
+        // way its owner can answer this one without walking back to the Mac.
+        var chats = Set(tabCoordinator.commandSessions.telegramChatsToNotify(
+            paneKey: paneKey, fleetListenerChatIds: []))
+        if let chat = config.telegram?.resolvedDefaultChatId { chats.insert(chat) }
+        if let chat = telegramChannel?.fleetNotifyChatId { chats.insert(chat) }
+        guard !chats.isEmpty else { return }
+
+        let buttons = optionButtons(for: order, dismissable: true)
+        let text = Self.questionCardText(
+            handle: paneKey.map { PaneHandleRegistry.shared.handle(for: $0) },
+            project: order.action.project, branch: order.action.branch,
+            message: order.action.message, options: order.action.options ?? [])
+        for chatId in chats {
+            AgentRegistry.shared.pushToChannel("telegram", message: OutboundMessage(
+                channelId: "telegram", targetChatId: chatId, content: text,
+                format: .markdown, buttons: buttons)
+            ) { [weak self] messageId in
+                guard let messageId else { return }
+                DispatchQueue.main.async {
+                    self?.cardButtonMessages[order.id, default: []].append(
+                        ChatNoticeBook.Ref(chatId: chatId, messageId: messageId))
+                }
+            }
+        }
+    }
+
+
+    /// The card as a chat message. Pure, so its shape is testable.
+    ///
+    /// The options are spelled out in the text as well as drawn as buttons: a
+    /// button label is trimmed to fit a phone's width, and the difference
+    /// between two options is often in the part that gets trimmed.
+    static func questionCardText(handle: Int?, project: String, branch: String,
+                                 message: String, options: [String]) -> String {
+        let target = [project, branch].filter { !$0.isEmpty }.joined(separator: " / ")
+        let head = [handle.map { "#\($0)" }, target.isEmpty ? nil : target]
+            .compactMap { $0 }.joined(separator: " · ")
+        var lines = ["\(AgentStatus.waiting.icon) **Waiting on you**"]
+        if !head.isEmpty { lines.append(head) }
+        let prompt = message.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !prompt.isEmpty { lines.append("\n\(prompt)") }
+        if !options.isEmpty {
+            lines.append("")
+            for (index, option) in options.enumerated() {
+                lines.append("\(index + 1). \(option)")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    /// Someone tapped a button in a chat.
+    ///
+    /// A token that no longer resolves is not an error: the tokens live only as
+    /// long as the run, and a card's message sits in the chat's history forever,
+    /// so a tap can arrive from last week or from before a relaunch. Say so and
+    /// change nothing — replaying it against a fleet that has moved on is how a
+    /// stale button ends up typing into somebody else's pane.
+    func handleChatCallback(_ callback: InboundCallback) {
+        guard let action = ChatCallbackRegistry.shared.action(for: callback.token) else {
+            replyToChat(callback, "That card has already been answered — or it is from before seahelm last started.")
+            return
+        }
+        switch action {
+        case .command(let line):
+            // A line's buttons are a listing's shortcuts — `/go #7` beside each
+            // pane — and stay tappable: picking one is not answering anything.
+            let surface = CommandSurface(
+                sessionKey: CommandSession.key(surface: "telegram", id: callback.chatId),
+                isDesktop: false, commander: callback.senderId)
+            commandExecutor.run(line, surface: surface) { [weak self] reply in
+                guard !reply.text.isEmpty else { return }
+                self?.replyToChat(callback, reply.text)
+            }
+            return
+        case .suggestionOption(let orderId, let index):
+            guard let order = tabCoordinator.pendingOrders.all().first(where: { $0.id == orderId }),
+                  let options = order.action.options, index < options.count else {
+                replyToChat(callback, "That card is gone — the agent moved on.")
+                return
+            }
+            let option = options[index]
+            // Retire first: answering the card re-enqueues the next question of
+            // a multi-part ask under the same id, and its fresh tokens must not
+            // be swept away by the resolve that follows.
+            ChatCallbackRegistry.shared.retire(orderId: orderId)
+            handleSuggestionTapped(order: order, optionText: option)
+            replyToChat(callback, "Picked **\(option)**.")
+        case .dismissSuggestion(let orderId):
+            tabCoordinator.pendingOrders.resolve(id: orderId)
+            replyToChat(callback, "Left it. The agent is still waiting — answer it on the Mac when you get there.")
+        }
+        // The card has been dealt with; its buttons must stop offering options
+        // in a message that stays in the chat's history for good — in *every*
+        // chat that was shown it, not only the one that answered. (A `.command`
+        // button returned above; nothing was answered.)
+        let orderId = Self.orderId(of: action)
+        let tapped = ChatNoticeBook.Ref(chatId: callback.chatId, messageId: callback.messageId)
+        if let orderId {
+            // Matched on the message, not the whole ref: `at` is "now" here and
+            // would never equal the moment the card was sent, so an identity
+            // comparison would book the same message twice and edit it twice.
+            let known = cardButtonMessages[orderId]?.contains {
+                $0.chatId == tapped.chatId && $0.messageId == tapped.messageId
+            } ?? false
+            if !known { cardButtonMessages[orderId, default: []].append(tapped) }
+            retireCardButtons(orderId)
+        } else {
+            AgentRegistry.shared.setButtons(channelId: callback.channelId, chatId: callback.chatId,
+                                            messageId: callback.messageId, buttons: [])
+        }
+    }
+
+    /// Which card a tap belongs to, when it belongs to one.
+    private static func orderId(of action: ChatCallbackAction) -> String? {
+        switch action {
+        case .command: return nil
+        case .suggestionOption(let orderId, _): return orderId
+        case .dismissSuggestion(let orderId): return orderId
+        }
+    }
+
+    private func replyToChat(_ callback: InboundCallback, _ markdown: String) {
+        AgentRegistry.shared.pushToChannel(callback.channelId, message: OutboundMessage(
+            channelId: callback.channelId, targetChatId: callback.chatId,
+            content: markdown, format: .markdown))
     }
 }

--- a/Sources/App/TerminalCoordinator.swift
+++ b/Sources/App/TerminalCoordinator.swift
@@ -90,6 +90,9 @@ class TerminalCoordinator {
         guard let container = activeSplitContainer(),
               let tree = container.tree else { return }
 
+        // Read before the tree changes: the new pane opens where the pane it
+        // came from is standing, not at the worktree root.
+        let inherited = inheritedWorkingDirectory(leafId: tree.focusedId, tree: tree)
         let paneSessionKey = tree.nextSessionName()
         let station = Station()
         station.paneSessionKey = paneSessionKey
@@ -106,7 +109,8 @@ class TerminalCoordinator {
             tree: tree,
             newStation: station,
             newLeafId: leafId,
-            focusNew: true
+            focusNew: true,
+            workingDirectory: inherited
         )
 
         delegate?.terminalCoordinatorDidUpdateSurfaces(self)
@@ -146,6 +150,7 @@ class TerminalCoordinator {
             targetLeafId = tree.focusedId
         }
 
+        let inherited = inheritedWorkingDirectory(leafId: targetLeafId, tree: tree)
         let paneSessionKey = paneSessionKeyOverride ?? tree.nextSessionName()
         let station = Station()
         station.paneSessionKey = paneSessionKey
@@ -168,13 +173,22 @@ class TerminalCoordinator {
             newStation: station,
             newLeafId: leafId,
             focusNew: focus,
-            restoreFocusLeafId: focus ? nil : previousFocus
+            restoreFocusLeafId: focus ? nil : previousFocus,
+            workingDirectory: inherited
         )
 
         delegate?.terminalCoordinatorDidUpdateSurfaces(self)
         saveSplitLayout(tree)
         announceFocusChange(container)
         return station.id
+    }
+
+    /// Where a split off `leafId` should open. The worktree root is the floor,
+    /// so a pane whose directory cannot be read behaves as it always did.
+    private func inheritedWorkingDirectory(leafId: String, tree: SplitTree) -> String {
+        let station = tree.allLeaves.first { $0.id == leafId }
+            .flatMap { StationRegistry.shared.station(forId: $0.stationId) }
+        return PaneWorkingDirectory.resolve(station: station, worktreePath: tree.worktreePath)
     }
 
     /// Whether an existing pane should adopt the new frame *without* a PTY
@@ -199,7 +213,8 @@ class TerminalCoordinator {
         newStation: Station,
         newLeafId: String,
         focusNew: Bool,
-        restoreFocusLeafId: String? = nil
+        restoreFocusLeafId: String? = nil,
+        workingDirectory: String? = nil
     ) {
         let frames = SplitContainerView.computeFrames(node: tree.root, in: container.bounds)
         let newFrame = frames[newLeafId] ?? container.bounds
@@ -219,7 +234,7 @@ class TerminalCoordinator {
         }
         _ = newStation.create(
             in: container,
-            workingDirectory: tree.worktreePath,
+            workingDirectory: workingDirectory ?? tree.worktreePath,
             paneSessionKey: newStation.paneSessionKey,
             initialFrame: newFrame
         )

--- a/Sources/Core/AgentRegistry.swift
+++ b/Sources/Core/AgentRegistry.swift
@@ -1090,6 +1090,9 @@ class AgentRegistry {
         channel.onMessage = { [weak self] message in
             self?.handleInbound(message)
         }
+        channel.onCallback = { [weak self] callback in
+            self?.handleCallback(callback)
+        }
     }
 
     /// Unregister and disconnect an external channel
@@ -1120,6 +1123,12 @@ class AgentRegistry {
     /// then — tests, headless runs — a headless executor over an empty fleet
     /// answers instead.
     var commandRoute: ((_ text: String, _ surface: CommandSurface, _ reply: @escaping (CommandReply) -> Void) -> Void)?
+
+    /// Resolves a chat button tap: what the token meant, and doing it. Set by
+    /// `MainWindowController`, which owns the card queue and the panes. Until
+    /// then a tap is answered as stale, which is also what an unrecognised
+    /// token gets — the two are the same thing to the tapper.
+    var callbackRoute: ((InboundCallback) -> Void)?
 
     /// Injects a rule-matched prompt into the pane a target names. Set by
     /// `MainWindowController`, which owns the pane list. Returns false when the
@@ -1173,6 +1182,16 @@ class AgentRegistry {
         }
     }
 
+    /// A button tap, on the main thread. The channel reports it from its poll
+    /// thread and the router walks the fleet and the card queue.
+    func handleCallback(_ callback: InboundCallback) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in self?.handleCallback(callback) }
+            return
+        }
+        callbackRoute?(callback)
+    }
+
     /// What answers before the window has wired a host — tests, headless runs:
     /// the command language over an empty fleet, with nothing persisted.
     private lazy var headlessExecutor = CommandExecutor(host: HeadlessCommandHost.shared,
@@ -1194,13 +1213,30 @@ class AgentRegistry {
         pushToChannel(message.channelId, message: outbound)
     }
 
-    /// Push a message to a specific external channel
-    func pushToChannel(_ channelId: String, message: OutboundMessage) {
+    /// Push a message to a specific external channel. `completion` carries the
+    /// sent message's id where the channel can report one — what a caller needs
+    /// to come back and change that message's buttons.
+    func pushToChannel(_ channelId: String, message: OutboundMessage,
+                       completion: ((String?) -> Void)? = nil) {
         lock.lock()
         let channel = externalChannels[channelId]
         lock.unlock()
 
-        channel?.send(message)
+        guard let channel else {
+            completion?(nil)
+            return
+        }
+        channel.send(message, completion: completion)
+    }
+
+    /// Change the buttons on a message a channel already sent; `[]` takes them
+    /// off. Channels that cannot edit their own messages do nothing.
+    func setButtons(channelId: String, chatId: String, messageId: String, buttons: [MessageButton]) {
+        lock.lock()
+        let channel = externalChannels[channelId]
+        lock.unlock()
+
+        channel?.setButtons(chatId: chatId, messageId: messageId, buttons: buttons)
     }
 
     /// Broadcast a message to all registered external channels

--- a/Sources/Core/AgentRegistry.swift
+++ b/Sources/Core/AgentRegistry.swift
@@ -1205,11 +1205,17 @@ class AgentRegistry {
 
     /// Broadcast a message to all registered external channels
     func broadcast(_ content: String, format: MessageFormat = .text) {
+        broadcast(content, format: format, excluding: [])
+    }
+
+    /// Like `broadcast`, but skip channel ids in `excluding` — used when the
+    /// caller delivers Telegram itself with pane-scoped routing.
+    func broadcast(_ content: String, format: MessageFormat = .text, excluding: Set<String>) {
         lock.lock()
         let channels = Array(externalChannels.values)
         lock.unlock()
 
-        for channel in channels {
+        for channel in channels where !excluding.contains(channel.channelId) {
             let message = OutboundMessage(
                 channelId: channel.channelId,
                 content: content,

--- a/Sources/Core/ChatNoticeBook.swift
+++ b/Sources/Core/ChatNoticeBook.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Which message in each chat an agent's next steps belong under.
+///
+/// A suggestion card carries no words of its own worth sending: its summary and
+/// the completion notice already on the phone are both the agent's final prose.
+/// So its options are added to that notice as buttons, and this remembers where
+/// that notice is — one per chat per pane, the newest replacing the last.
+///
+/// Entries expire. Past the window the chat has moved on, and buttons appearing
+/// under a message the reader has stopped looking at are worse than none: they
+/// offer a next step for a turn that has scrolled away.
+struct ChatNoticeBook: Equatable {
+    /// A message a chat is holding, and when it was sent.
+    struct Ref: Equatable {
+        let chatId: String
+        let messageId: String
+        let at: Date
+
+        init(chatId: String, messageId: String, at: Date = Date()) {
+            self.chatId = chatId
+            self.messageId = messageId
+            self.at = at
+        }
+    }
+
+    /// How long a notice stays the message an agent's next steps belong under.
+    static let window: TimeInterval = 180
+
+    private var refs: [String: [Ref]] = [:]
+
+    init() {}
+
+    /// The newest notice about `pane` in this chat, replacing any older one.
+    mutating func record(pane: String, chatId: String, messageId: String, at: Date = Date()) {
+        guard !pane.isEmpty else { return }
+        var list = (refs[pane] ?? []).filter { $0.chatId != chatId }
+        list.append(Ref(chatId: chatId, messageId: messageId, at: at))
+        refs[pane] = list
+    }
+
+    /// Notices about `pane` still recent enough to attach to.
+    func recent(pane: String, now: Date = Date()) -> [Ref] {
+        guard !pane.isEmpty else { return [] }
+        let cutoff = now.addingTimeInterval(-Self.window)
+        return (refs[pane] ?? []).filter { $0.at >= cutoff }
+    }
+
+    /// Drop what can no longer be attached to, so a long-running fleet does not
+    /// accumulate a row per pane it once said something about.
+    mutating func prune(now: Date = Date()) {
+        let cutoff = now.addingTimeInterval(-Self.window)
+        refs = refs.compactMapValues { list in
+            let live = list.filter { $0.at >= cutoff }
+            return live.isEmpty ? nil : live
+        }
+    }
+
+    var isEmpty: Bool { refs.isEmpty }
+}

--- a/Sources/Core/Command/CommandSession.swift
+++ b/Sources/Core/Command/CommandSession.swift
@@ -138,6 +138,35 @@ final class CommandSessionStore {
         queue.sync { sessions.values.filter { $0.boundPaneKey == paneKey && !$0.closed } }
     }
 
+    /// Telegram chats that should hear a pane-status notification.
+    ///
+    /// Bound chats for `paneKey` always hear it. `fleetListenerChatIds` (the
+    /// configured default / last-order chat) hear the whole fleet only while
+    /// unbound — after `/go #n` they are silenced for every other pane, which
+    /// is what binding is for.
+    func telegramChatsToNotify(paneKey: String?,
+                               fleetListenerChatIds: [String]) -> [String] {
+        queue.sync {
+            var chats = Set<String>()
+            if let paneKey {
+                for session in sessions.values
+                where session.surface == "telegram"
+                    && !session.closed
+                    && session.boundPaneKey == paneKey {
+                    chats.insert(session.id)
+                }
+            }
+            for chatId in fleetListenerChatIds {
+                let session = sessions[CommandSession.key(surface: "telegram", id: chatId)]
+                    ?? CommandSession(key: CommandSession.key(surface: "telegram", id: chatId))
+                if session.boundPaneKey == nil || session.closed {
+                    chats.insert(chatId)
+                }
+            }
+            return Array(chats)
+        }
+    }
+
     /// Mark every session bound to this pane closed. Returns them, so the
     /// caller can clean up whatever else the binding owned.
     @discardableResult

--- a/Sources/Core/ExternalChannel.swift
+++ b/Sources/Core/ExternalChannel.swift
@@ -96,15 +96,26 @@ protocol ExternalChannel: AnyObject {
     /// Called by the channel when a message arrives from the external platform
     var onMessage: ((InboundMessage) -> Void)? { get set }
 
+    /// Called when someone taps a button on a message this channel sent.
+    /// Separate from `onMessage` because nothing was said: see `InboundCallback`.
+    var onCallback: ((InboundCallback) -> Void)? { get set }
+
     /// Send a message out to the external platform
     func send(_ message: OutboundMessage)
 
-    /// Take the buttons off a message this channel already sent.
+    /// Send, and report the id of the message the buttons hang under, so the
+    /// caller can come back and change them. Nil when nothing was sent.
+    func send(_ message: OutboundMessage, completion: ((String?) -> Void)?)
+
+    /// Change the buttons on a message this channel already sent; `[]` takes
+    /// them off. Channels that cannot edit what they sent do nothing.
     ///
-    /// A card that has been answered must not go on offering its options — on
-    /// the phone that message stays in the history forever. Channels that
-    /// cannot edit what they sent do nothing.
-    func retireButtons(chatId: String, messageId: String)
+    /// Both directions are needed. A card that has been answered must not go
+    /// on offering its options — on the phone that message stays in the
+    /// history forever — and an agent's suggested next steps are added to the
+    /// completion notice they belong under rather than sent as a second
+    /// message repeating it.
+    func setButtons(chatId: String, messageId: String, buttons: [MessageButton])
 
     /// Connection management
     func connect()
@@ -112,5 +123,15 @@ protocol ExternalChannel: AnyObject {
 }
 
 extension ExternalChannel {
-    func retireButtons(chatId: String, messageId: String) {}
+    func send(_ message: OutboundMessage, completion: ((String?) -> Void)?) {
+        send(message)
+        completion?(nil)
+    }
+
+    func setButtons(chatId: String, messageId: String, buttons: [MessageButton]) {}
+
+    /// The common direction, named for what it means.
+    func retireButtons(chatId: String, messageId: String) {
+        setButtons(chatId: chatId, messageId: messageId, buttons: [])
+    }
 }

--- a/Sources/Core/IntegrationRowStatus.swift
+++ b/Sources/Core/IntegrationRowStatus.swift
@@ -1,0 +1,61 @@
+import AppKit
+
+/// How an integration checkout reads in the fleet list.
+///
+/// A checkout has no agent. `idle` / `running` there describes whatever shell
+/// happens to be open in it — which is why that row's status dot has always
+/// said nothing worth reading, and why the two groupings that sort *by* status
+/// leave the checkout out of the list entirely. What a person wants from that
+/// row is whether the last round landed.
+///
+/// So the dot means something else on this one row. That is a smaller lie than
+/// the one it replaces: a green dot on a checkout whose round dropped two
+/// worktrees.
+enum IntegrationRowStatus: Equatable {
+    /// No round has run here yet.
+    case notBuilt
+    /// Everything on offer went in and was checked out.
+    case clean
+    /// Work was dropped, what landed carries markers, or the result was built
+    /// and held back.
+    case attention
+    /// The round did not run at all.
+    case failed
+
+    init(_ state: IntegrationPanelState?) {
+        guard let state else {
+            self = .notBuilt
+            return
+        }
+        if state.failure != nil {
+            self = .failed
+        } else if state.needsAttention {
+            self = .attention
+        } else {
+            self = .clean
+        }
+    }
+
+    /// One column wide, like every other dot in the list — `⑃` is the merge
+    /// glyph the integration banner already uses, so a clean checkout is
+    /// recognisable as one rather than as an idle agent.
+    var glyph: String {
+        switch self {
+        case .notBuilt:  return "◌"
+        case .clean:     return "⑃"
+        case .attention: return "!"
+        case .failed:    return "✕"
+        }
+    }
+
+    /// Shared with `AgentStatus.color`, so "wants you" and "broke" read the
+    /// same here as they do on every other row.
+    var color: NSColor {
+        switch self {
+        case .notBuilt:  return SemanticColors.subtle
+        case .clean:     return SemanticColors.idle
+        case .attention: return SemanticColors.attention
+        case .failed:    return SemanticColors.danger
+        }
+    }
+}

--- a/Sources/Core/IntegrationRunner.swift
+++ b/Sources/Core/IntegrationRunner.swift
@@ -39,7 +39,8 @@ struct IntegrationRunReport: Equatable {
         switch outcome {
         case .held(.dirtyWorktree, _): line += " · held · local edits"
         case .held(.movedHead, _): line += " · held · commits made here"
-        case .published, .unchanged, .failed: break
+        case .failed(let reason): line += " · failed · \(reason)"
+        case .published, .unchanged: break
         }
         return line
     }
@@ -66,7 +67,11 @@ struct IntegrationRunReport: Equatable {
             conflictedPaths: result.conflictedPaths,
             isHeld: held,
             heldPaths: heldPaths,
-            heldHead: heldHead
+            heldHead: heldHead,
+            failure: {
+                if case .failed(let reason) = outcome { return reason }
+                return nil
+            }()
         )
     }
 

--- a/Sources/Core/IntegrationStatusStore.swift
+++ b/Sources/Core/IntegrationStatusStore.swift
@@ -24,6 +24,25 @@ struct IntegrationPanelState: Codable, Equatable {
     /// Set instead of `heldPaths` when the hold was a commit made in the
     /// checkout rather than an uncommitted edit.
     var heldHead: String?
+    /// Why the round did not produce a result at all — git refused, the base is
+    /// unreachable, the checkout could not be made. Optional so state written
+    /// before this existed still decodes.
+    ///
+    /// Recorded rather than only reported, because a round that threw used to
+    /// write nothing: the last good round's line stayed on screen and First
+    /// Mate went on claiming an integration that no longer existed.
+    var failure: String?
+
+    /// The last round did not land cleanly: work was dropped or left carrying
+    /// markers, the result was built but held back, or the round failed
+    /// outright.
+    ///
+    /// This is what First Mate marks. A clean round is meant to be invisible —
+    /// the integration worktree is simply current — so the marker means "this
+    /// one wants a person", not "integration happened".
+    var needsAttention: Bool {
+        failure != nil || isHeld || !excluded.isEmpty || !conflictedPaths.isEmpty
+    }
 
     struct Excluded: Codable, Equatable {
         var label: String
@@ -31,7 +50,8 @@ struct IntegrationPanelState: Codable, Equatable {
     }
 
     init(line: String, included: [String], excluded: [Excluded], conflictedPaths: [String],
-         isHeld: Bool, heldPaths: [String]? = nil, heldHead: String? = nil) {
+         isHeld: Bool, heldPaths: [String]? = nil, heldHead: String? = nil,
+         failure: String? = nil) {
         self.line = line
         self.included = included
         self.excluded = excluded
@@ -39,6 +59,14 @@ struct IntegrationPanelState: Codable, Equatable {
         self.isHeld = isHeld
         self.heldPaths = heldPaths
         self.heldHead = heldHead
+        self.failure = failure
+    }
+
+    /// What a round that never ran leaves behind, so the banner stops showing
+    /// the last good round.
+    static func failed(_ reason: String) -> IntegrationPanelState {
+        IntegrationPanelState(line: "integration · failed · \(reason)", included: [], excluded: [],
+                              conflictedPaths: [], isHeld: false, failure: reason)
     }
 }
 

--- a/Sources/Core/PendingOrdersQueue.swift
+++ b/Sources/Core/PendingOrdersQueue.swift
@@ -130,43 +130,51 @@ final class PendingOrdersQueue {
         if changed { notify() }
     }
 
+    /// Every removal goes through here, so a card that leaves the queue takes
+    /// its chat buttons with it.
+    ///
+    /// A card mirrored to a phone leaves a message that keeps its keyboard for
+    /// as long as the chat exists. Stripping the buttons off that message is
+    /// best effort and races a tap already in flight; retiring the tokens is
+    /// not — it is the one thing that makes a tap on an answered card inert
+    /// instead of typing the option into the pane a second time.
+    @discardableResult
+    private func remove(where predicate: (PendingOrder) -> Bool) -> Bool {
+        let dropped = orders.filter(predicate)
+        guard !dropped.isEmpty else { return false }
+        orders.removeAll(where: predicate)
+        for order in dropped { ChatCallbackRegistry.shared.retire(orderId: order.id) }
+        notify()
+        return true
+    }
+
     /// Drop a pane's open suggestion without acting on it. Returns whether
     /// anything went, so a remote caller can tell "declined" from "already gone".
     @discardableResult
     func dismissSuggestion(terminalID: String) -> Bool {
-        let before = orders.count
-        orders.removeAll { $0.action.kind == .suggestNextOrder && $0.action.terminalID == terminalID }
-        guard orders.count != before else { return false }
-        notify()
-        return true
+        remove { $0.action.kind == .suggestNextOrder && $0.action.terminalID == terminalID }
     }
 
     func all() -> [PendingOrder] { orders }
 
     func resolve(id: String) {
-        let before = orders.count
-        orders.removeAll { $0.id == id }
-        if orders.count != before { notify() }
+        remove { $0.id == id }
     }
 
     /// Remove the pending AskUserQuestion card for the given pane — its agent moved
     /// past the question (it was answered in the TUI), so the card is stale.
     /// Pane-scoped: a sibling pane's unanswered question must survive.
     func resolveQuestion(terminalID: String) {
-        let before = orders.count
-        orders.removeAll {
+        remove {
             FirstMateAction.isQuestionPayload($0.action.payload)
                 && $0.action.terminalID == terminalID
         }
-        if orders.count != before { notify() }
     }
 
     /// Remove the pending suggest order for the given pane. Pane-scoped: typing in
     /// one pane must not clear a sibling pane's suggestions.
     func resolveSuggest(terminalID: String) {
-        let before = orders.count
-        orders.removeAll { $0.action.kind == .suggestNextOrder && $0.action.terminalID == terminalID }
-        if orders.count != before { notify() }
+        remove { $0.action.kind == .suggestNextOrder && $0.action.terminalID == terminalID }
     }
 
     /// Drop every card belonging to a pane that is gone — closed, or its agent
@@ -180,9 +188,7 @@ final class PendingOrdersQueue {
     /// one pane's death from sweeping them away.
     func resolvePane(terminalID: String) {
         guard !terminalID.isEmpty else { return }
-        let before = orders.count
-        orders.removeAll { $0.action.terminalID == terminalID }
-        if orders.count != before { notify() }
+        remove { $0.action.terminalID == terminalID }
     }
 
     /// Drop every card for a worktree that is gone. Used when a whole worktree is
@@ -190,8 +196,6 @@ final class PendingOrdersQueue {
     /// worktree-scoped cards `resolvePane` deliberately spares.
     func resolveWorktree(path: String) {
         guard !path.isEmpty else { return }
-        let before = orders.count
-        orders.removeAll { $0.action.worktreePath == path }
-        if orders.count != before { notify() }
+        remove { $0.action.worktreePath == path }
     }
 }

--- a/Sources/Core/TelegramBotAPI.swift
+++ b/Sources/Core/TelegramBotAPI.swift
@@ -27,6 +27,16 @@ struct TelegramChat: Decodable, Equatable {
     var isPrivate: Bool { type == "private" }
 }
 
+/// The slice of a message the bridge needs when it is the *target* of a reply.
+///
+/// Not a `TelegramMessage`: a value type cannot contain itself, and the only
+/// question ever asked of a reply target is who sent it — replying to the
+/// bot's own message is how you address it in a group without typing its name.
+struct TelegramReplyTarget: Decodable, Equatable {
+    let messageId: Int
+    let from: TelegramUser?
+}
+
 struct TelegramMessage: Decodable, Equatable {
     let messageId: Int
     /// Unix seconds.
@@ -39,15 +49,40 @@ struct TelegramMessage: Decodable, Equatable {
     let text: String?
     /// A photo or document sent with a note carries the note here, not in `text`.
     let caption: String?
+    /// The message this one replies to, when it replies to anything.
+    let replyToMessage: TelegramReplyTarget?
+
+    init(messageId: Int, date: TimeInterval, chat: TelegramChat, from: TelegramUser?,
+         senderChat: TelegramChat?, text: String?, caption: String?,
+         replyToMessage: TelegramReplyTarget? = nil) {
+        self.messageId = messageId
+        self.date = date
+        self.chat = chat
+        self.from = from
+        self.senderChat = senderChat
+        self.text = text
+        self.caption = caption
+        self.replyToMessage = replyToMessage
+    }
 
     var body: String? { text ?? caption }
     var timestamp: Date { Date(timeIntervalSince1970: date) }
+}
+
+/// Someone tapped an inline button. `data` is the token the button carried out;
+/// `message` is the one it hangs under, so the buttons can be taken off it.
+struct TelegramCallbackQuery: Decodable, Equatable {
+    let id: String
+    let from: TelegramUser
+    let message: TelegramMessage?
+    let data: String?
 }
 
 struct TelegramUpdate: Decodable, Equatable {
     let updateId: Int
     let message: TelegramMessage?
     let channelPost: TelegramMessage?
+    let callbackQuery: TelegramCallbackQuery?
 
     /// The one kind of payload the bridge acts on. Edits, reactions and the
     /// rest are deliberately not requested (`allowedUpdates`), so they never
@@ -84,7 +119,7 @@ private struct LenientUpdate: Decodable {
         }
         let c = try decoder.container(keyedBy: CodingKeys.self)
         update = TelegramUpdate(updateId: try c.decode(Int.self, forKey: .updateId),
-                                message: nil, channelPost: nil)
+                                message: nil, channelPost: nil, callbackQuery: nil)
     }
 }
 
@@ -189,8 +224,10 @@ final class TelegramBotAPI {
             "timeout": timeout,
             "limit": limit,
             // Only what the bridge acts on. Asking for less also means a bot
-            // added to a busy group is not woken for every reaction.
-            "allowed_updates": ["message", "channel_post"],
+            // added to a busy group is not woken for every reaction. A button
+            // tap is a `callback_query` and arrives on no other channel — leave
+            // it out and the inline keyboards below are decorative.
+            "allowed_updates": ["message", "channel_post", "callback_query"],
         ]
         if let offset { params["offset"] = offset }
         let lenient: [LenientUpdate] = try call("getUpdates", params: params,
@@ -200,7 +237,13 @@ final class TelegramBotAPI {
 
     /// `parseMode` is `"HTML"` or nil for plain text. Callers chunk to
     /// `TelegramFormatter.maxMessageLength` first; this sends one message.
-    func sendMessage(chatId: String, text: String, parseMode: String?) throws {
+    ///
+    /// `buttons` become a one-per-row inline keyboard. Returns the sent
+    /// message's id, which is what a later `editMessageReplyMarkup` needs to
+    /// take those buttons off again.
+    @discardableResult
+    func sendMessage(chatId: String, text: String, parseMode: String?,
+                     buttons: [MessageButton] = []) throws -> Int {
         var params: [String: Any] = [
             "chat_id": chatId,
             "text": text,
@@ -209,7 +252,56 @@ final class TelegramBotAPI {
             "link_preview_options": ["is_disabled": true],
         ]
         if let parseMode { params["parse_mode"] = parseMode }
-        let _: TelegramMessage = try call("sendMessage", params: params, deadline: Self.stallSeconds)
+        if !buttons.isEmpty {
+            params["reply_markup"] = ["inline_keyboard": Self.keyboard(buttons)]
+        }
+        let sent: TelegramMessage = try call("sendMessage", params: params, deadline: Self.stallSeconds)
+        return sent.messageId
+    }
+
+    /// One button per row: an option is a sentence, and Telegram truncates a
+    /// row it cannot fit rather than wrapping it.
+    static func keyboard(_ buttons: [MessageButton]) -> [[[String: String]]] {
+        buttons.map { [["text": trimLabel($0.label), "callback_data": $0.token]] }
+    }
+
+    /// Telegram's own cap is generous but a button wider than the phone reads
+    /// as a wall of text. Cut on a whole character, keeping the front, which is
+    /// where an option says what it does.
+    static func trimLabel(_ label: String, limit: Int = 48) -> String {
+        let flat = label.replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard flat.count > limit else { return flat }
+        return String(flat.prefix(limit - 1)) + "\u{2026}"
+    }
+
+    /// Stop the spinner on the tapper's phone, optionally with a toast.
+    ///
+    /// Telegram shows a button as pending until this lands, so it is answered
+    /// even when the tap turned out to be stale: an unanswered query reads as
+    /// the bot having died mid-tap.
+    func answerCallbackQuery(id: String, text: String?) throws {
+        var params: [String: Any] = ["callback_query_id": id]
+        if let text, !text.isEmpty { params["text"] = String(text.prefix(200)) }
+        let _: Bool = try call("answerCallbackQuery", params: params, deadline: Self.stallSeconds)
+    }
+
+    /// Put a keyboard on a message already sent, or take one off with `[]`.
+    ///
+    /// Both directions matter. An answered card must stop offering its options
+    /// — the message stays in the chat's history forever and a second tap would
+    /// drive the pane's TUI again — and an agent's suggested next steps arrive
+    /// a beat after the completion notice they belong under, so they are added
+    /// to that message rather than sent as a second one saying the same words.
+    func setReplyMarkup(chatId: String, messageId: Int, buttons: [MessageButton]) throws {
+        var params: [String: Any] = ["chat_id": chatId, "message_id": messageId]
+        if !buttons.isEmpty {
+            params["reply_markup"] = ["inline_keyboard": Self.keyboard(buttons)]
+        }
+        // Editing a chat message answers with the edited message, not `true`
+        // — that shape is only for inline-mode messages, which this is not.
+        let _: TelegramMessage = try call("editMessageReplyMarkup", params: params,
+                                          deadline: Self.stallSeconds)
     }
 
     /// Publish the verb table to Telegram, so typing `/` in the chat lists the

--- a/Sources/Core/TelegramChannel.swift
+++ b/Sources/Core/TelegramChannel.swift
@@ -47,6 +47,14 @@ final class TelegramChannel: ExternalChannel {
     /// the config names no chat and no allowed user is numeric.
     private var lastCommandChatId: String?
 
+    /// Where unbound fleet notifications go: configured default, else the chat
+    /// that last issued an order.
+    var fleetNotifyChatId: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return config.resolvedDefaultChatId ?? lastCommandChatId
+    }
+
     private static let maxBackoff: TimeInterval = 30
     /// Attempts per outbound chunk before the rest of the message is abandoned.
     private static let sendAttempts = 3

--- a/Sources/Core/TelegramChannel.swift
+++ b/Sources/Core/TelegramChannel.swift
@@ -16,6 +16,7 @@ final class TelegramChannel: ExternalChannel {
     let channelId: String
     let channelType: ExternalChannelType = .telegram
     var onMessage: ((InboundMessage) -> Void)?
+    var onCallback: ((InboundCallback) -> Void)?
     var onStateChange: ((GatewayState) -> Void)?
 
     private var config: TelegramConfig
@@ -111,6 +112,13 @@ final class TelegramChannel: ExternalChannel {
     }
 
     func send(_ message: OutboundMessage) {
+        send(message, completion: nil)
+    }
+
+    /// `completion` reports the id of the message that carries the buttons —
+    /// the last chunk — so a caller can come back and change them later. It
+    /// fires with nil when nothing was sent.
+    func send(_ message: OutboundMessage, completion: ((String?) -> Void)?) {
         lock.lock()
         let cfg = config
         let api = self.api
@@ -120,6 +128,7 @@ final class TelegramChannel: ExternalChannel {
 
         guard let api else {
             NSLog("[Telegram] Dropping outbound: bridge not connected")
+            completion?(nil)
             return
         }
 
@@ -133,6 +142,7 @@ final class TelegramChannel: ExternalChannel {
 
         guard let target, !target.isEmpty else {
             NSLog("[Telegram] Dropping outbound: no recipient configured")
+            completion?(nil)
             return
         }
 
@@ -140,47 +150,85 @@ final class TelegramChannel: ExternalChannel {
         let rendered = parseMode == nil ? message.content : TelegramFormatter.html(from: message.content)
 
         sendQueue.async { [weak self] in
-            guard let self else { return }
+            guard let self else {
+                completion?(nil)
+                return
+            }
             let chunks = TelegramFormatter.chunk(rendered)
+            var lastId: Int?
             for (index, chunk) in chunks.enumerated() {
-                guard self.sendChunk(api: api, target: target, chunk: chunk, parseMode: parseMode) else {
+                // The keyboard belongs to the end of what it is about: on a
+                // long card, the options must sit under the last screenful,
+                // not three messages above it. That last chunk is also the one
+                // reported back, for the same reason.
+                let buttons = index == chunks.count - 1 ? message.buttons : []
+                guard let id = self.sendChunk(api: api, target: target, chunk: chunk,
+                                              parseMode: parseMode, buttons: buttons) else {
                     // Say how much was lost. A long answer that stops mid-way
                     // with nothing to mark the cut reads as the agent having
                     // said only that much.
                     NSLog("[Telegram] Gave up with \(chunks.count - index) of \(chunks.count) chunk(s) unsent")
+                    completion?(nil)
                     return
                 }
+                lastId = id
             }
+            completion?(lastId.map(String.init))
         }
     }
 
     /// One chunk, retried. A multi-part answer that loses its second part to a
     /// transient network error is worse than one that arrives late: the reader
     /// gets a truncated message and nothing tells them it was cut.
-    private func sendChunk(api: TelegramBotAPI, target: String, chunk: String, parseMode: String?) -> Bool {
+    /// The sent message's id, or nil if the chunk was lost.
+    private func sendChunk(api: TelegramBotAPI, target: String, chunk: String, parseMode: String?,
+                          buttons: [MessageButton] = []) -> Int? {
         for attempt in 1...Self.sendAttempts {
             do {
-                try api.sendMessage(chatId: target, text: chunk, parseMode: parseMode)
+                let id = try api.sendMessage(chatId: target, text: chunk, parseMode: parseMode,
+                                             buttons: buttons)
                 NSLog("[Telegram] → \(target): \(chunk.count) chars")
-                return true
+                return id
             } catch let error as TelegramAPIError where error.isBadRequest && parseMode != nil {
                 // Telegram is strict about its HTML. Rather than lose the
                 // message over a stray tag, resend the same words flat.
                 do {
-                    try api.sendMessage(chatId: target, text: TelegramFormatter.stripHTML(chunk), parseMode: nil)
-                    return true
+                    return try api.sendMessage(chatId: target, text: TelegramFormatter.stripHTML(chunk),
+                                               parseMode: nil, buttons: buttons)
                 } catch {
                     NSLog("[Telegram] Send failed (flat): \(error.localizedDescription)")
-                    return false
+                    return nil
                 }
             } catch TelegramAPIError.cancelled {
-                return false
+                return nil
             } catch {
                 NSLog("[Telegram] Send attempt \(attempt)/\(Self.sendAttempts) failed: \(error.localizedDescription)")
                 if attempt < Self.sendAttempts { Thread.sleep(forTimeInterval: Self.sendRetryDelay) }
             }
         }
-        return false
+        return nil
+    }
+
+    /// Put the buttons on a message already sent, or take them off with `[]`.
+    ///
+    /// Best effort: a message Telegram will not let us edit (too old, deleted,
+    /// or already carrying exactly this keyboard) is not worth a retry — for
+    /// the taking-off direction `ChatCallbackRegistry` has already made the
+    /// buttons inert, and for the putting-on direction the options are still
+    /// in the message's own text.
+    func setButtons(chatId: String, messageId: String, buttons: [MessageButton]) {
+        guard let id = Int(messageId) else { return }
+        lock.lock()
+        let api = self.api
+        lock.unlock()
+        guard let api else { return }
+        sendQueue.async {
+            do {
+                try api.setReplyMarkup(chatId: chatId, messageId: id, buttons: buttons)
+            } catch {
+                NSLog("[Telegram] Could not set buttons on \(chatId)/\(id): \(error.localizedDescription)")
+            }
+        }
     }
 
     // MARK: - Config
@@ -235,7 +283,11 @@ final class TelegramChannel: ExternalChannel {
             lock.unlock()
             for update in updates {
                 offset = max(offset ?? 0, update.updateId + 1)
-                if let message = update.payload { handle(message, config: live) }
+                if let message = update.payload {
+                    handle(message, config: live)
+                } else if let callback = update.callbackQuery {
+                    handle(callback: callback, config: live)
+                }
             }
         }
     }
@@ -385,6 +437,45 @@ final class TelegramChannel: ExternalChannel {
                              content: markdown, format: .markdown))
     }
 
+    /// Someone tapped a button on a card the bridge sent.
+    ///
+    /// The tap is answered here and immediately — Telegram spins the button
+    /// until it is, and an unanswered query reads as the bot having died
+    /// mid-tap — while what the button *means* is resolved upstairs, where the
+    /// fleet is. The outcome comes back as an ordinary message rather than a
+    /// toast: on a card that moved an agent, "which option did I pick" is worth
+    /// keeping in the chat, and a toast is gone the moment you look away.
+    private func handle(callback: TelegramCallbackQuery, config cfg: TelegramConfig) {
+        lock.lock()
+        let api = self.api
+        lock.unlock()
+
+        guard cfg.allows(user: callback.from) else {
+            NSLog("[Telegram] Ignoring button tap from unlisted user \(callback.from.displayName) (\(callback.from.id))")
+            try? api?.answerCallbackQuery(id: callback.id, text: "Not for you.")
+            return
+        }
+        try? api?.answerCallbackQuery(id: callback.id, text: nil)
+
+        guard let token = callback.data, !token.isEmpty, let message = callback.message else { return }
+        let chatId = String(message.chat.id)
+
+        lock.lock()
+        chatIdBySender[String(callback.from.id)] = chatId
+        lastCommandChatId = chatId
+        lock.unlock()
+
+        NSLog("[Telegram] ← \(callback.from.displayName) tapped \(token) in \(chatId)")
+        onCallback?(InboundCallback(
+            channelId: channelId,
+            senderId: String(callback.from.id),
+            senderName: callback.from.displayName,
+            chatId: chatId,
+            messageId: String(message.messageId),
+            token: token
+        ))
+    }
+
     /// A message that is not an order may still be work: a monitoring channel
     /// the bot was added to, a colleague in a group, a stranger asking. Run it
     /// past the rules and, on a match, hand the rendered prompt up as an
@@ -437,8 +528,12 @@ final class TelegramChannel: ExternalChannel {
     ///    never be orders, only signals.
     /// 2. **Chat** — in a private chat with the bot everything is an order,
     ///    prose included, because there is nobody else to be talking to. In a
-    ///    group only a `/command` is: bare prose there is conversation, and a
-    ///    stray line in a shared group must not steer an agent.
+    ///    group it must be *addressed to the bot*: a `/command`, a line
+    ///    starting `@thebot`, or a reply to something the bot itself said.
+    ///    What stays out is bare prose — a stray line in a shared group must
+    ///    not steer an agent — and that is the only thing the group rule was
+    ///    ever protecting. Naming the bot is as deliberate as a slash, so
+    ///    refusing it only taught people that the bot was broken in groups.
     ///
     /// No echo guard is needed. The bot's own messages never come back as
     /// updates — that was the whole trouble with a transport that shared the
@@ -459,8 +554,40 @@ final class TelegramChannel: ExternalChannel {
         }
 
         let body = stripBotMention(text, botUsername: botUsername)
-        guard message.chat.isPrivate || body.hasPrefix("/") else { return nil }
-        return Command(body: body, senderId: String(from.id), senderName: from.displayName)
+        if message.chat.isPrivate || body.hasPrefix("/") {
+            return Command(body: body, senderId: String(from.id), senderName: from.displayName)
+        }
+        guard let addressed = addressedProse(body, message: message, botUsername: botUsername) else {
+            return nil
+        }
+        return Command(body: addressed, senderId: String(from.id), senderName: from.displayName)
+    }
+
+    /// Group prose aimed at the bot, with the address taken off; nil when the
+    /// line was not aimed at it.
+    ///
+    /// Telegram gives a room two ways to talk *to* a bot rather than about it,
+    /// and both are explicit enough to carry an order:
+    ///
+    ///   - a leading `@thebot` — what Telegram's own mention autocomplete
+    ///     inserts, and stripped here so the agent is not handed its own name;
+    ///   - a reply to one of the bot's messages, which is how you answer a
+    ///     card or follow up on an agent's report without naming anyone.
+    ///
+    /// A mention with nothing after it is not an order: it is someone typing
+    /// the bot's name, usually about it.
+    static func addressedProse(_ body: String, message: TelegramMessage, botUsername: String?) -> String? {
+        guard let name = botUsername, !name.isEmpty else { return nil }
+        let mention = "@\(name)"
+        if body.lowercased().hasPrefix(mention.lowercased()) {
+            let rest = String(body.dropFirst(mention.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+            return rest.isEmpty ? nil : rest
+        }
+        if let replied = message.replyToMessage?.from?.username,
+           replied.lowercased() == name.lowercased() {
+            return body
+        }
+        return nil
     }
 
     /// `/status@seahelm_bot` is how Telegram disambiguates commands in a group

--- a/Sources/Status/NotificationManager.swift
+++ b/Sources/Status/NotificationManager.swift
@@ -421,8 +421,19 @@ class NotificationManager: NSObject {
     /// The AgentRegistry broadcast this replaced had none of those, and never fired on
     /// completion at all.
     ///
+    /// Fires on every edge that earns a banner, whether or not the banner is
+    /// actually shown, and reports which via `bannerSuppressed`. Suppression is
+    /// a statement about *this screen* — the pane is on it, frontmost — and the
+    /// phone is not this screen: a chat that bound itself to the pane with
+    /// `/go #n` asked for its answers from somewhere else and must still get
+    /// them. Deciding it here would silence that chat too, which is the bug
+    /// where an order sent from Telegram was answered only in the terminal the
+    /// sender happened to be sitting in front of. The receiver draws the line
+    /// between a bound conversation and a fleet-wide listener.
+    ///
     /// Set by MainWindowController; nil in tests and headless runs.
-    var onDeliverExternal: ((_ status: AgentStatus, _ title: String, _ subtitle: String, _ body: String, _ terminalID: String) -> Void)?
+    var onDeliverExternal: ((_ status: AgentStatus, _ title: String, _ subtitle: String, _ body: String,
+                             _ terminalID: String, _ bannerSuppressed: Bool) -> Void)?
 
     /// Whether a suggestion card for this pane is already expanded on screen (the
     /// island popped open with it). Set by MainWindowController; nil in tests and
@@ -649,21 +660,24 @@ class NotificationManager: NSObject {
         // expanded showing this pane's suggestion card (the same completion,
         // rendered with the buttons that act on it).
         let cardOnScreen = !terminalID.isEmpty && isCardOnScreen?(terminalID) == true
-        if Self.shouldSuppressBanner(appActive: NSApp.isActive,
-                                     targetVisible: isTargetVisible,
-                                     cardOnScreen: cardOnScreen) { return }
+        let bannerSuppressed = Self.shouldSuppressBanner(appActive: NSApp.isActive,
+                                                         targetVisible: isTargetVisible,
+                                                         cardOnScreen: cardOnScreen)
 
         // Mirror the banner, not the history entry: this fires on exactly the
-        // edges that earn a banner, and is skipped by the return above when the
-        // user is already looking at the pane — a phone ping for something on
-        // screen in front of them is noise.
+        // edges that earn a banner, so the chat inherits the same gating. It is
+        // handed the suppression flag rather than gated by it — see the
+        // property's note: a chat bound to this pane hears it even while the
+        // pane is on screen, a fleet-wide listener still yields to the screen.
         onDeliverExternal?(newStatus, content.title, content.subtitle,
                            Self.formatExternalBody(status: newStatus,
                                                    workspaceName: workspaceName,
                                                    branch: branch,
                                                    lastMessage: lastMessage,
                                                    lastAssistantMessage: lastAssistantMessage),
-                           terminalID)
+                           terminalID, bannerSuppressed)
+
+        if bannerSuppressed { return }
 
         var userInfo: [String: Any] = ["worktreePath": worktreePath]
         if let historyPaneIndex { userInfo["paneIndex"] = historyPaneIndex }

--- a/Sources/Terminal/PaneWorkingDirectory.swift
+++ b/Sources/Terminal/PaneWorkingDirectory.swift
@@ -1,0 +1,76 @@
+import Darwin
+import Foundation
+
+/// Where a new pane opens.
+///
+/// A split inherits the directory the pane it came from is *in*. The worktree
+/// root — the old answer — is only that directory until someone cds, and then
+/// every split lands somewhere the user has to leave again (issue #27). This is
+/// also what every other terminal does, so it is the behaviour people arrive
+/// with.
+///
+/// The pane's own worktree is unchanged by any of this: a pane is filed under
+/// the worktree it was split from, wherever its shell happens to be standing.
+enum PaneWorkingDirectory {
+    /// The ladder, most authoritative first. Pure — `exists` is injected so the
+    /// order can be tested without a filesystem.
+    ///
+    /// The kernel outranks OSC 7 because it cannot be stale: `pwd` is whatever
+    /// the shell last chose to report, and a shell that never reports (bash with
+    /// no hook, anything inside a multiplexer that swallows the sequence)
+    /// reports nothing at all. Both outrank the directory the pane was *created*
+    /// in, which is the thing being fixed.
+    static func choose(probed: String?, oscPwd: String?, initial: String?, worktreePath: String,
+                       exists: (String) -> Bool = Self.directoryExists) -> String {
+        for candidate in [probed, oscPwd, initial] {
+            guard let candidate else { continue }
+            let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty, exists(trimmed) { return trimmed }
+        }
+        return worktreePath
+    }
+
+    /// Everything the ladder needs about a live pane.
+    static func resolve(station: Station?, worktreePath: String) -> String {
+        choose(probed: station?.paneSessionKey.flatMap(probeSessionCwd),
+               oscPwd: station?.pwd,
+               initial: station?.initialWorkingDirectory,
+               worktreePath: worktreePath)
+    }
+
+    /// The working directory of a zmx session's shell — the one `pwd` would
+    /// print in that pane.
+    ///
+    /// Costs one `zmx list` (a few milliseconds) and one syscall, paid once per
+    /// split rather than on the status poll: it is the only moment anyone needs
+    /// the answer, and reading it per pane per cycle would be work nothing looks
+    /// at.
+    static func probeSessionCwd(paneSessionKey: String) -> String? {
+        guard !paneSessionKey.isEmpty,
+              let listing = ProcessRunner.output([ZmxLocator.executable(), "list"]),
+              let pid = ProcessProbe.sessionPid(paneSessionKey: paneSessionKey,
+                                                zmxListOutput: listing) else { return nil }
+        return cwd(ofPid: pid)
+    }
+
+    /// A process's current directory, straight from the kernel. Nil when the
+    /// process is gone or refuses to say — a hardened binary, another user's.
+    static func cwd(ofPid pid: Int32) -> String? {
+        var info = proc_vnodepathinfo()
+        let size = MemoryLayout<proc_vnodepathinfo>.size
+        let read = withUnsafeMutablePointer(to: &info) {
+            proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, $0, Int32(size))
+        }
+        guard read == Int32(size) else { return nil }
+        let path = withUnsafePointer(to: &info.pvi_cdir.vip_path) {
+            $0.withMemoryRebound(to: CChar.self, capacity: Int(MAXPATHLEN)) { String(cString: $0) }
+        }
+        return path.isEmpty ? nil : path
+    }
+
+    static func directoryExists(_ path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+    }
+}

--- a/Sources/UI/Dashboard/DashboardOverviewView.swift
+++ b/Sources/UI/Dashboard/DashboardOverviewView.swift
@@ -110,6 +110,10 @@ final class DashboardOverviewView: NSView {
     /// without writing into the user's real config directory.
     private let isIntegrationWorktree: (String) -> Bool
     private let integrationStatus: (String) -> String?
+    /// The whole of the last round, for the one thing the line cannot carry:
+    /// whether it wants a person. Sniffing that out of the text would make the
+    /// marker depend on wording.
+    private let integrationState: (String) -> IntegrationPanelState?
     /// Master switch, pushed down from settings. Off hides the button, the
     /// banner and the pinned row — the checkout on disk is left alone.
     var integrationEnabled: Bool = true {
@@ -124,7 +128,7 @@ final class DashboardOverviewView: NSView {
     }
     private let integrationBanner = NSStackView()
     private var integrationBannerHeight: NSLayoutConstraint!
-    private var integrationBannerLines: [String] = []
+    private var integrationBannerLines: [IntegrationBannerLine] = []
     private static let addWorktreeButtonIdentifier = NSUserInterfaceItemIdentifier("seahelm.addWorktree")
     private static let integrateButtonIdentifier = NSUserInterfaceItemIdentifier("seahelm.integrate")
     private static let closeProjectButtonIdentifier = NSUserInterfaceItemIdentifier("seahelm.closeProject")
@@ -147,6 +151,7 @@ final class DashboardOverviewView: NSView {
         now = Date.init
         isIntegrationWorktree = { IntegrationWorktreeStore.shared.isIntegrationWorktree($0) }
         integrationStatus = { IntegrationStatusStore.shared.status(forWorktree: $0) }
+        integrationState = { IntegrationStatusStore.shared.state(forWorktree: $0) }
         groupingMode = preference.load()
         super.init(frame: frameRect)
         setup()
@@ -157,6 +162,7 @@ final class DashboardOverviewView: NSView {
         now = Date.init
         isIntegrationWorktree = { IntegrationWorktreeStore.shared.isIntegrationWorktree($0) }
         integrationStatus = { IntegrationStatusStore.shared.status(forWorktree: $0) }
+        integrationState = { IntegrationStatusStore.shared.state(forWorktree: $0) }
         groupingMode = preference.load()
         super.init(coder: coder)
         setup()
@@ -167,13 +173,15 @@ final class DashboardOverviewView: NSView {
         defaults: UserDefaults,
         now: @escaping () -> Date,
         isIntegrationWorktree: @escaping (String) -> Bool = { IntegrationWorktreeStore.shared.isIntegrationWorktree($0) },
-        integrationStatus: @escaping (String) -> String? = { IntegrationStatusStore.shared.status(forWorktree: $0) }
+        integrationStatus: @escaping (String) -> String? = { IntegrationStatusStore.shared.status(forWorktree: $0) },
+        integrationState: @escaping (String) -> IntegrationPanelState? = { IntegrationStatusStore.shared.state(forWorktree: $0) }
     ) {
         let preference = WorktreeGroupingPreference(defaults: defaults)
         groupingPreference = preference
         self.now = now
         self.isIntegrationWorktree = isIntegrationWorktree
         self.integrationStatus = integrationStatus
+        self.integrationState = integrationState
         groupingMode = preference.load()
         super.init(frame: frameRect)
         setup()
@@ -276,15 +284,18 @@ final class DashboardOverviewView: NSView {
     /// path, because the line changes far more often than the fleet's structure
     /// does — that is the whole reason it lives outside `stack`.
     private func refreshIntegrationBanner(_ panes: [WorktreeRowInfo]) {
-        let checkouts = integrationEnabled && (groupingMode == .status || groupingMode == .activityTime)
-            ? panes.filter { isIntegrationWorktree($0.worktreePath) }
+        let checkouts = integrationEnabled
+            ? Self.bannerPaths(checkouts: panes.filter { isIntegrationWorktree($0.worktreePath) },
+                               mode: groupingMode)
             : []
 
-        // Compare the rendered text, not the paths: the line changes far more
+        // Compare the rendered lines, not the paths: the line changes far more
         // often than the set of checkouts does, and rebuilding labels on every
         // poll would churn views for nothing.
-        let lines = checkouts.map { checkout in
-            "⑃  " + (integrationStatus(checkout.worktreePath) ?? "integration · not built yet")
+        let lines = checkouts.map {
+            Self.bannerLine(project: $0.project,
+                            status: integrationStatus($0.worktreePath),
+                            needsAttention: integrationState($0.worktreePath)?.needsAttention ?? false)
         }
         guard lines != integrationBannerLines else { return }
         integrationBannerLines = lines
@@ -296,13 +307,55 @@ final class DashboardOverviewView: NSView {
         }
 
         for line in lines {
-            let label = NSTextField(labelWithString: line)
+            let label = NSTextField(labelWithString: line.text)
             label.font = AppFont.mono(size: 11)
-            label.textColor = Self.inkDim
+            // Colour *and* a different glyph. A marker carried by colour alone
+            // is no marker on a display, or a pair of eyes, that does not
+            // separate a dim teal from a warm one.
+            label.textColor = line.needsAttention ? SemanticColors.attention : Self.inkDim
             label.lineBreakMode = .byTruncatingTail
             integrationBanner.addArrangedSubview(label)
         }
         integrationBannerHeight.constant = CGFloat(lines.count) * 15 + CGFloat(max(0, lines.count - 1)) * 3
+    }
+
+    /// The integration state to draw on a checkout's row, or nil for an
+    /// ordinary worktree — whose dot means what it always did.
+    private func integrationRowStatus(_ item: WorktreeGroupingItem) -> IntegrationRowStatus? {
+        guard item.isIntegration else { return nil }
+        return IntegrationRowStatus(integrationState(item.path))
+    }
+
+    /// One banner line: what the round did, and whether it wants a person.
+    struct IntegrationBannerLine: Equatable {
+        let text: String
+        let needsAttention: Bool
+    }
+
+    /// Which checkouts the banner shows: the ones with no row of their own.
+    ///
+    /// Grouping by status or by activity leaves the checkout out of the list —
+    /// it has no agent, so it would dilute both — and the banner is the only
+    /// place it can be seen there. Everywhere else it has a row, whose dot now
+    /// carries the same state, and a banner on top of that would say it twice.
+    static func bannerPaths<T>(checkouts: [T], mode: WorktreeGroupingMode) -> [T] {
+        (mode == .status || mode == .activityTime) ? checkouts : []
+    }
+
+    /// `!` rather than `⑃` for a round that did not land: the two are one
+    /// column apart in a monospace list, which is what makes a marker findable
+    /// by scanning rather than by reading every line to the end.
+    ///
+    /// The project is named because this strip sits above the whole list rather
+    /// than inside a group. One repo's checkout floating over another repo's
+    /// header reads as that repo's, which is exactly the wrong thing for a line
+    /// whose whole job is to say something went wrong.
+    static func bannerLine(project: String, status: String?,
+                           needsAttention: Bool) -> IntegrationBannerLine {
+        let body = status ?? "integration · not built yet"
+        let named = project.isEmpty ? body : "\(project) · \(body)"
+        return IntegrationBannerLine(text: (needsAttention ? "!  " : "⑃  ") + named,
+                                     needsAttention: needsAttention)
     }
 
     /// Header: add a whole repo via the folder picker.
@@ -552,7 +605,7 @@ final class DashboardOverviewView: NSView {
                                   status: groupedItem.status,
                                   selected: groupedItem.id == selectedId,
                                   showsRepository: groupingMode != .repository,
-                                  isIntegration: groupedItem.isIntegration)
+                                  integration: integrationRowStatus(groupedItem))
                 row.onTap = { [weak self] path in self?.onSelectWorktree?(path) }
                 row.onDelete = { [weak self] path in self?.onDeleteWorktree?(path) }
                 row.onReturn = { [weak self] path in self?.onReturnWorktree?(path) }
@@ -641,7 +694,7 @@ final class DashboardOverviewView: NSView {
                 guard let pane = panesByPath[item.path] else { continue }
                 if let row = rowViewsByID[item.id] {
                     row.update(pane: pane, status: item.status, selected: item.id == selectedId,
-                               isIntegration: item.isIntegration)
+                               integration: integrationRowStatus(item))
                     row.setPending(pendingWorktreePaths.contains(pane.worktreePath))
                 }
                 if groupingMode == .pane, pane.panes.count > 1 {
@@ -760,6 +813,10 @@ final class DashboardOverviewView: NSView {
         integrationBanner.arrangedSubviews
             .compactMap { ($0 as? NSTextField)?.stringValue }
     }
+    /// Which of those lines are marked as wanting a person.
+    var integrationBannerAttentionForTesting: [Bool] {
+        integrationBannerLines.map(\.needsAttention)
+    }
     /// Project titles behind the rendered "integrate" buttons, in group order.
     var integrateProjectsForTesting: [String] {
         headerButtons(matching: Self.integrateButtonIdentifier)
@@ -785,6 +842,10 @@ final class DashboardOverviewView: NSView {
             .flatMap { $0.arrangedSubviews }
             .compactMap { $0 as? NSButton }
             .filter { $0.identifier == identifier }
+    }
+    /// The leading dot each rendered row is showing, keyed by worktree path.
+    var rowGlyphsForTesting: [String: String] {
+        rowViewsByID.mapValues(\.dotGlyphForTesting)
     }
     var renderedSelectedRowIDForTesting: String? { rowViewsByID[selectedId] == nil ? nil : selectedId }
     /// Ids of every row currently painting the hover tint — more than one means
@@ -1051,8 +1112,10 @@ final class DashboardOverviewView: NSView {
         /// `path` would open, reveal, and *delete* the worktree it used to be.
         private var path: String
         private var isMainWorktree: Bool
-        /// The repo's integration checkout, which gets a Reset in its menu.
-        private var isIntegration: Bool
+        /// Set on the repo's integration checkout: what its dot means instead of
+        /// an agent status, and the flag behind the Reset item in its menu.
+        private var integration: IntegrationRowStatus?
+        private var isIntegration: Bool { integration != nil }
         private var selected: Bool
         private let showsRepository: Bool
         private let staticDot: NSTextField
@@ -1107,13 +1170,14 @@ final class DashboardOverviewView: NSView {
         }
 
         init(pane: WorktreeRowInfo, status: AgentStatus, selected: Bool,
-             showsRepository: Bool, isIntegration: Bool = false) {
+             showsRepository: Bool, integration: IntegrationRowStatus? = nil) {
             self.path = pane.worktreePath
             self.isMainWorktree = pane.isMainWorktree
-            self.isIntegration = isIntegration
+            self.integration = integration
             self.selected = selected
             self.showsRepository = showsRepository
-            self.staticDot = Self.label(status.glyph, status.color, 8)
+            self.staticDot = Self.label(integration?.glyph ?? status.glyph,
+                                        integration?.color ?? status.color, 8)
             // The spinner is only ever visible while the row is `.running`, and it
             // now outlives the status it was built under (rows are reused across
             // incremental updates), so pin it to `.running`'s colour rather than
@@ -1252,15 +1316,17 @@ final class DashboardOverviewView: NSView {
             return result
         }
 
-        func update(pane: WorktreeRowInfo, status: AgentStatus, selected: Bool, isIntegration: Bool = false) {
+        func update(pane: WorktreeRowInfo, status: AgentStatus, selected: Bool,
+                    integration: IntegrationRowStatus? = nil) {
             path = pane.worktreePath
             isMainWorktree = pane.isMainWorktree
-            self.isIntegration = isIntegration
+            self.integration = integration
             setSelected(selected, animated: false)
             setAccessibilityLabel(pane.name)
             applyContent(pane: pane, status: status)
         }
 
+        var dotGlyphForTesting: String { staticDot.isHidden ? "◐" : staticDot.stringValue }
         var runtimeTextForTesting: String { timeLabel.stringValue }
         var titleTextForTesting: String { titleLabel.stringValue }
         var titleFrameForTesting: NSRect { titleLabel.frame }
@@ -1316,8 +1382,12 @@ final class DashboardOverviewView: NSView {
                 let color = ProjectColor.color(for: project)
                 if repositoryLabel.textColor != color { repositoryLabel.textColor = color }
             }
-            Self.setText(staticDot, status.glyph)
-            if staticDot.textColor != status.color { staticDot.textColor = status.color }
+            // The checkout's dot says what the last round did; every other row's
+            // says what its agent is doing.
+            let glyph = integration?.glyph ?? status.glyph
+            let color = integration?.color ?? status.color
+            Self.setText(staticDot, glyph)
+            if staticDot.textColor != color { staticDot.textColor = color }
             lastStatus = status
             applyDotVisibility()
         }
@@ -1330,7 +1400,10 @@ final class DashboardOverviewView: NSView {
                 if busySpinner.isHidden { busySpinner.isHidden = false }
             } else {
                 if !busySpinner.isHidden { busySpinner.isHidden = true }
-                let running = lastStatus == .running
+                // A shell left running in the checkout must not spin its dot:
+                // that dot is reporting the integration now, and a spinner
+                // would read as a round in flight.
+                let running = integration == nil && lastStatus == .running
                 if staticDot.isHidden != running { staticDot.isHidden = running }
                 if runningDot.isHidden != !running { runningDot.isHidden = !running }
             }

--- a/Tests/AgentRegistryExternalTests.swift
+++ b/Tests/AgentRegistryExternalTests.swift
@@ -7,6 +7,7 @@ final class MockExternalChannel: ExternalChannel {
     let channelType: ExternalChannelType = .telegram
     var gatewayState: GatewayState = .disconnected
     var onMessage: ((InboundMessage) -> Void)?
+    var onCallback: ((InboundCallback) -> Void)?
     var sentMessages: [OutboundMessage] = []
     var connectCalled = false
     var disconnectCalled = false

--- a/Tests/ChatNoticeBookTests.swift
+++ b/Tests/ChatNoticeBookTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import seahelm
+
+/// Where an agent's next-step options get attached.
+final class ChatNoticeBookTests: XCTestCase {
+    private let now = Date()
+
+    func testNewestNoticePerChatReplacesTheLast() {
+        var book = ChatNoticeBook()
+        book.record(pane: "t1", chatId: "c1", messageId: "10", at: now.addingTimeInterval(-30))
+        book.record(pane: "t1", chatId: "c1", messageId: "11", at: now)
+        // Options belong under the turn that just finished, not the one before it.
+        XCTAssertEqual(book.recent(pane: "t1", now: now).map(\.messageId), ["11"])
+    }
+
+    func testEveryChatToldAboutThePaneGetsItsOwnAnchor() {
+        var book = ChatNoticeBook()
+        book.record(pane: "t1", chatId: "c1", messageId: "10", at: now)
+        book.record(pane: "t1", chatId: "c2", messageId: "77", at: now)
+        XCTAssertEqual(Set(book.recent(pane: "t1", now: now).map(\.messageId)), ["10", "77"])
+    }
+
+    /// Panes do not share an anchor: a suggestion from one must not hang its
+    /// options under another's completion notice.
+    func testNoticesAreScopedToOnePane() {
+        var book = ChatNoticeBook()
+        book.record(pane: "t1", chatId: "c1", messageId: "10", at: now)
+        XCTAssertTrue(book.recent(pane: "t2", now: now).isEmpty)
+        XCTAssertTrue(book.recent(pane: "", now: now).isEmpty)
+    }
+
+    /// Past the window the chat has moved on, and buttons under a message the
+    /// reader has scrolled away from offer a next step for a finished turn.
+    func testANoticeStopsBeingAnAnchorOnceItIsOld() {
+        var book = ChatNoticeBook()
+        book.record(pane: "t1", chatId: "c1", messageId: "10",
+                    at: now.addingTimeInterval(-ChatNoticeBook.window - 1))
+        XCTAssertTrue(book.recent(pane: "t1", now: now).isEmpty)
+        // Still held until pruned — `recent` is the gate, `prune` is the cleanup.
+        XCTAssertFalse(book.isEmpty)
+        book.prune(now: now)
+        XCTAssertTrue(book.isEmpty)
+    }
+
+    /// A pane still being talked about survives the sweep.
+    func testPruneKeepsWhatIsStillAttachable() {
+        var book = ChatNoticeBook()
+        book.record(pane: "old", chatId: "c1", messageId: "1",
+                    at: now.addingTimeInterval(-ChatNoticeBook.window - 1))
+        book.record(pane: "new", chatId: "c1", messageId: "2", at: now)
+        book.prune(now: now)
+        XCTAssertTrue(book.recent(pane: "old", now: now).isEmpty)
+        XCTAssertEqual(book.recent(pane: "new", now: now).map(\.messageId), ["2"])
+    }
+}

--- a/Tests/ChatQuestionCardTests.swift
+++ b/Tests/ChatQuestionCardTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import seahelm
+
+/// The card an agent is blocked on, as it reaches a phone.
+final class ChatQuestionCardTests: XCTestCase {
+    func testCardNamesThePaneAndSpellsOutTheOptions() {
+        let text = MainWindowController.questionCardText(
+            handle: 12, project: "seahelm", branch: "main",
+            message: "Run the destructive migration?",
+            options: ["Yes, run it", "No, stop here"])
+        XCTAssertTrue(text.contains("#12 · seahelm / main"), text)
+        XCTAssertTrue(text.contains("Run the destructive migration?"), text)
+        // Numbered in the text as well as drawn as buttons: a button label is
+        // trimmed to fit a phone, and the difference between two options is
+        // often in the part that gets trimmed.
+        XCTAssertTrue(text.contains("1. Yes, run it"), text)
+        XCTAssertTrue(text.contains("2. No, stop here"), text)
+    }
+
+    /// A pane with no handle yet (a local pane seen for the first time) still
+    /// gets a readable card rather than a stray separator.
+    func testCardWithoutAHandleStillNamesTheWorktree() {
+        let text = MainWindowController.questionCardText(
+            handle: nil, project: "seahelm", branch: "main", message: "Pick one", options: ["a"])
+        XCTAssertTrue(text.contains("seahelm / main"), text)
+        XCTAssertFalse(text.contains("·"), text)
+    }
+
+    func testEachOptionGetsItsOwnRow() {
+        let rows = TelegramBotAPI.keyboard([
+            MessageButton(label: "Yes", token: "k1"),
+            MessageButton(label: "No", token: "k2"),
+        ])
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0], [["text": "Yes", "callback_data": "k1"]])
+        XCTAssertEqual(rows[1], [["text": "No", "callback_data": "k2"]])
+    }
+
+    /// A whole sentence of an option would be cut by Telegram at whatever width
+    /// the phone has; cutting it here keeps the ellipsis honest, and newlines
+    /// out of a label that has to render on one line.
+    func testLongLabelsAreTrimmedAndFlattened() {
+        let long = String(repeating: "ship it ", count: 20)
+        let trimmed = TelegramBotAPI.trimLabel(long)
+        XCTAssertEqual(trimmed.count, 48)
+        XCTAssertTrue(trimmed.hasSuffix("…"))
+        XCTAssertEqual(TelegramBotAPI.trimLabel("keep\nit\none line"), "keep it one line")
+    }
+}

--- a/Tests/CommandSessionStoreTests.swift
+++ b/Tests/CommandSessionStoreTests.swift
@@ -87,6 +87,41 @@ final class CommandSessionStoreTests: XCTestCase {
         try Data("{}".utf8).write(to: legacy)
         XCTAssertEqual(CommandSessionStore(url: url, legacyMailURL: legacy).session(for: "mail:thread-1").commander, "me@x.y")
     }
+
+    /// Unbound default chat hears every pane; after `/go` it only hears that pane.
+    func testTelegramNotifyRoutingRespectsGoBinding() {
+        let store = CommandSessionStore(url: nil, legacyMailURL: nil)
+        let me = "42"
+        // Unbound: fleet listener gets every event.
+        XCTAssertEqual(Set(store.telegramChatsToNotify(paneKey: "k16", fleetListenerChatIds: [me])), [me])
+        XCTAssertEqual(Set(store.telegramChatsToNotify(paneKey: "k9", fleetListenerChatIds: [me])), [me])
+
+        store.bind("telegram:\(me)", toPaneKey: "k16", paneId: "p16", worktreePath: "/w")
+        // Bound to #16: only #16 events.
+        XCTAssertEqual(Set(store.telegramChatsToNotify(paneKey: "k16", fleetListenerChatIds: [me])), [me])
+        XCTAssertTrue(store.telegramChatsToNotify(paneKey: "k9", fleetListenerChatIds: [me]).isEmpty)
+
+        // A group bound to the same pane still hears it; the personal chat does too.
+        store.bind("telegram:group99", toPaneKey: "k16", paneId: "p16", worktreePath: "/w")
+        XCTAssertEqual(Set(store.telegramChatsToNotify(paneKey: "k16", fleetListenerChatIds: [me])),
+                       Set([me, "group99"]))
+    }
+
+    /// The desk looking at a pane must not silence the chat that ordered it.
+    ///
+    /// When the pane is on screen and frontmost the banner is suppressed, and
+    /// with it the fleet-wide listeners — `fleetListenerChatIds` arrives empty.
+    /// A chat bound with `/go` still hears its pane: it sent the order from a
+    /// phone that is not looking at this screen, and its answer used to be lost
+    /// entirely, delivered only to the terminal the sender happened to be
+    /// sitting in front of.
+    func testBoundChatHearsItsPaneWithNoFleetListeners() {
+        let store = CommandSessionStore(url: nil, legacyMailURL: nil)
+        store.bind("telegram:42", toPaneKey: "k12", paneId: "p12", worktreePath: "/w")
+        XCTAssertEqual(store.telegramChatsToNotify(paneKey: "k12", fleetListenerChatIds: []), ["42"])
+        // Another pane's event still says nothing while the fleet is silenced.
+        XCTAssertTrue(store.telegramChatsToNotify(paneKey: "k9", fleetListenerChatIds: []).isEmpty)
+    }
 }
 
 final class PaneHandleRegistryTests: XCTestCase {

--- a/Tests/DashboardOverviewGroupingTests.swift
+++ b/Tests/DashboardOverviewGroupingTests.swift
@@ -239,10 +239,10 @@ final class DashboardOverviewGroupingTests: XCTestCase {
                            "grouped by project the checkout is a pinned row, not a banner")
 
             view.selectGroupingModeForTesting(.status)
-            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  integration · 2 worktrees"])
+            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  alpha · integration · 2 worktrees"])
 
             view.selectGroupingModeForTesting(.activityTime)
-            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  integration · 2 worktrees"])
+            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  alpha · integration · 2 worktrees"])
 
             view.selectGroupingModeForTesting(.pane)
             XCTAssertEqual(view.integrationBannerLinesForTesting, [])
@@ -256,7 +256,7 @@ final class DashboardOverviewGroupingTests: XCTestCase {
             let view = makeViewWithIntegration(defaults: defaults, status: nil)
             view.update(fleetWithIntegration())
             view.selectGroupingModeForTesting(.status)
-            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  integration · not built yet"])
+            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  alpha · integration · not built yet"])
         }
     }
 
@@ -272,11 +272,68 @@ final class DashboardOverviewGroupingTests: XCTestCase {
         }
     }
 
-    private func makeViewWithIntegration(defaults: UserDefaults, status: String?) -> DashboardOverviewView {
+    private func makeViewWithIntegration(defaults: UserDefaults, status: String?,
+                                        state: IntegrationPanelState? = nil) -> DashboardOverviewView {
         DashboardOverviewView(frame: NSRect(x: 0, y: 0, width: 600, height: 600),
                               defaults: defaults, now: { self.now },
                               isIntegrationWorktree: { $0 == "/alpha-worktrees/integration" },
-                              integrationStatus: { _ in status })
+                              integrationStatus: { _ in status },
+                              integrationState: { _ in state })
+    }
+
+    /// A round that dropped work, or never ran, is marked — glyph and colour —
+    /// rather than reading like any other line in a dim list.
+    func testBannerMarksARoundThatNeedsSomeone() {
+        withDefaults { defaults in
+            let held = IntegrationPanelState(line: "integration · 2 worktrees · held · local edits",
+                                             included: ["a", "b"], excluded: [], conflictedPaths: [],
+                                             isHeld: true)
+            let view = makeViewWithIntegration(defaults: defaults, status: held.line, state: held)
+            view.update(fleetWithIntegration())
+            view.selectGroupingModeForTesting(.status)
+
+            XCTAssertEqual(view.integrationBannerLinesForTesting,
+                           ["!  alpha · integration · 2 worktrees · held · local edits"])
+            XCTAssertEqual(view.integrationBannerAttentionForTesting, [true])
+        }
+    }
+
+    /// The checkout's own row carries the state, so the modes that give it a row
+    /// need no banner — and the dot there is the integration's, not a shell's.
+    func testTheCheckoutRowShowsTheIntegrationState() {
+        withDefaults { defaults in
+            let failed = IntegrationPanelState.failed("no base ref")
+            let view = makeViewWithIntegration(defaults: defaults, status: failed.line, state: failed)
+            view.update(fleetWithIntegration())
+
+            for mode in [WorktreeGroupingMode.repository, .pane] {
+                view.selectGroupingModeForTesting(mode)
+                XCTAssertEqual(view.rowGlyphsForTesting["/alpha-worktrees/integration"], "✕",
+                               "grouping \(mode) left the checkout reading as an agent")
+                // An ordinary worktree's dot still means what it always did.
+                XCTAssertEqual(view.rowGlyphsForTesting["/alpha"], AgentStatus.idle.glyph)
+                XCTAssertEqual(view.integrationBannerLinesForTesting, [],
+                               "grouping \(mode) said it twice")
+            }
+        }
+    }
+
+    /// Every state the checkout can be in reads differently at a glance.
+    func testEachIntegrationStateGetsItsOwnDot() {
+        let excluded = IntegrationPanelState(
+            line: "l", included: ["a"],
+            excluded: [.init(label: "b", paths: ["f.swift"])],
+            conflictedPaths: [], isHeld: false)
+        let clean = IntegrationPanelState(line: "l", included: ["a"], excluded: [],
+                                          conflictedPaths: [], isHeld: false)
+        for (state, glyph) in [(nil as IntegrationPanelState?, "◌"), (clean, "\u{2443}"),
+                               (excluded, "!"), (IntegrationPanelState.failed("x"), "✕")] {
+            withDefaults { defaults in
+                let view = makeViewWithIntegration(defaults: defaults, status: "l", state: state)
+                view.update(fleetWithIntegration())
+                XCTAssertEqual(view.rowGlyphsForTesting["/alpha-worktrees/integration"], glyph)
+            }
+        }
     }
 
     private func fleetWithIntegration() -> [WorktreeRowInfo] {
@@ -322,7 +379,7 @@ final class DashboardOverviewGroupingTests: XCTestCase {
             XCTAssertEqual(view.integrateProjectsForTesting, ["alpha"])
 
             view.selectGroupingModeForTesting(.status)
-            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  integration · 2 worktrees"])
+            XCTAssertEqual(view.integrationBannerLinesForTesting, ["⑃  alpha · integration · 2 worktrees"])
         }
     }
 

--- a/Tests/IntegrationAttentionTests.swift
+++ b/Tests/IntegrationAttentionTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import seahelm
+
+/// What First Mate marks, and what it leaves alone.
+final class IntegrationAttentionTests: XCTestCase {
+    private func state(included: [String] = [], excluded: [IntegrationPanelState.Excluded] = [],
+                       conflicted: [String] = [], held: Bool = false,
+                       failure: String? = nil) -> IntegrationPanelState {
+        IntegrationPanelState(line: "l", included: included, excluded: excluded,
+                              conflictedPaths: conflicted, isHeld: held, failure: failure)
+    }
+
+    /// A clean publish is meant to be invisible — the checkout is simply current.
+    func testACleanRoundIsNotMarked() {
+        XCTAssertFalse(state(included: ["a", "b"]).needsAttention)
+    }
+
+    func testEveryWayARoundFailsToLandIsMarked() {
+        XCTAssertTrue(state(excluded: [.init(label: "b", paths: ["f.swift"])]).needsAttention,
+                      "work was dropped")
+        XCTAssertTrue(state(conflicted: ["f.swift"]).needsAttention,
+                      "what landed carries conflict markers")
+        XCTAssertTrue(state(held: true).needsAttention,
+                      "built but not checked out")
+        XCTAssertTrue(state(failure: "no base ref").needsAttention,
+                      "the round never ran")
+    }
+
+    /// State written before `failure` existed still decodes, and reads as the
+    /// clean round it was.
+    func testOlderStateStillDecodes() throws {
+        let raw = """
+        {"line":"integration · 2 worktrees","included":["a","b"],"excluded":[],
+         "conflictedPaths":[],"isHeld":false}
+        """
+        let decoded = try XCTUnwrap(IntegrationStatusStore.decode(raw))
+        XCTAssertNil(decoded.failure)
+        XCTAssertFalse(decoded.needsAttention)
+    }
+
+    /// A round that threw used to write nothing, leaving the last good round on
+    /// screen — First Mate claiming an integration that no longer existed.
+    func testAFailedRoundReplacesTheLastGoodLine() {
+        let failed = IntegrationPanelState.failed("no base ref")
+        XCTAssertEqual(failed.line, "integration · failed · no base ref")
+        XCTAssertTrue(failed.needsAttention)
+        XCTAssertTrue(failed.included.isEmpty)
+    }
+
+    /// The report's own line says it too, so the text and the marker agree.
+    func testReportCarriesTheFailureIntoItsPanelState() {
+        let report = IntegrationRunReport(
+            integrationWorktreePath: "/wt/integration",
+            result: IntegrationResult(commit: "c", tree: "t", base: "b",
+                                      included: [], excluded: [], conflictedPaths: []),
+            outcome: .failed("merge refused"),
+            unsnapshotable: [],
+            committedOnly: []
+        )
+        XCTAssertTrue(report.needsAttention)
+        XCTAssertEqual(report.panelState.failure, "merge refused")
+        XCTAssertTrue(report.panelState.needsAttention)
+        XCTAssertTrue(report.cardLine.contains("failed · merge refused"), report.cardLine)
+    }
+
+    // MARK: - how a checkout reads in the list
+
+    func testTheRowDotSaysWhatTheLastRoundDid() {
+        XCTAssertEqual(IntegrationRowStatus(nil), .notBuilt)
+        XCTAssertEqual(IntegrationRowStatus(state(included: ["a"])), .clean)
+        XCTAssertEqual(IntegrationRowStatus(state(held: true)), .attention)
+        XCTAssertEqual(IntegrationRowStatus(state(excluded: [.init(label: "b", paths: [])])), .attention)
+        XCTAssertEqual(IntegrationRowStatus(state(failure: "no base ref")), .failed)
+    }
+
+    /// Four states, four glyphs, all one column wide so the list stays aligned.
+    func testEveryRowStateHasItsOwnSingleColumnGlyph() {
+        let glyphs = [IntegrationRowStatus.notBuilt, .clean, .attention, .failed].map(\.glyph)
+        XCTAssertEqual(Set(glyphs).count, glyphs.count)
+        XCTAssertTrue(glyphs.allSatisfy { $0.count == 1 }, "\(glyphs)")
+    }
+
+    // MARK: - which checkouts the banner shows
+
+    /// Grouping by status or activity leaves the checkout out of the list, so
+    /// the banner is the only place it can be seen there.
+    func testOnlyTheGroupingsWithoutARowGetABanner() {
+        for mode in [WorktreeGroupingMode.status, .activityTime] {
+            XCTAssertEqual(DashboardOverviewView.bannerPaths(checkouts: ["/a", "/b"], mode: mode),
+                           ["/a", "/b"])
+        }
+        for mode in [WorktreeGroupingMode.repository, .pane] {
+            XCTAssertEqual(DashboardOverviewView.bannerPaths(checkouts: ["/a", "/b"], mode: mode), [],
+                           "the row already carries it")
+        }
+    }
+
+    func testTheMarkedLineIsOneColumnApartFromTheCleanOne() {
+        let clean = DashboardOverviewView.bannerLine(project: "alpha", status: "integration · 2 worktrees",
+                                                     needsAttention: false)
+        let marked = DashboardOverviewView.bannerLine(project: "alpha", status: "integration · 2 worktrees",
+                                                      needsAttention: true)
+        XCTAssertEqual(clean.text, "\u{2443}  alpha · integration · 2 worktrees")
+        XCTAssertEqual(marked.text, "!  alpha · integration · 2 worktrees")
+        XCTAssertEqual(clean.text.count, marked.text.count)
+    }
+
+    /// The strip sits above the whole list, so a line that does not name its
+    /// repo reads as belonging to whichever group header it happens to float
+    /// over — which is how a teamclaw round ended up looking like seahelm's.
+    func testTheBannerNamesItsRepo() {
+        let line = DashboardOverviewView.bannerLine(project: "teamclaw", status: nil,
+                                                    needsAttention: false)
+        XCTAssertTrue(line.text.contains("teamclaw · integration · not built yet"), line.text)
+    }
+}

--- a/Tests/PaneWorkingDirectoryTests.swift
+++ b/Tests/PaneWorkingDirectoryTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import seahelm
+
+/// Where a split opens (issue #27).
+final class PaneWorkingDirectoryTests: XCTestCase {
+    private let all: (String) -> Bool = { _ in true }
+
+    /// The kernel outranks OSC 7, which outranks where the pane was created —
+    /// and the worktree root is the floor, not the answer.
+    func testTheLadderPrefersTheFreshestSource() {
+        XCTAssertEqual(
+            PaneWorkingDirectory.choose(probed: "/probed", oscPwd: "/osc", initial: "/initial",
+                                        worktreePath: "/wt", exists: all),
+            "/probed")
+        XCTAssertEqual(
+            PaneWorkingDirectory.choose(probed: nil, oscPwd: "/osc", initial: "/initial",
+                                        worktreePath: "/wt", exists: all),
+            "/osc")
+        XCTAssertEqual(
+            PaneWorkingDirectory.choose(probed: nil, oscPwd: nil, initial: "/initial",
+                                        worktreePath: "/wt", exists: all),
+            "/initial")
+    }
+
+    /// A pane that says nothing about itself behaves exactly as it did before
+    /// this existed: the split opens at the worktree root.
+    func testTheWorktreeRootIsTheFloor() {
+        XCTAssertEqual(
+            PaneWorkingDirectory.choose(probed: nil, oscPwd: "", initial: "   ",
+                                        worktreePath: "/wt", exists: all),
+            "/wt")
+    }
+
+    /// A directory that has been deleted under the pane must not be handed to
+    /// surface creation — it takes the next candidate down instead.
+    func testAVanishedDirectoryIsSkipped() {
+        XCTAssertEqual(
+            PaneWorkingDirectory.choose(probed: "/gone", oscPwd: "/still-here", initial: nil,
+                                        worktreePath: "/wt", exists: { $0 != "/gone" }),
+            "/still-here")
+        XCTAssertEqual(
+            PaneWorkingDirectory.choose(probed: "/gone", oscPwd: "/also-gone", initial: "/gone-too",
+                                        worktreePath: "/wt", exists: { _ in false }),
+            "/wt")
+    }
+
+    /// The kernel read itself — the part the ladder cannot fake. Asked of this
+    /// process, whose directory the test already knows.
+    func testTheCwdOfALiveProcessIsReadable() throws {
+        let mine = try XCTUnwrap(PaneWorkingDirectory.cwd(ofPid: getpid()))
+        XCTAssertEqual(URL(fileURLWithPath: mine).resolvingSymlinksInPath().path,
+                       URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                           .resolvingSymlinksInPath().path)
+    }
+
+    func testADeadProcessSaysNothing() {
+        // pid 0 is the kernel's own — never a shell, and never readable as one.
+        XCTAssertNil(PaneWorkingDirectory.cwd(ofPid: -1))
+    }
+
+    func testAPaneWithNoSessionIsNotProbed() {
+        XCTAssertNil(PaneWorkingDirectory.probeSessionCwd(paneSessionKey: ""))
+    }
+}

--- a/Tests/PendingOrdersQueueTests.swift
+++ b/Tests/PendingOrdersQueueTests.swift
@@ -7,6 +7,32 @@ final class PendingOrdersQueueTests: XCTestCase {
                         project: "p", terminalID: "t", message: "m")
     }
 
+    /// A card that leaves the queue takes its chat buttons with it. The message
+    /// carrying them stays in the chat's history for good, so the token dying is
+    /// the only thing between a second tap and the option being typed into the
+    /// pane twice.
+    func testResolvingACardRetiresItsChatButtons() {
+        let q = PendingOrdersQueue()
+        q.enqueue(action(.suggestNextOrder))
+        let id = q.all()[0].id
+        let token = ChatCallbackRegistry.shared.mint(.suggestionOption(orderId: id, index: 0))
+        XCTAssertNotNil(ChatCallbackRegistry.shared.action(for: token))
+
+        q.resolve(id: id)
+        XCTAssertNil(ChatCallbackRegistry.shared.action(for: token))
+    }
+
+    /// Every removal path, not just `resolve`: a pane that closes takes its
+    /// buttons with it too.
+    func testClosingAPaneRetiresItsChatButtons() {
+        let q = PendingOrdersQueue()
+        q.enqueue(action(.suggestNextOrder))
+        let token = ChatCallbackRegistry.shared.mint(.dismissSuggestion(orderId: q.all()[0].id))
+
+        q.resolvePane(terminalID: "t")
+        XCTAssertNil(ChatCallbackRegistry.shared.action(for: token))
+    }
+
     func testEnqueueAddsOrder() {
         let q = PendingOrdersQueue()
         q.enqueue(action(.suggestNextOrder))

--- a/Tests/TelegramBridgeTests.swift
+++ b/Tests/TelegramBridgeTests.swift
@@ -135,9 +135,15 @@ final class TelegramBridgeTests: XCTestCase {
                          from: TelegramUser? = TelegramUser(id: 42, isBot: false, firstName: "Matt", username: "matt_c"),
                          chat: TelegramChat = TelegramChat(id: 42, type: "private", title: nil, username: nil),
                          senderChat: TelegramChat? = nil,
-                         caption: String? = nil) -> TelegramMessage {
-        TelegramMessage(messageId: 1, date: 1_757_000_000, chat: chat, from: from,
-                        senderChat: senderChat, text: text, caption: caption)
+                         caption: String? = nil,
+                         replyingTo: String? = nil) -> TelegramMessage {
+        let target = replyingTo.map {
+            TelegramReplyTarget(messageId: 9,
+                                from: TelegramUser(id: 999, isBot: true, firstName: "bot", username: $0))
+        }
+        return TelegramMessage(messageId: 1, date: 1_757_000_000, chat: chat, from: from,
+                               senderChat: senderChat, text: text, caption: caption,
+                               replyToMessage: target)
     }
 
     private let group = TelegramChat(id: -100, type: "supergroup", title: "Team", username: nil)
@@ -164,6 +170,44 @@ final class TelegramBridgeTests: XCTestCase {
         XCTAssertNil(TelegramChannel.command(in: message("lunch?", chat: group), config: ownerConfig, botUsername: nil))
         let cmd = TelegramChannel.command(in: message("/status", chat: group), config: ownerConfig, botUsername: nil)
         XCTAssertEqual(cmd?.body, "/status")
+    }
+
+    /// Naming the bot is as deliberate as a slash: `@thebot ship it` in a group
+    /// is an order, and the bot's own name does not travel on to the agent.
+    func testGroupMentionOfTheBotIsAnOrder() {
+        let cmd = TelegramChannel.command(in: message("@seahelm_bot ship it", chat: group),
+                                          config: ownerConfig, botUsername: "seahelm_bot")
+        XCTAssertEqual(cmd?.body, "ship it")
+        // Telegram's own capitalisation of a mention is whatever the user typed.
+        XCTAssertEqual(TelegramChannel.command(in: message("@SeaHelm_Bot ship it", chat: group),
+                                               config: ownerConfig, botUsername: "seahelm_bot")?.body,
+                       "ship it")
+    }
+
+    /// Replying to something the bot said is the other way a room addresses it.
+    func testGroupReplyToTheBotIsAnOrder() {
+        let cmd = TelegramChannel.command(in: message("yes, do that", chat: group, replyingTo: "seahelm_bot"),
+                                          config: ownerConfig, botUsername: "seahelm_bot")
+        XCTAssertEqual(cmd?.body, "yes, do that")
+    }
+
+    /// The gate the group rule was always protecting: prose aimed at somebody
+    /// else — another bot, a colleague's message — must not reach an agent.
+    func testGroupProseAimedElsewhereIsStillNotAnOrder() {
+        XCTAssertNil(TelegramChannel.command(in: message("@other_bot deploy", chat: group),
+                                             config: ownerConfig, botUsername: "seahelm_bot"))
+        XCTAssertNil(TelegramChannel.command(in: message("sure", chat: group, replyingTo: "other_bot"),
+                                             config: ownerConfig, botUsername: "seahelm_bot"))
+        // The bot's name with nothing after it is someone talking *about* it.
+        XCTAssertNil(TelegramChannel.command(in: message("@seahelm_bot", chat: group),
+                                             config: ownerConfig, botUsername: "seahelm_bot"))
+    }
+
+    /// A mention is not a way past the allowlist.
+    func testGroupMentionFromUnlistedUserIsIgnored() {
+        let stranger = TelegramUser(id: 7, isBot: false, firstName: "X", username: nil)
+        XCTAssertNil(TelegramChannel.command(in: message("@seahelm_bot deploy", from: stranger, chat: group),
+                                             config: ownerConfig, botUsername: "seahelm_bot"))
     }
 
     /// Telegram appends `@botname` to commands in groups with several bots.

--- a/docs/command-surfaces.md
+++ b/docs/command-surfaces.md
@@ -62,5 +62,6 @@
 ## 通知走向
 
 - agent 完成的通知发到 Telegram 的默认 chat（`default_chat_id`，缺省为第一个数字 id 的白名单用户）。
-- 凡是用 `/go` 绑定了那个 pane 的会话（某个 Telegram 群、某个邮件线程）也各收一份。
+- 该 chat 若已 `/go` 到某个 pane，则**只**收那个 pane 的完成/报错通知；解绑后恢复收全舰队。
+- 凡是用 `/go` 绑定了那个 pane 的其它会话（某个 Telegram 群、某个邮件线程）也各收一份。
 - 桌面上就是 Island 和系统横幅。

--- a/docs/command-surfaces.md
+++ b/docs/command-surfaces.md
@@ -14,9 +14,10 @@
 ### Telegram：私聊 vs 群聊
 
 - **私聊**里任何一行都是命令：裸文本发给绑定的 pane，`/…` 走动词表。
-- **群里只有 `/命令` 算命令**，裸文本是闲聊——共享群里随口一句话不该驱动 agent（`TelegramChannel.command`）。
-- 群里的命令**必须以 `/` 开头**。Telegram 的 privacy mode 默认开着（`getMe` 里 `can_read_all_group_messages: false`），bot 在群里只收得到以斜杠开头的消息、对它自己消息的回复、以及服务消息；`@yourbot /status` 这种把提及写在前面的形式 **Telegram 根本不会投递**，seahelm 这边连日志都不会有。群里有多个 bot 时用后缀形式 `/status@yourbot`，`TelegramChannel.stripBotMention` 会把后缀去掉。
-- 只有要用 Triggers（让 bot 读群里其他人的普通消息去触发 agent）时，才需要在 @BotFather 里 `/setprivacy` → Disable，并且**把 bot 移出群再重新加回去**才生效。即便如此 seahelm 在群里仍然只把 `/命令` 当命令，其余走规则匹配。
+- **群里必须「对着 bot 说」**，三种形式算命令（`TelegramChannel.command` / `addressedProse`）：`/命令`、以 `@yourbot` 开头的一句话、以及**对 bot 自己某条消息的回复**。裸文本仍然是闲聊——共享群里随口一句话不该驱动 agent，这是这道门唯一要挡的东西；点名 bot 和打斜杠一样明确。
+- 但**能不能收到**是 Telegram 说了算。privacy mode 默认开着（`getMe` 里 `can_read_all_group_messages: false`），bot 在群里只收得到以斜杠开头的消息、对它自己消息的回复、以及服务消息——**@提及开头的普通话根本不会投递**，seahelm 这边连日志都不会有。所以开箱即用的两条是 `/命令` 和**回复 bot**；想让 `@yourbot 把这个跑一遍` 也能用，得在 @BotFather 里 `/setprivacy` → Disable，并且**把 bot 移出群再重新加回去**才生效。
+- 群里有多个 bot 时命令用后缀形式 `/status@yourbot`，`TelegramChannel.stripBotMention` 会把后缀去掉；开头的 `@yourbot` 则由 `addressedProse` 剥掉，不会跟着话一起送进 pane。
+- privacy mode 关掉之后，bot 会看到群里所有消息：这时白名单成员的裸文本**依然不算命令**（只有上面三种形式算），其余人的消息走规则匹配（Triggers）。
 - 白名单（`allowed_users`）按发消息的**用户**判定，与在私聊还是群里无关；不在白名单的人发的 `/命令` 会被忽略。
 
 三个文字入口共用同一个 `CommandExecutor`，差别只在确认方式和"当前"的定义。First Mate 是侧栏的舰队总览加上背后的监督者，不接受文字命令；监督者发起的动作以卡片形式出现在 Island 里，下表最后一列写的是它会不会自己做这件事。目前 Island 只渲染 suggestNextOrder 一类卡片；integrationReport 会进队列，但没有界面把它画出来。
@@ -62,6 +63,13 @@
 ## 通知走向
 
 - agent 完成的通知发到 Telegram 的默认 chat（`default_chat_id`，缺省为第一个数字 id 的白名单用户）。
+- **agent 卡在提问/审批时**（Claude Code 的权限弹窗、AskUserQuestion），那张卡片连同选项按钮一起发到能回答它的 chat，点按钮就等于在桌面上点那张卡（`MainWindowController.publishCardsToChat` → `ChatCallbackRegistry` → `handleSuggestionTapped`）。
+- 卡片**不受 `/go` 绑定静音**：绑定的意思是「我这条对话说给 #12 听」，不是「别告诉我舰队停了」。完成通知照旧只发给绑定的 pane，卡片则默认 chat 也收。
+- **两种卡片进 chat 的方式不同**，因为它们挣得的位置不同：
+  - **提问/审批**是「停住了」，pane 一直等在那儿——自己发一条消息。
+  - **suggestion**（下一步建议）是「要不要顺手做」，而且它的正文和完成通知是同一段 agent 原话——**不发新消息**，把选项作为按钮**补到那条完成通知上**（`editMessageReplyMarkup`）。没有通知就没有按钮：那一轮如果本来就不值得告诉手机，它的下一步也不值得。锚点由 `ChatNoticeBook` 记着，每个 chat 每个 pane 一条，3 分钟过期——再久聊天已经翻页了，按钮挂在没人看的消息下面比没有更糟。
+  - 通知的 message id 是异步回来的（`send(_:completion:)`）；suggestion 卡片在拿到 id 之前不算「已发」，下一轮 2 秒刷新会再试。
+- 卡片答掉之后按钮就作废：卡片离开队列时 `PendingOrdersQueue` 会退掉它的 token，聊天记录里那条消息的键盘也会被撤掉。token 只活一次运行，重启后旧按钮一律按「过期」回。
 - 该 chat 若已 `/go` 到某个 pane，则**只**收那个 pane 的完成/报错通知；解绑后恢复收全舰队。
 - 凡是用 `/go` 绑定了那个 pane 的其它会话（某个 Telegram 群、某个邮件线程）也各收一份。
 - 桌面上就是 Island 和系统横幅。

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 		8EABBB670FE78F05B40F735B /* IslandModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8704C54160BF8CD4FE29B9D6 /* IslandModel.swift */; };
 		8EABC0497151BA1CC9E3C12A /* HostGatewaySessionBackpressureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC94EE653B0D0F418057A15 /* HostGatewaySessionBackpressureTests.swift */; };
 		8EAE24B6C81EA826474EEC90 /* StatusDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6A0AE5886DB08F5B0D024C /* StatusDetector.swift */; };
+		8EDDD84238F144EACE8C0D76 /* IntegrationAttentionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C011CC363C2F473FB93BBD2 /* IntegrationAttentionTests.swift */; };
 		8F0624099E494AEDE963E0CC /* FirstMateEvaluateOutcomeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4089897C96C2E4E3E151DDD2 /* FirstMateEvaluateOutcomeTests.swift */; };
 		8FE5D1705C06DDB664FF7C94 /* Manifests in Resources */ = {isa = PBXBuildFile; fileRef = A94DAD757D9F452B11283244 /* Manifests */; };
 		90650F907FCC7FB24383A44D /* HooksChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A7E8E322E5A353D4457DBC /* HooksChannel.swift */; };
@@ -485,6 +486,7 @@
 		FD31D39DD1C179392C0993F6 /* DiffSyntaxHighlighter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510FA8122ABEBFF0AAB1C539 /* DiffSyntaxHighlighter.swift */; };
 		FD97CEE3018382B7182D5EB7 /* DialogPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DC6CD361867294E47A209E3 /* DialogPresenter.swift */; };
 		FE0A82E1F0D8DBE2D036CB71 /* AIPanelPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD256925C8144E1C18DEC0E /* AIPanelPage.swift */; };
+		FE58A1CB16B3FF9EEAFA132F /* IntegrationRowStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456723EB5522C611A1982269 /* IntegrationRowStatus.swift */; };
 		FED31A3C39D21CA95E4FE06D /* FirstMate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9EEEBC6FB86CD29B2B3D45 /* FirstMate.swift */; };
 /* End PBXBuildFile section */
 
@@ -624,6 +626,7 @@
 		42E7300FEE6468E0C6CDD629 /* DashboardViewControllerClickTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewControllerClickTests.swift; sourceTree = "<group>"; };
 		43175062905BAABB3109B693 /* AgentRegistryIngestOutcomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryIngestOutcomeTests.swift; sourceTree = "<group>"; };
 		448BBAB293764647E8FDB894 /* WorktreeGroupingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeGroupingTests.swift; sourceTree = "<group>"; };
+		456723EB5522C611A1982269 /* IntegrationRowStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationRowStatus.swift; sourceTree = "<group>"; };
 		46776FFD2F37DD5907B7D108 /* ScanDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanDecoderTests.swift; sourceTree = "<group>"; };
 		472ACEFBD0F23747FC60EB0D /* TerminalHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalHeaderViewTests.swift; sourceTree = "<group>"; };
 		4775959C72857610AC1F12DC /* WorktreeStatusAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeStatusAggregator.swift; sourceTree = "<group>"; };
@@ -726,6 +729,7 @@
 		7AD4898C898C52B4C1DDEEC0 /* StopHookResponderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopHookResponderTests.swift; sourceTree = "<group>"; };
 		7B3EAA643D3A58E42AE2B7CD /* SeahelmSkillInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmSkillInstaller.swift; sourceTree = "<group>"; };
 		7BE708AEC9451A9A8135976C /* ProcessProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessProbeTests.swift; sourceTree = "<group>"; };
+		7C011CC363C2F473FB93BBD2 /* IntegrationAttentionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationAttentionTests.swift; sourceTree = "<group>"; };
 		7C16AC1C12C568E0A2971C9E /* CodexSessionPromptLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexSessionPromptLookup.swift; sourceTree = "<group>"; };
 		7C1D507BEBD483B978CC2DBC /* seahelm.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = seahelm.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C3D3984EB87D6ED65A3312A /* PaneInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneInfo.swift; sourceTree = "<group>"; };
@@ -1084,6 +1088,7 @@
 				B5512F73C560C4BEA3AA8424 /* IdeaStore.swift */,
 				340F0D26DC8D1C8F72279B6A /* IngestOutcome.swift */,
 				256BB7C447703DD227B69806 /* IntegrationCoordinator.swift */,
+				456723EB5522C611A1982269 /* IntegrationRowStatus.swift */,
 				C8F1B159E50F3F6CDA6466BE /* IntegrationRunner.swift */,
 				811DF1463E1F5D6EFC56F68A /* IntegrationStatusStore.swift */,
 				AAC3559992F8B4562068B449 /* IntegrationWorktreeStore.swift */,
@@ -1490,6 +1495,7 @@
 				16AC3A2325B391B90BFD6175 /* HostGatewayVTFrameTests.swift */,
 				EF22C41D6F582FFD30D8BD2D /* HTMLPreviewResourceTests.swift */,
 				7CFF2129E5D3A2E51C49F22C /* IdeaStoreTests.swift */,
+				7C011CC363C2F473FB93BBD2 /* IntegrationAttentionTests.swift */,
 				A1876E1900448D0350043DB3 /* IntegrationBuilderTests.swift */,
 				09F9C5F9EE967F8B87332014 /* IntegrationCoordinatorTests.swift */,
 				90EF92DD407F1B5BBC3F3FC1 /* IntegrationWorktreeTests.swift */,
@@ -2050,6 +2056,7 @@
 				72897701FB2E01A0DA5305D1 /* HostGatewayStaticFilesTests.swift in Sources */,
 				868325DCA0D71C5CF997E11E /* HostGatewayVTFrameTests.swift in Sources */,
 				19A26EE54A5CE77EB9A5A51B /* IdeaStoreTests.swift in Sources */,
+				8EDDD84238F144EACE8C0D76 /* IntegrationAttentionTests.swift in Sources */,
 				969A1488531C0DC09B3C0D84 /* IntegrationBuilderTests.swift in Sources */,
 				0F78AFF34ACE62201D0582E6 /* IntegrationCoordinatorTests.swift in Sources */,
 				2AB9FBCF955A1C0BC01C1C3C /* IntegrationWorktreeTests.swift in Sources */,
@@ -2299,6 +2306,7 @@
 				E100AB08193BEDC6CD9E62C1 /* IngestOutcome.swift in Sources */,
 				1F121DE08BEE76DF3987C368 /* IntegrationBuilder.swift in Sources */,
 				42729ADC959CA03BA771E6C2 /* IntegrationCoordinator.swift in Sources */,
+				FE58A1CB16B3FF9EEAFA132F /* IntegrationRowStatus.swift in Sources */,
 				68AC25AFDA14448CAE9FA7A2 /* IntegrationRunner.swift in Sources */,
 				A4511021DEF08E77298E6F09 /* IntegrationStatusStore.swift in Sources */,
 				E134224DD16226B5C25277C5 /* IntegrationWorktree.swift in Sources */,

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		0F486115B10D4353770B261C /* SessionRestoreConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFFAE60D0EF11A5DC22B2B73 /* SessionRestoreConfigTests.swift */; };
 		0F78AFF34ACE62201D0582E6 /* IntegrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09F9C5F9EE967F8B87332014 /* IntegrationCoordinatorTests.swift */; };
 		0FDF118A34CA87216F2FD70D /* GitProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BAEF3139798D53AE355496 /* GitProcess.swift */; };
+		1055CF6524AAB2DC4EE2C835 /* ChatNoticeBookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8816ECB0847ABFD594B1AB3 /* ChatNoticeBookTests.swift */; };
 		1063EE7F5505310F9DEE6E07 /* SuggestGuidanceWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159B10196D13B333CFC76E1D /* SuggestGuidanceWriter.swift */; };
 		10D70ABC6FF1371989A62258 /* ClaudeUsageSummaryProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 258A1C3E5F11466A79C1CAF3 /* ClaudeUsageSummaryProvider.swift */; };
 		12348F72590729F9B44FC244 /* HostGatewayStaticFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADAB7F280D7925E9A0CD660C /* HostGatewayStaticFiles.swift */; };
@@ -220,6 +221,7 @@
 		7839409D46CC0B8E4810B869 /* WorktreeCreatorEnvCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A028D76F177CA1C4379BC3 /* WorktreeCreatorEnvCopyTests.swift */; };
 		785DB0B4417DD04E94CD58AD /* HostGatewayDecisionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D09525B8D6C093323B62D10B /* HostGatewayDecisionsTests.swift */; };
 		7906BA09A1F8FE6C728AD72C /* TelegramSetupWizard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B4705665C97FD7F9A95FDFC /* TelegramSetupWizard.swift */; };
+		79A076BEF314843CD19EE657 /* ChatNoticeBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B2F4C9A4491CF0E397E1D0F /* ChatNoticeBook.swift */; };
 		79F532FA70B21691FB226AF8 /* GitHubDiffAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3492399099DDDAE527C6CA /* GitHubDiffAdapter.swift */; };
 		7A34C1A6124339C30D0EC84C /* PRListCellLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC46DE31056D710E7F3BF1E2 /* PRListCellLayoutTests.swift */; };
 		7A4F6892F9AE56EF60508D89 /* FirstMateConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B08FEEAC5D86CEE353749EA /* FirstMateConfigTests.swift */; };
@@ -468,6 +470,7 @@
 		F7AE5D618DD874989BE4F93C /* SemanticColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15A95E0337AEDBCE9546B8F /* SemanticColors.swift */; };
 		F822A1F30137CB7940F82296 /* PRListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF331BF96A89F1DC3E9C1BD /* PRListView.swift */; };
 		F88018C1DE074B7B23AABDA3 /* SplitPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D06307CBEFF44025C8E9AD3 /* SplitPaneTests.swift */; };
+		F8D552BE492D81AD67DBB488 /* ChatQuestionCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C257053E5A9E9DC19BB550EB /* ChatQuestionCardTests.swift */; };
 		F8E50AFAEFE6FB68CF09D75A /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF702127762EBDF898385B56 /* Analytics.swift */; };
 		F9C679963A114DDEAE7A9861 /* FuzzyMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71C3A59719695387993016D /* FuzzyMatch.swift */; };
 		F9F0C36BE9EDF1F4B6D49AD8 /* CodeEditSourceEditor in Frameworks */ = {isa = PBXBuildFile; productRef = D644401EFC00C60C7F075E6D /* CodeEditSourceEditor */; };
@@ -537,6 +540,7 @@
 		1A9D36C4513804B095CBABA5 /* PairRateLimiterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairRateLimiterTests.swift; sourceTree = "<group>"; };
 		1AB9B880E783FE26BA01DA38 /* GatewayStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayStateTests.swift; sourceTree = "<group>"; };
 		1B08FEEAC5D86CEE353749EA /* FirstMateConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateConfigTests.swift; sourceTree = "<group>"; };
+		1B2F4C9A4491CF0E397E1D0F /* ChatNoticeBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatNoticeBook.swift; sourceTree = "<group>"; };
 		1B81039609F254AED8BCEC72 /* CommandFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandFormatterTests.swift; sourceTree = "<group>"; };
 		1C0F7D7F30A3F031DC191AFF /* StationHealthCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationHealthCheckTests.swift; sourceTree = "<group>"; };
 		1D9E5FDD907FFB3D57373A8A /* HostGatewaySessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewaySessionTests.swift; sourceTree = "<group>"; };
@@ -829,6 +833,7 @@
 		B7A33515B716406497BF7E74 /* ShortcutHintBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutHintBarTests.swift; sourceTree = "<group>"; };
 		B841F51C5CE64F7FFA956EF3 /* SignalDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalDecoder.swift; sourceTree = "<group>"; };
 		B86D2BBA33C13BFA224F58D4 /* GlobalKeymap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalKeymap.swift; sourceTree = "<group>"; };
+		B8816ECB0847ABFD594B1AB3 /* ChatNoticeBookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatNoticeBookTests.swift; sourceTree = "<group>"; };
 		B88BC86C7B6B48D00A1F8059 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		B8E255132C2399E444871CFA /* OnboardingThemeStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingThemeStepView.swift; sourceTree = "<group>"; };
 		B93F28C39550D1DFF047CEC1 /* CommandSessionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandSessionStoreTests.swift; sourceTree = "<group>"; };
@@ -860,6 +865,7 @@
 		C122F14B425BC7F3DF1FEB8B /* WorktreeDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDiscovery.swift; sourceTree = "<group>"; };
 		C1768F75790892B5D280CBC0 /* NewBranchDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewBranchDialog.swift; sourceTree = "<group>"; };
 		C197F88AECB09C7C3D4449DE /* SessionManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManagerTests.swift; sourceTree = "<group>"; };
+		C257053E5A9E9DC19BB550EB /* ChatQuestionCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatQuestionCardTests.swift; sourceTree = "<group>"; };
 		C282D98A9A6117C70B06D3F1 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		C30353E5B3401026090F247F /* CommandParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandParserTests.swift; sourceTree = "<group>"; };
 		C343A8D3A5164AA2BF4DB650 /* CommandSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandSession.swift; sourceTree = "<group>"; };
@@ -1031,6 +1037,7 @@
 				AEC631B07301756615C755E6 /* AgentType.swift */,
 				BF702127762EBDF898385B56 /* Analytics.swift */,
 				81F38890EF85FE22F83ED385 /* ChatCallbackRegistry.swift */,
+				1B2F4C9A4491CF0E397E1D0F /* ChatNoticeBook.swift */,
 				2D90204521BAE476A8EF340E /* ClaudeHooksSetup.swift */,
 				26EFCABEFB8EEA92A8B6FA13 /* ClaudeStatuslineBridgeInstaller.swift */,
 				A51B009382FE3586E735355D /* CodexHooksSetup.swift */,
@@ -1431,6 +1438,8 @@
 				6C827E67B268966037EEDC48 /* AgentSessionRefTests.swift */,
 				F4D445453693B8D5A3D088F1 /* AgentTypeTests.swift */,
 				01DB279E827314DBFA97331B /* ChatCallbackRegistryTests.swift */,
+				B8816ECB0847ABFD594B1AB3 /* ChatNoticeBookTests.swift */,
+				C257053E5A9E9DC19BB550EB /* ChatQuestionCardTests.swift */,
 				5E88C517CE4270179492479E /* ChoiceOptionParserTests.swift */,
 				38FD43578EB5A227077BAA11 /* ChromeCollapseAnimationTests.swift */,
 				4890F1362CCDACF15E685662 /* ChromeLayoutMetricsTests.swift */,
@@ -1989,6 +1998,8 @@
 				F18F39D20F1D77592272356C /* AgentSessionRefTests.swift in Sources */,
 				53D46BF1B3E00A35B53A86C4 /* AgentTypeTests.swift in Sources */,
 				E898E9379622EC8D16777977 /* ChatCallbackRegistryTests.swift in Sources */,
+				1055CF6524AAB2DC4EE2C835 /* ChatNoticeBookTests.swift in Sources */,
+				F8D552BE492D81AD67DBB488 /* ChatQuestionCardTests.swift in Sources */,
 				9F3608916964651FE502DAD3 /* ChoiceOptionParserTests.swift in Sources */,
 				3D18A10A7522058688B2A1F7 /* ChromeCollapseAnimationTests.swift in Sources */,
 				12B626905E1B75F6419CD452 /* ChromeLayoutMetricsTests.swift in Sources */,
@@ -2200,6 +2211,7 @@
 				646692CC7C11231CC40284EC /* Array+SafeIndex.swift in Sources */,
 				7BDCC195CBE9B564845BB8D3 /* CenterOverlayView.swift in Sources */,
 				0AE7E3F52B1D7EFFF5D01E6A /* ChatCallbackRegistry.swift in Sources */,
+				79A076BEF314843CD19EE657 /* ChatNoticeBook.swift in Sources */,
 				72EA963BA7948ECBF5DABF5C /* ChoiceOptionParser.swift in Sources */,
 				3BE5AE4B30540C9F80527B7F /* ChromeDividerView.swift in Sources */,
 				DCD355D8BE1EF13AECD21332 /* ChromeHeaderDelegate.swift in Sources */,
@@ -2483,7 +2495,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.58;
+				MARKETING_VERSION = 2.0.59;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",
@@ -2720,7 +2732,7 @@
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 2.0.58;
+				MARKETING_VERSION = 2.0.59;
 				OTHER_LDFLAGS = (
 					"$(PROJECT_DIR)/GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a",
 					"-lc++",

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		4670998F86598F2E5C84ACD3 /* StationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F9565C3156144526A74B08 /* StationManager.swift */; };
 		47229EE74F8F3BEA93AB0B6A /* TelegramRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC6460413988FF775BDA1B3 /* TelegramRuleTests.swift */; };
 		476D67C49BFE7D8093D880F3 /* QuitConfirmation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3016038B5EAC23288651C6 /* QuitConfirmation.swift */; };
+		47759F5CFF91DF5045DB4658 /* PaneWorkingDirectoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730849EDAF323B0D541E397C /* PaneWorkingDirectoryTests.swift */; };
 		478A900B42820F9CAC0829BF /* ghostty in Resources */ = {isa = PBXBuildFile; fileRef = 3C22FD399E95F8A453F40C3A /* ghostty */; };
 		478BA84CC6F98EA5F7F73B73 /* QRCodeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D89A6016405AEDB17C3FB5E /* QRCodeRenderer.swift */; };
 		489D78C033D8B6E4A47DD497 /* UsageSummaryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B417FD281AFB3860433F468F /* UsageSummaryStoreTests.swift */; };
@@ -234,6 +235,7 @@
 		7D09CC05B794C0D59CA4146B /* WindowChromeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105E0FAF9CFF482771DB785 /* WindowChromeController.swift */; };
 		7DD2666A7F2FE0E895A38F8B /* WorktreeTaskStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2F9EA56DB31E6555203E06 /* WorktreeTaskStoreTests.swift */; };
 		7E73C1FAA15054E71BDFDEF8 /* GitHubReturnPRClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E584B1D165D21C28521196B /* GitHubReturnPRClient.swift */; };
+		7ED2875B97C74F9DF0DF3F79 /* PaneWorkingDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5DCCDD64708BEB08D20C0A /* PaneWorkingDirectory.swift */; };
 		7F9546C174F5D5E52457F7A8 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7558A8D72AFCE237E39E401 /* MarkdownRendererTests.swift */; };
 		7FAB179ADDFF8EF7D3B14D93 /* DashboardOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C7F59E202B984E1E81797E /* DashboardOverviewView.swift */; };
 		80C1779FA957EF77BB2331A1 /* WorktreePathNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C97F6C22C29552377720F4D /* WorktreePathNavigationTests.swift */; };
@@ -710,6 +712,7 @@
 		724E222E995FED6444915776 /* GitHubPRDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubPRDecodingTests.swift; sourceTree = "<group>"; };
 		7282FEF43CB2989F9CE4859B /* ActivityEventExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityEventExtractor.swift; sourceTree = "<group>"; };
 		72D7AE18D546D48E83055667 /* github-pr-detail.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "github-pr-detail.json"; sourceTree = "<group>"; };
+		730849EDAF323B0D541E397C /* PaneWorkingDirectoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneWorkingDirectoryTests.swift; sourceTree = "<group>"; };
 		73FDA109B06DD6B1F279D87A /* PaneReducerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneReducerTests.swift; sourceTree = "<group>"; };
 		755D82DD1EFBD20111AC9BF2 /* RepoPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoPage.swift; sourceTree = "<group>"; };
 		75619FAA0B399E6EFEFD58ED /* WorktreeFileIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeFileIndexTests.swift; sourceTree = "<group>"; };
@@ -887,6 +890,7 @@
 		CB28B1CB12CE417A892A04C4 /* VTPipelineBenchmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VTPipelineBenchmarks.swift; sourceTree = "<group>"; };
 		CBC709BF6C114756E9794146 /* HostGatewayFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayFrameTests.swift; sourceTree = "<group>"; };
 		CC52B4BA3F3B6E593DC13486 /* PiExtensionInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiExtensionInstaller.swift; sourceTree = "<group>"; };
+		CC5DCCDD64708BEB08D20C0A /* PaneWorkingDirectory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneWorkingDirectory.swift; sourceTree = "<group>"; };
 		CCA00190FE1317EED4BDFA0D /* ProcessRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessRunner.swift; sourceTree = "<group>"; };
 		CCF6409060B18FD8F316245D /* PairingCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCrypto.swift; sourceTree = "<group>"; };
 		CD6CAE97113B8F2314759D70 /* PendingOrdersQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingOrdersQueue.swift; sourceTree = "<group>"; };
@@ -1522,6 +1526,7 @@
 				63C8FE4C75F1A4EF074C03C2 /* PaneStatusTests.swift */,
 				49437644810F143C24E9273B /* PaneTitleResolverTests.swift */,
 				5CF8D45DC59BA85924DB8D9E /* PaneTransferTests.swift */,
+				730849EDAF323B0D541E397C /* PaneWorkingDirectoryTests.swift */,
 				D8F5245DB2D144DD5964D270 /* PendingOrdersQueueTests.swift */,
 				4C5477C17977F4C27B7B01CB /* PiExtensionInstallerTests.swift */,
 				DC46DE31056D710E7F3BF1E2 /* PRListCellLayoutTests.swift */,
@@ -1651,6 +1656,7 @@
 				05F3C2A8D8BBDA9181C858E4 /* GhosttyNSView.swift */,
 				BB9854E3679A7AF9524F5077 /* LayoutNode.swift */,
 				9890C9BDCA01771964CF26FD /* PaneProgressBar.swift */,
+				CC5DCCDD64708BEB08D20C0A /* PaneWorkingDirectory.swift */,
 				5D7FF8E6F2D2E5EC4963C627 /* SplitNode.swift */,
 				849C6707188E7E90997D691A /* SplitTree.swift */,
 				40CAD3E9929AC9E5E32EBA9F /* Station.swift */,
@@ -2085,6 +2091,7 @@
 				371A789DDD991B083F733DB8 /* PaneStatusTests.swift in Sources */,
 				6AC11D3AF38BF0EEAD1C57F3 /* PaneTitleResolverTests.swift in Sources */,
 				B192412250A276B2421D9AEB /* PaneTransferTests.swift in Sources */,
+				47759F5CFF91DF5045DB4658 /* PaneWorkingDirectoryTests.swift in Sources */,
 				9B491C853EC9D44767FD6F90 /* PanelCoordinatorTests.swift in Sources */,
 				58A4DC34C98D37D2E6B90D09 /* PendingOrdersQueueTests.swift in Sources */,
 				34295E2A78AAF5B432E08698 /* PiExtensionInstallerTests.swift in Sources */,
@@ -2363,6 +2370,7 @@
 				3D2531372E08D4B5475FF17A /* PaneReducer.swift in Sources */,
 				88159AB787745A8A302E0FB2 /* PaneStatus.swift in Sources */,
 				CA52C85A65D3725357E07FDB /* PaneTitleResolver.swift in Sources */,
+				7ED2875B97C74F9DF0DF3F79 /* PaneWorkingDirectory.swift in Sources */,
 				5136C9D66B753F63E5BC83AD /* PanelCoordinator.swift in Sources */,
 				9C55DE7AD6C3DCE23F18B842 /* PendingOrdersQueue.swift in Sources */,
 				DA2A0458E60D38BD6F7C9649 /* PendingWorktreeTransfer.swift in Sources */,


### PR DESCRIPTION
四件互不相关的事，一个 commit 一件，每个都单独编译通过（bisect 到中间不会断）。

### `fix(telegram)` 绑定的 chat 不再被桌面可见性静音

外发镜像挂在系统横幅上，而且排在「你正看着这个 pane」那句 `return` **后面** —— 于是从 Telegram 下的指令，回复只落在下单人恰好坐在前面的那个终端里。`onDeliverExternal` 现在每条边都触发并汇报横幅是否真的显示了，由接收方划线：静音说的是「这块屏幕」，手机不是这块屏幕。全舰队监听者仍然让位，绑定到该 pane 的 chat 不再让位。

（这个 commit 也含上一轮就在工作区里的「按 `/go` 绑定路由通知」——同一个函数里的同一件事，分不开。）

### `feat(telegram)` 手机上批准 agent，群里对着 bot 说话

- agent 卡在权限弹窗/AskUserQuestion 时，那张卡片连同选项按钮发到能回答它的 chat，点按钮走的是 island 同一个 `handleSuggestionTapped`。`ChatCallbackRegistry` 本来就是为这个建的，之前没有生产者也没有消费者。
- suggestion 卡片不发新消息 —— 它的正文和完成通知是同一段 agent 原话，选项作为按钮**补到那条通知上**（锚点由 `ChatNoticeBook` 记，3 分钟过期）。没有通知就没有按钮。
- 卡片离开队列时，按钮在**每个**显示过它的 chat 里作废：token 退掉，这才是让「已答卡片上再点一下」变成空操作的东西。
- 群里原本只认 `/命令`，把 Telegram 给的另外两种「对着 bot 说」的姿势丢了：`@thebot` 开头、以及回复 bot 自己的消息。裸文本仍然不算 —— 那才是这道门要挡的。（privacy mode 下 Telegram 只投递后一种，文档里写清楚了。）

### `feat(integration)` 集成状态画在 checkout 自己那一行

checkout 没有 agent，`idle`/`running` 描述的是碰巧开在里面的 shell —— 一个丢了两个 worktree 的 round 顶着绿点是假话。那个点现在表达 round：`⑃` 干净、`!` 有东西被排除/留了标记/被 held、`✕` 这轮根本没跑起来、`◌` 还没跑过。字形加颜色，一列宽。

`needsAttention` 从 `IntegrationPanelState` 算出来，不从摘要文字里猜关键词。另外两件：round 抛异常时原本什么状态都不写，First Mate 会继续显示上一轮成功的行，宣称一个已经不存在的集成；顶部那条 banner（在把 checkout 排除出列表的两种分组下是唯一落点）现在写项目名 —— 它浮在整个列表之上，不写名字就会被读成它下面那个项目的。

### `fix(split)` 新 pane 开在旧 pane 站的地方

Closes #27。工作目录原本写死 worktree 根，那只是「还没 cd 之前」碰巧对。现在按可信度取：内核（`zmx list` 拿 shell pid → `proc_pidinfo`）→ OSC 7 的 `pwd` → pane 创建目录 → worktree 根兜底。内核排前面是因为它不会过时，而 zmx 会话里 shell 常年一次都不汇报。成本是一次 `zmx list` 加一个系统调用，只在 split 那一刻付。

---

**验证**：163 个相关单测通过（新增 `PaneWorkingDirectoryTests`、`ChatNoticeBookTests`、`ChatQuestionCardTests`、`IntegrationAttentionTests` 及若干扩充）。split 那条在实机上端到端验证过：源 pane `cd apps` 后 split，新 zmx 会话的 `start_dir` 确实是 `.../apps`。四个 commit 逐个 checkout 编译通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6fmGobHGJbmtYYAFfNtCW