### PR TITLE
fix(site): the example fleet drew a layout the app no longer has

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -104,37 +104,43 @@
           <span>3 worktrees &middot; 5 panes</span>
           <span class="island">
             <span><span class="dot s-wait">&#9679;</span> 1 needs input</span>
-            <span><span class="dot s-run pulse">&#9686;</span> 2 running</span>
+            <span><span class="dot s-run pulse">&#9680;</span> 2 running</span>
           </span>
         </div>
         <div class="fleet-grid">
           <div class="wt">
             <div class="wt-head"><span class="branch">main</span><span class="wt-state s-idle">idle</span></div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-idle">&#9675;</span> claude</div>
-              <div class="pane-msg">Idle &middot; 4m</div>
-            </div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-idle">&#9675;</span> codex</div>
-              <div class="pane-msg">Idle &middot; 22m</div>
+            <div class="wt-panes">
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-idle">&#9675;</span> claude</div>
+                <div class="pane-msg">Idle &middot; 4m</div>
+              </div>
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-idle">&#9675;</span> codex</div>
+                <div class="pane-msg">Idle &middot; 22m</div>
+              </div>
             </div>
           </div>
           <div class="wt">
             <div class="wt-head"><span class="branch">feat/island-usage</span><span class="wt-state s-run">running</span></div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-run pulse">&#9686;</span> claude</div>
-              <div class="pane-msg">Edit &middot; UsageSummaryFormatter.swift</div>
-            </div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-run pulse">&#9686;</span> codex</div>
-              <div class="pane-msg">Bash &middot; xcodebuild test</div>
+            <div class="wt-panes">
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-run pulse">&#9680;</span> claude</div>
+                <div class="pane-msg">Edit &middot; UsageSummaryFormatter.swift</div>
+              </div>
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-run pulse">&#9680;</span> codex</div>
+                <div class="pane-msg">Bash &middot; xcodebuild test</div>
+              </div>
             </div>
           </div>
           <div class="wt">
             <div class="wt-head"><span class="branch">fix/zmx-recovery</span><span class="wt-state s-wait">needs input</span></div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-wait">&#9679;</span> claude</div>
-              <div class="pane-msg">Allow <span style="color:var(--ink)">rm -rf .build</span>?</div>
+            <div class="wt-panes">
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-wait">&#9679;</span> claude</div>
+                <div class="pane-msg">Allow <span style="color:var(--ink)">rm -rf .build</span>?</div>
+              </div>
             </div>
           </div>
         </div>
@@ -221,9 +227,9 @@
           <rect x="146" y="212" width="354" height="100" rx="6" class="svg-box-plain"/>
           <text x="160" y="236" class="svg-t2">feat/island-usage</text>
           <rect x="162" y="248" width="160" height="48" rx="5" class="svg-box"/>
-          <text x="176" y="277" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  claude</text>
+          <text x="176" y="277" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  claude</text>
           <rect x="334" y="248" width="150" height="48" rx="5" class="svg-box"/>
-          <text x="348" y="277" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  codex</text>
+          <text x="348" y="277" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  codex</text>
 
           <!-- project B -->
           <rect x="524" y="66" width="386" height="260" rx="8" class="svg-box"/>
@@ -291,7 +297,7 @@
           <rect x="26" y="68" width="378" height="90" rx="6" class="svg-box"/>
           <text x="40" y="92" class="svg-t2">main</text>
           <rect x="42" y="104" width="172" height="42" rx="5" class="svg-box"/>
-          <text x="56" y="131" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  claude</text>
+          <text x="56" y="131" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  claude</text>
           <rect x="226" y="104" width="162" height="42" rx="5" class="svg-box"/>
           <text x="240" y="131" class="svg-t"><tspan fill="var(--idle)">&#9675;</tspan>  codex</text>
 
