### PR TITLE
Drop the example fleet from the site instead of redrawing it

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -34,7 +34,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+Condensed:wght@600;700&family=IBM+Plex+Sans:wght@400;500&family=Newsreader:ital,opsz,wght@1,6..72,400&display=swap">
 
-<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/style.css?v=20260908">
 </head>
 <body>
 <!-- ══════════════ MASTHEAD + HERO · above the waterline ══════════════ -->
@@ -93,60 +93,10 @@
   </div>
 </section>
 
-<!-- ══════════════ THE WATERLINE · the fleet at rest ══════════════ -->
+<!-- ══════════════ THE WATERLINE · getting aboard ══════════════ -->
 <section class="deck surface">
   <div class="wrap">
     <div class="berth">
-      <div class="fleet">
-        <div class="fleet-bar">
-          <span>openbeta/seahelm</span>
-          <span style="opacity:.5">&middot;</span>
-          <span>3 worktrees &middot; 5 panes</span>
-          <span class="island">
-            <span><span class="dot s-wait">&#9679;</span> 1 needs input</span>
-            <span><span class="dot s-run pulse">&#9680;</span> 2 running</span>
-          </span>
-        </div>
-        <div class="fleet-grid">
-          <div class="wt">
-            <div class="wt-head"><span class="branch">main</span><span class="wt-state s-idle">idle</span></div>
-            <div class="wt-panes">
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-idle">&#9675;</span> claude</div>
-                <div class="pane-msg">Idle &middot; 4m</div>
-              </div>
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-idle">&#9675;</span> codex</div>
-                <div class="pane-msg">Idle &middot; 22m</div>
-              </div>
-            </div>
-          </div>
-          <div class="wt">
-            <div class="wt-head"><span class="branch">feat/island-usage</span><span class="wt-state s-run">running</span></div>
-            <div class="wt-panes">
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-run pulse">&#9680;</span> claude</div>
-                <div class="pane-msg">Edit &middot; UsageSummaryFormatter.swift</div>
-              </div>
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-run pulse">&#9680;</span> codex</div>
-                <div class="pane-msg">Bash &middot; xcodebuild test</div>
-              </div>
-            </div>
-          </div>
-          <div class="wt">
-            <div class="wt-head"><span class="branch">fix/zmx-recovery</span><span class="wt-state s-wait">needs input</span></div>
-            <div class="wt-panes">
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-wait">&#9679;</span> claude</div>
-                <div class="pane-msg">Allow <span style="color:var(--ink)">rm -rf .build</span>?</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <p class="note">Example fleet. Every status above is one the app really reports.</p>
-
       <div class="hero-cta">
         <div class="cmd"><span class="prompt">$</span> curl -fsSL https://seahelm.dev/install.sh | sh</div>
         <a class="linkout" href="https://github.com/BetaYao/seahelm">github.com/BetaYao/seahelm</a>

--- a/site/style.css
+++ b/site/style.css
@@ -167,48 +167,11 @@ p  { margin: 0; }
 }
 .linkout:hover { color: var(--ink); }
 
-/* ── the at-rest fleet strip ──────────────────────────────────── */
-.fleet {
-  border: 1px solid var(--rule); border-radius: 10px; overflow: hidden;
-  background: var(--sea-1); box-shadow: var(--shadow); margin-top: .5rem;
-}
-.fleet-bar {
-  display: flex; align-items: center; gap: .75rem; flex-wrap: wrap;
-  padding: .6rem .85rem; border-bottom: 1px solid var(--rule-2);
-  background: var(--sea-2); font: 400 .78rem/1 var(--f-mono); color: var(--ink-2);
-}
-.island {
-  margin-left: auto; display: inline-flex; align-items: center; gap: .6rem;
-  border: 1px solid var(--rule); border-radius: 999px; padding: .3rem .7rem;
-  background: var(--sea-1);
-}
-/* A roster, not a grid of cards: one row per worktree, its panes side by side
-   inside the row — which is what a split actually is. */
-.fleet-grid { display: grid; }
-.wt {
-  padding: .7rem .9rem; border-bottom: 1px solid var(--rule-2);
-  display: grid; grid-template-columns: minmax(9.5rem, 14rem) 1fr;
-  gap: .75rem; align-items: center;
-}
-.wt:last-child { border-bottom: 0; }
-.wt-head { display: flex; align-items: baseline; gap: .5rem; min-width: 0; }
-.wt-panes { display: grid; grid-auto-flow: column; grid-auto-columns: 1fr; gap: .5rem; min-width: 0; }
-.branch { font: 500 .84rem/1.2 var(--f-mono); }
-.wt-state { margin-left: .1rem; font: 400 .68rem/1 var(--f-mono); text-transform: uppercase; letter-spacing: .09em; }
-.pane {
-  border: 1px solid var(--rule-2); border-radius: 6px; padding: .5rem .6rem;
-  background: var(--sea-2); display: grid; gap: .28rem;
-}
-.pane-top { display: flex; align-items: center; gap: .45rem; font: 500 .78rem/1 var(--f-mono); }
-.pane-msg { font: 400 .74rem/1.35 var(--f-mono); color: var(--ink-2); }
-.dot { font-size: .95em; line-height: 1; }
+/* ── status colours · shared by the state legend ──────────────── */
 .s-run  { color: var(--run); }
 .s-wait { color: var(--wait); }
 .s-idle { color: var(--idle); }
 .s-err  { color: var(--err); }
