### PR TITLE
Rebind the gateway port instead of reporting a dead ready

### DIFF
--- a/Sources/Core/HostGatewayServer.swift
+++ b/Sources/Core/HostGatewayServer.swift
@@ -34,6 +34,21 @@ final class HostGatewayServer {
     private var proxied: [ObjectIdentifier: NWConnection] = [:]
     private var readyHandlers: [() -> Void] = []
     private let stateLock = NSLock()
+    /// Rebind attempts left for the public port.
+    ///
+    /// `NWListener.cancel()` is asynchronous, so `stop()` returns while the old
+    /// listener may still hold the port and a restart — which is what a pairing
+    /// mint does — can land on an address that is not free yet. Unretried that
+    /// surfaces as `.failed`, and `failStart` then fires the ready handlers with
+    /// `isListening == false`: the switch reads on with nothing behind it, the
+    /// one outcome owning this port is meant to rule out.
+    private var frontBindAttemptsLeft = 0
+    private static let frontBindAttempts = 20
+    private static let frontBindRetryDelay: TimeInterval = 0.05
+    /// Tells the current bind attempt from a superseded one, so a dropped
+    /// listener's late `.cancelled` cannot tear down its own replacement.
+    private var frontListenerGeneration = 0
+
     private var _isListening = false
 
     /// Request head cap: real browser heads are ~1KB, so this only bounds abuse.
@@ -84,6 +99,7 @@ final class HostGatewayServer {
                 if self.isListening { self.fireReadyHandlers() }
                 return
             }
+            self.frontBindAttemptsLeft = Self.frontBindAttempts
             self.subscribeToAgentEvents()
             self.startWebSocketListener()
         }