@@ -315,7 +321,7 @@
           <rect x="536" y="174" width="378" height="90" rx="6" class="svg-box"/>
           <text x="550" y="198" class="svg-t2">feat/x</text>
           <rect x="552" y="210" width="172" height="42" rx="5" fill="var(--accent-soft)" stroke="var(--accent)" stroke-width="1.6"/>
-          <text x="566" y="237" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  claude</text>
+          <text x="566" y="237" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  claude</text>
           <text x="914" y="231" class="svg-note" text-anchor="end">Station + zmx session kept</text>
           <text x="914" y="250" class="svg-lbl" text-anchor="end">placeholder destroyed</text>
 
@@ -524,7 +530,7 @@
     </figure>
 
     <div class="legend">
-      <div><span class="g s-run">&#9686;</span><span class="k">Running</span><span class="v">a tool call is in flight</span></div>
+      <div><span class="g s-run">&#9680;</span><span class="k">Running</span><span class="v">a tool call is in flight</span></div>
       <div><span class="g s-wait">&#9679;</span><span class="k">Needs input</span><span class="v">blocked on a human</span></div>
       <div><span class="g s-idle">&#9675;</span><span class="k">Idle</span><span class="v">prompt is back, waiting</span></div>
       <div><span class="g s-err">&#10005;</span><span class="k">Error</span><span class="v">the agent broke</span></div>
@@ -676,7 +682,7 @@
           <text x="36" y="104" class="svg-t2">HEAD + edits</text>
 
           <rect x="206" y="48" width="170" height="86" rx="7" class="svg-box"/>
-          <text x="222" y="78" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  feat/island</text>
+          <text x="222" y="78" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  feat/island</text>
           <text x="222" y="104" class="svg-t2">mid-turn</text>
 
           <rect x="392" y="48" width="170" height="86" rx="7" class="svg-box"/>

--- a/site/style.css
+++ b/site/style.css
@@ -182,12 +182,19 @@ p  { margin: 0; }
   border: 1px solid var(--rule); border-radius: 999px; padding: .3rem .7rem;
   background: var(--sea-1);
 }
-.fleet-grid { display: grid; grid-template-columns: repeat(3, 1fr); }
-.wt { padding: .85rem .9rem 1rem; border-right: 1px solid var(--rule-2); display: grid; gap: .6rem; align-content: start; }
-.wt:last-child { border-right: 0; }
-.wt-head { display: flex; align-items: baseline; gap: .5rem; }
+/* A roster, not a grid of cards: one row per worktree, its panes side by side
+   inside the row — which is what a split actually is. */
+.fleet-grid { display: grid; }
+.wt {
+  padding: .7rem .9rem; border-bottom: 1px solid var(--rule-2);
+  display: grid; grid-template-columns: minmax(9.5rem, 14rem) 1fr;
+  gap: .75rem; align-items: center;
+}
+.wt:last-child { border-bottom: 0; }
+.wt-head { display: flex; align-items: baseline; gap: .5rem; min-width: 0; }
+.wt-panes { display: grid; grid-auto-flow: column; grid-auto-columns: 1fr; gap: .5rem; min-width: 0; }
 .branch { font: 500 .84rem/1.2 var(--f-mono); }