-.pulse { animation: pulse 2.4s ease-in-out infinite; }
-@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .42; } }
-@media (prefers-reduced-motion: reduce) { .pulse { animation: none; } }
 
 /* ── the tour ─────────────────────────────────────────────────── */
 .film { padding: 2.6rem 0 0; display: grid; gap: 1rem; }
@@ -343,8 +306,6 @@ footer { border-top: 1px solid var(--rule); padding: 2.8rem 0 3.6rem; display: g
 .foot-meta { font: 400 .78rem/1.7 var(--f-mono); color: var(--ink-2); }
 
 @media (max-width: 720px) {
-  .wt { grid-template-columns: 1fr; align-items: start; gap: .5rem; }
-  .wt-panes { grid-auto-flow: row; }
   .row { grid-template-columns: 1fr; gap: .3rem; }
   .legend > div { border-right: 0; border-bottom: 1px solid var(--rule-2); }
 }

--- a/site/zh/index.html
+++ b/site/zh/index.html
@@ -34,7 +34,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans+Condensed:wght@600;700&family=IBM+Plex+Sans:wght@400;500&family=Newsreader:ital,opsz,wght@1,6..72,400&display=swap">
 
-<link rel="stylesheet" href="/style.css">
+<link rel="stylesheet" href="/style.css?v=20260908">
 </head>
 <body>
 <!-- ══════════════ MASTHEAD + HERO · above the waterline ══════════════ -->
@@ -92,60 +92,10 @@
   </div>
 </section>
 
-<!-- ══════════════ THE WATERLINE · the fleet at rest ══════════════ -->
+<!-- ══════════════ THE WATERLINE · getting aboard ══════════════ -->
 <section class="deck surface">
   <div class="wrap">
     <div class="berth">
-      <div class="fleet">
-        <div class="fleet-bar">
-          <span>openbeta/seahelm</span>
-          <span style="opacity:.5">&middot;</span>
-          <span>3 个 worktree &middot; 5 个 pane</span>
-          <span class="island">
-            <span><span class="dot s-wait">&#9679;</span> 1 个待输入</span>
-            <span><span class="dot s-run pulse">&#9680;</span> 2 个在跑</span>
-          </span>
-        </div>
-        <div class="fleet-grid">
-          <div class="wt">
-            <div class="wt-head"><span class="branch">main</span><span class="wt-state s-idle">空闲</span></div>
-            <div class="wt-panes">
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-idle">&#9675;</span> claude</div>
-                <div class="pane-msg">空闲 &middot; 4 分钟</div>
-              </div>
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-idle">&#9675;</span> codex</div>
-                <div class="pane-msg">空闲 &middot; 22 分钟</div>
-              </div>
-            </div>
-          </div>
-          <div class="wt">
-            <div class="wt-head"><span class="branch">feat/island-usage</span><span class="wt-state s-run">运行中</span></div>
-            <div class="wt-panes">
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-run pulse">&#9680;</span> claude</div>
-                <div class="pane-msg">Edit &middot; UsageSummaryFormatter.swift</div>
-              </div>
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-run pulse">&#9680;</span> codex</div>
-                <div class="pane-msg">Bash &middot; xcodebuild test</div>
-              </div>
-            </div>
-          </div>
-          <div class="wt">
-            <div class="wt-head"><span class="branch">fix/zmx-recovery</span><span class="wt-state s-wait">待输入</span></div>
-            <div class="wt-panes">
-              <div class="pane">
-                <div class="pane-top"><span class="dot s-wait">&#9679;</span> claude</div>
-                <div class="pane-msg">允许执行 <span style="color:var(--ink)">rm -rf .build</span> 吗？</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <p class="note">示例舰队。上面每一种状态都是这个 app 真实会报的状态。</p>
-
       <div class="hero-cta">
         <div class="cmd"><span class="prompt">$</span> curl -fsSL https://seahelm.dev/install.sh | sh</div>
         <a class="linkout" href="https://github.com/BetaYao/seahelm">github.com/BetaYao/seahelm</a>


### PR DESCRIPTION
首页那块手绘的「示例舰队」画的是 app 早就没有的布局。它已经因为这个原因被重画过一次(#110),而这次改动落地时它正在被重画第二次 —— 这恰好就是删掉它的理由:**一张手写的 UI 图就是那个 UI 的第二份拷贝,而且永远是没人更新的那一份。**

而且那句 caption 写着「上面每一种状态都是这个 app 真实会报的状态」,所以它过期不是美观问题,是这句话变成了假话。

下面那段 tour 视频拍的是真家伙、在动;上面那段 lede 用文字说清了名册是什么。两者都不会自己过期。

### 删了什么

- 中英两版首页里整块 `<div class="fleet">` mock 及其 caption;安装命令那块 `hero-cta` 留着。
- 随之变成死代码的 CSS:`.fleet*`、`.wt*`、`.pane*`、`.branch`、`.dot`、`.pulse` 和它的 `@keyframes`,以及 720px 断点里对应的两条。
- `.s-run/.s-wait/.s-idle/.s-err` **保留** —— 下面的状态图例还在用,给它换了个独立的注释头。
- 区块注释 `THE WATERLINE · the fleet at rest` → `getting aboard`,因为那儿已经没有舰队了。

两个页面都重新过了标签配对检查。净变化 5 增 144 删。

`?v=20260908` 那个样式表缓存戳是另一个 session 留在工作区里的,一并带上了 —— 这次改动动了 style.css,而站点走 CDN。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6fmGobHGJbmtYYAFfNtCW