@@ -194,13 +210,21 @@ final class HostGatewayServer {
         do {
             let listener = try NWListener(using: parameters, on: port)
             frontListener = listener
+            frontListenerGeneration += 1
+            let generation = frontListenerGeneration
             listener.stateUpdateHandler = { [weak self] state in
-                guard let self else { return }
+                guard let self, generation == self.frontListenerGeneration else { return }
                 switch state {
                 case .ready:
                     self.isListening = true
                     self.fireReadyHandlers()
-                case .failed, .cancelled:
+                case .failed:
+                    // A port still held by a listener we only just cancelled is
+                    // a slow start, not a dead one.
+                    if !self.retryFrontListener() {
+                        self.failStart("front listener \(state)")
+                    }
+                case .cancelled:
                     self.failStart("front listener \(state)")
                 default:
                     break
@@ -214,6 +238,23 @@ final class HostGatewayServer {
             NSLog("[HostGateway] front listener failed: \(error.localizedDescription)")
             failStart("front listener error")
         }
+    }
+
+    /// Drops the failed attempt and schedules another, if any are left and the
+    /// server has not been stopped meanwhile. Returns whether it did.
+    private func retryFrontListener() -> Bool {
+        guard frontBindAttemptsLeft > 0, wsListener != nil else { return false }
+        frontBindAttemptsLeft -= 1
+        // Orphan this attempt's handler before cancelling it, or its own
+        // `.cancelled` would come back through the branch below as a teardown.
+        frontListenerGeneration += 1
+        frontListener?.cancel()
+        frontListener = nil
+        queue.asyncAfter(deadline: .now() + Self.frontBindRetryDelay) { [weak self] in
+            guard let self, self.frontListener == nil, self.wsListener != nil else { return }
+            self.startFrontListener()
+        }
+        return true
     }
 
     private func failStart(_ reason: String) {

--- a/Tests/ProcessProbeTests.swift
+++ b/Tests/ProcessProbeTests.swift
@@ -162,17 +162,48 @@ final class ProcessProbeTests: XCTestCase {
         XCTAssertEqual(argv, ProcessProbe.argv(of: getpid()), "parse must be stable across calls")
     }
 
-    func testArgvIsStableWhenABufferIsReusedAcrossProcesses() {
-        // The batch path reuses one buffer, so a long argv followed by a short one
-        // must not leave the earlier process's bytes visible in the second result.
-        let table = ProcessProbe.processTable()
-        XCTAssertFalse(table.isEmpty)
-        let sampled = Array(table.prefix(40))
-        let batch = ProcessProbe.withArgv(sampled)
-        for proc in batch {
-            XCTAssertEqual(proc.argv, ProcessProbe.argv(of: proc.pid),
-                           "pid \(proc.pid) parsed differently in the batch than on its own")
+    func testArgvIsStableWhenABufferIsReusedAcrossProcesses() throws {
+        // Two children of this test, not a sample of the machine's process table.
+        // The property under test is that the shared buffer leaves nothing of a
+        // long argv in the short one read after it. Demonstrating that against
+        // live processes meant re-reading a pid later and trusting it still named
+        // the same process — on a busy machine it may have exited, or had its pid
+        // reused by something unrelated, and the comparison then failed over
+        // process mortality rather than buffer hygiene.
+        let padding = String(repeating: "Z", count: 4096)
+        let long = Process()
+        long.executableURL = URL(fileURLWithPath: "/bin/sh")
+        long.arguments = ["-c", "sleep 5 # \(padding)"]
+        let short = Process()
+        short.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        short.arguments = ["5"]
+        try long.run()
+        try short.run()
+        defer { long.terminate(); short.terminate() }
+
+        // `run()` returns once the fork is under way; argv is only readable after
+        // the exec has landed.
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline,
+              ProcessProbe.argv(of: long.processIdentifier).isEmpty
+                || ProcessProbe.argv(of: short.processIdentifier).isEmpty {
+            usleep(20_000)
         }
+
+        // Long first: the short read that follows is the one that could inherit
+        // whatever the long one left behind.
+        let batch = ProcessProbe.withArgv([
+            ProcessProbe.Proc(pid: long.processIdentifier, ppid: getpid(), argv: []),
+            ProcessProbe.Proc(pid: short.processIdentifier, ppid: getpid(), argv: []),
+        ])
+
+        XCTAssertTrue(batch[0].argv.joined(separator: " ").contains(padding),
+                      "the long argv must really be long, or the short read proves nothing")
+        XCTAssertEqual(batch[1].argv.count, 2, "short argv came back as \(batch[1].argv)")
+        XCTAssertTrue(batch[1].argv[0].hasSuffix("sleep"))
+        XCTAssertEqual(batch[1].argv[1], "5")
+        XCTAssertFalse(batch[1].argv.joined().contains("Z"),
+                       "the previous process's bytes bled through the reused buffer")
     }
 
     func testProcessTableCarriesTreeShapeWithoutArgv() {


### PR DESCRIPTION
一个从 `fix/two-flaky-tests`(2026-09-01,从没开过 PR)cherry-pick 回来的 commit。`HostGatewayServer.swift` 和 `ProcessProbeTests.swift` 从那个分支点起在 main 上一行都没改过,所以 cherry-pick 零冲突,内容与当初完全一致。

### 网关这个不是测试问题

`NWListener.cancel()` 是异步的:`stop()` 返回时旧监听器可能还占着公开端口,紧接着的 `start()` 绑到还没释放的地址上,拿到 `.failed`,走进 `failStart` —— 而 `failStart` 在 `isListening = false` 之后**照样触发 ready 回调**。等待方被告知网关已就绪,实际没有任何东西在服务。

生产里够得着:**配对 mint 就是用这个方式重启 server 的**。日志里只留一行 `bind(...) [48: Address already in use]`,然后一切看起来正常。

修法是 `startFrontListener` 重试绑定,最多 1 秒(20 × 50ms),两道保险:generation 计数器,让某次被放弃的尝试迟到的 `.cancelled` 不能拆掉它自己的替身;以及 `wsListener != nil` 判断,让 `stop()` 之前排队的重试不会在 `stop()` 之后又把端口绑回来。

### 另一半:ProcessProbeTests 不再跟机器的进程表赛跑

`testArgvIsStableWhenABufferIsReusedAcrossProcesses` 原本采样机器上 40 个真实进程,跑一遍批量路径,再逐个复读比对 —— 两次读的都是移动目标:进程可能在两次之间退出(argv 变空),更糟的是 pid 被回收(有一次抓到 `seahelm-hook claude-code` 复读成了 `base64 -d`)。这些都不说明 buffer 有没有问题。

改成自己 spawn 两个子进程(先一个长 argv,再一个短的 `sleep`),断言短的那次读不带上一个的任何字节。同一个性质,不依赖机器上正在跑什么。

### 验证(在今天的 main 上重新跑的)

| | `HostGatewayServerTests` × 5 |
|---|---|
| 带修复 | **5 通过 / 0 失败** |
| 只把 `HostGatewayServer.swift` 退回 main | 4 通过 / **1 失败** |

失败那次复现的正是上面那一幕,而且测试拿到 ready 之后真的去连了端口:

```
[HostGateway] not listening: front listener cancelled
HostGatewayServerTests.swift:51: error: testStoppingReleasesThePortForTheNextServer
  XCTAssertTrue failed - server should be listening on port 27999
[C7 127.0.0.1:27999] Socket SO_ERROR [61: Connection refused]
```

n=5 不构成统计证明,但它把这个具体失败重现了,而带修复的 5 次一次没挂(那 5 次同时跑了 `ProcessProbeTests`,也全过)。

原 commit 里提到的第三个 flaky(`ChromeCollapseAnimationTests`)不在本 PR 范围内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6fmGobHGJbmtYYAFfNtCW