-.wt-state { margin-left: auto; font: 400 .68rem/1 var(--f-mono); text-transform: uppercase; letter-spacing: .09em; }
+.wt-state { margin-left: .1rem; font: 400 .68rem/1 var(--f-mono); text-transform: uppercase; letter-spacing: .09em; }
 .pane {
   border: 1px solid var(--rule-2); border-radius: 6px; padding: .5rem .6rem;
   background: var(--sea-2); display: grid; gap: .28rem;
@@ -336,9 +343,8 @@ footer { border-top: 1px solid var(--rule); padding: 2.8rem 0 3.6rem; display: g
 .foot-meta { font: 400 .78rem/1.7 var(--f-mono); color: var(--ink-2); }
 
 @media (max-width: 720px) {
-  .fleet-grid { grid-template-columns: 1fr; }
-  .wt { border-right: 0; border-bottom: 1px solid var(--rule-2); }
-  .wt:last-child { border-bottom: 0; }
+  .wt { grid-template-columns: 1fr; align-items: start; gap: .5rem; }
+  .wt-panes { grid-auto-flow: row; }
   .row { grid-template-columns: 1fr; gap: .3rem; }
   .legend > div { border-right: 0; border-bottom: 1px solid var(--rule-2); }
 }

--- a/site/zh/index.html
+++ b/site/zh/index.html
@@ -103,37 +103,43 @@
           <span>3 个 worktree &middot; 5 个 pane</span>
           <span class="island">
             <span><span class="dot s-wait">&#9679;</span> 1 个待输入</span>
-            <span><span class="dot s-run pulse">&#9686;</span> 2 个在跑</span>
+            <span><span class="dot s-run pulse">&#9680;</span> 2 个在跑</span>
           </span>
         </div>
         <div class="fleet-grid">
           <div class="wt">
             <div class="wt-head"><span class="branch">main</span><span class="wt-state s-idle">空闲</span></div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-idle">&#9675;</span> claude</div>
-              <div class="pane-msg">空闲 &middot; 4 分钟</div>
-            </div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-idle">&#9675;</span> codex</div>
-              <div class="pane-msg">空闲 &middot; 22 分钟</div>
+            <div class="wt-panes">
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-idle">&#9675;</span> claude</div>
+                <div class="pane-msg">空闲 &middot; 4 分钟</div>
+              </div>
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-idle">&#9675;</span> codex</div>
+                <div class="pane-msg">空闲 &middot; 22 分钟</div>
+              </div>
             </div>
           </div>
           <div class="wt">
             <div class="wt-head"><span class="branch">feat/island-usage</span><span class="wt-state s-run">运行中</span></div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-run pulse">&#9686;</span> claude</div>
-              <div class="pane-msg">Edit &middot; UsageSummaryFormatter.swift</div>
-            </div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-run pulse">&#9686;</span> codex</div>
-              <div class="pane-msg">Bash &middot; xcodebuild test</div>
+            <div class="wt-panes">
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-run pulse">&#9680;</span> claude</div>
+                <div class="pane-msg">Edit &middot; UsageSummaryFormatter.swift</div>
+              </div>
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-run pulse">&#9680;</span> codex</div>
+                <div class="pane-msg">Bash &middot; xcodebuild test</div>
+              </div>
             </div>
           </div>
           <div class="wt">
             <div class="wt-head"><span class="branch">fix/zmx-recovery</span><span class="wt-state s-wait">待输入</span></div>
-            <div class="pane">
-              <div class="pane-top"><span class="dot s-wait">&#9679;</span> claude</div>
-              <div class="pane-msg">允许执行 <span style="color:var(--ink)">rm -rf .build</span> 吗？</div>
+            <div class="wt-panes">
+              <div class="pane">
+                <div class="pane-top"><span class="dot s-wait">&#9679;</span> claude</div>
+                <div class="pane-msg">允许执行 <span style="color:var(--ink)">rm -rf .build</span> 吗？</div>
+              </div>
             </div>
           </div>
         </div>
@@ -220,9 +226,9 @@
           <rect x="146" y="212" width="354" height="100" rx="6" class="svg-box-plain"/>
           <text x="160" y="236" class="svg-t2">feat/island-usage</text>
           <rect x="162" y="248" width="160" height="48" rx="5" class="svg-box"/>
-          <text x="176" y="277" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  claude</text>
+          <text x="176" y="277" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  claude</text>
           <rect x="334" y="248" width="150" height="48" rx="5" class="svg-box"/>
-          <text x="348" y="277" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  codex</text>
+          <text x="348" y="277" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  codex</text>
 
           <!-- project B -->
           <rect x="524" y="66" width="386" height="260" rx="8" class="svg-box"/>
@@ -290,7 +296,7 @@
           <rect x="26" y="68" width="378" height="90" rx="6" class="svg-box"/>
           <text x="40" y="92" class="svg-t2">main</text>
           <rect x="42" y="104" width="172" height="42" rx="5" class="svg-box"/>
-          <text x="56" y="131" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  claude</text>
+          <text x="56" y="131" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  claude</text>
           <rect x="226" y="104" width="162" height="42" rx="5" class="svg-box"/>
           <text x="240" y="131" class="svg-t"><tspan fill="var(--idle)">&#9675;</tspan>  codex</text>
 
@@ -314,7 +320,7 @@
           <rect x="536" y="174" width="378" height="90" rx="6" class="svg-box"/>
           <text x="550" y="198" class="svg-t2">feat/x</text>
           <rect x="552" y="210" width="172" height="42" rx="5" fill="var(--accent-soft)" stroke="var(--accent)" stroke-width="1.6"/>
-          <text x="566" y="237" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  claude</text>
+          <text x="566" y="237" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  claude</text>
           <text x="914" y="231" class="svg-note" text-anchor="end">Station 与 zmx 会话都留着</text>
           <text x="914" y="250" class="svg-lbl" text-anchor="end">占位 pane 被销毁</text>
 
@@ -523,7 +529,7 @@
     </figure>
 
     <div class="legend">
-      <div><span class="g s-run">&#9686;</span><span class="k">运行中</span><span class="v">有一次工具调用在途</span></div>
+      <div><span class="g s-run">&#9680;</span><span class="k">运行中</span><span class="v">有一次工具调用在途</span></div>
       <div><span class="g s-wait">&#9679;</span><span class="k">待输入</span><span class="v">卡在等人</span></div>
       <div><span class="g s-idle">&#9675;</span><span class="k">空闲</span><span class="v">提示符回来了，等着</span></div>
       <div><span class="g s-err">&#10005;</span><span class="k">出错</span><span class="v">agent 挂了</span></div>
@@ -671,7 +677,7 @@
           <text x="36" y="104" class="svg-t2">HEAD + 改动</text>
 
           <rect x="206" y="48" width="170" height="86" rx="7" class="svg-box"/>
-          <text x="222" y="78" class="svg-t"><tspan fill="var(--run)">&#9686;</tspan>  feat/island</text>
+          <text x="222" y="78" class="svg-t"><tspan fill="var(--run)">&#9680;</tspan>  feat/island</text>
           <text x="222" y="104" class="svg-t2">一轮进行中</text>
 
           <rect x="392" y="48" width="170" height="86" rx="7" class="svg-box"/>


### PR DESCRIPTION
Two things wrong with the example-fleet mock-up, both against a caption that promises accuracy: *"Every status above is one the app really reports."*

## 1. It drew worktree cards

The mock-up was a three-column grid of `.wt` cards. That is the Grid/card dashboard removed before #97 — and it sat **directly beneath** a lede promising "a row per worktree, mustered by repo, by status, or by what moved last, one agent to a split pane." The picture contradicted the sentence above it.

Now a roster: one row per worktree, branch and status on the left, its panes side by side inside the row — which is what a split is. Rendered and eyeballed at 1280px and at the mobile breakpoint, both languages.

## 2. The running dot was the wrong glyph

| status | mock-up | `AgentStatus.glyph` |
|---|---|---|
| idle | `○` U+25CB | `○` ✅ |
| needs input | `●` U+25CF | `●` ✅ |
| running | `◖` **U+25D6** | `◐` **U+25D0** ❌ |

Nine occurrences per page, both languages.

## Not fixed here

The mock-up shows three of the six statuses `AgentStatus` defines — `error ✕`, `exited ◌` and `unknown ◌` are absent. Not a lie (the caption says every status shown is real, not that every real status is shown), but a section selling "you can see who is stuck" arguably wants the error state in the picture. Left alone since it changes what the section argues, not just how it is drawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYGZXCWRW3mLnhr8ADuGjh