### PR TITLE
Draw the integration report card the queue was already raising

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -2332,7 +2332,7 @@ extension MainWindowController {
         publishCardsToChat(tabCoordinator.pendingOrders.all())
 
         let fresh = islandSeenSuggestions.absorb(orders)
-        if !fresh.isEmpty, !model.isOpened {
+        if IslandModel.shouldOpen(for: fresh), !model.isOpened {
             let targetVisible = fresh.allSatisfy {
                 tabCoordinator.isWorktreeVisible($0.action.worktreePath)
             }

--- a/Sources/UI/Island/IslandModel.swift
+++ b/Sources/UI/Island/IslandModel.swift
@@ -77,10 +77,30 @@ final class IslandModel {
     /// a healthy one looks like, which is why this has to be said out loud.
     var controlChannelWarning: String?
 
+    /// The cards the island draws, newest first.
+    ///
+    /// `suggestNextOrder` covers an agent's next-step chips and its questions
+    /// alike — they share the kind and differ by payload. `integrationReport`
+    /// is here because the island is the only place its one irreversible
+    /// option is offered: the card was raised on every held round and drawn
+    /// nowhere, so the decision existed and could not be reached.
     static func newestSuggestions(from orders: [PendingOrder]) -> [PendingOrder] {
         Array(orders.lazy
-            .filter { $0.action.kind == .suggestNextOrder }
+            .filter { $0.action.kind == .suggestNextOrder || $0.action.kind == .integrationReport }
             .reversed())
+    }
+
+    /// Whether newly-arrived cards are worth opening the island for.
+    ///
+    /// A card with nothing to decide is a notice and waits to be found. That
+    /// separates the two integration rounds worth telling apart: one that
+    /// dropped a conflicting worktree says so and stays put — it happens on
+    /// every round while two worktrees touch the same file — while one held
+    /// back, whose only way forward destroys what is in the checkout, pops.
+    /// Agent suggestions and questions always carry options, so this changes
+    /// nothing for them.
+    static func shouldOpen(for fresh: [PendingOrder]) -> Bool {
+        fresh.contains { !($0.action.options ?? []).isEmpty }
     }
 
     /// Screen geometry, set by the panel controller.

--- a/Sources/UI/Island/OpenedSurfaceView.swift
+++ b/Sources/UI/Island/OpenedSurfaceView.swift
@@ -397,18 +397,34 @@ private struct SuggestionCard: View {
     private var isQuestion: Bool {
         FirstMateAction.isQuestionPayload(order.action.payload)
     }
+    /// An integration round, which belongs to a repo rather than to a pane:
+    /// no agent raised it and there is no branch behind it.
+    private var isIntegration: Bool {
+        order.action.kind == .integrationReport
+    }
+
+    private var icon: String {
+        if isIntegration { return "arrow.triangle.merge" }
+        return isQuestion ? "questionmark.circle.fill" : "lightbulb.fill"
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 6) {
-                Image(systemName: isQuestion ? "questionmark.circle.fill" : "lightbulb.fill")
+                Image(systemName: icon)
                     .font(.system(size: 11))
-                    .foregroundStyle(.yellow)
+                    .foregroundStyle(isIntegration ? .orange : .yellow)
                 Text(order.action.project)
                     .font(.system(size: 11, weight: .semibold, design: .monospaced))
                     .foregroundStyle(.white.opacity(0.85))
                 if !order.action.branch.isEmpty {
                     Text(order.action.branch)
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.5))
+                } else if isIntegration {
+                    // The card names what it is about: without this it reads as
+                    // the repo saying something, and a repo never speaks.
+                    Text("integration")
                         .font(.system(size: 11, weight: .medium, design: .monospaced))
                         .foregroundStyle(.white.opacity(0.5))
                 }

--- a/Tests/PendingOrdersQueueTests.swift
+++ b/Tests/PendingOrdersQueueTests.swift
@@ -67,6 +67,49 @@ final class PendingOrdersQueueTests: XCTestCase {
         XCTAssertEqual(q.all().last?.action.message, "new")
     }
 
+    /// The island is the only place integration's one irreversible option is
+    /// offered, and the card carrying it used to be raised on every held round
+    /// and drawn nowhere.
+    func testIslandDrawsIntegrationReportsToo() {
+        let q = PendingOrdersQueue()
+        q.upsert(action(.suggestNextOrder, wt: "/wt/a"))
+        q.upsert(FirstMateAction(kind: .integrationReport, zone: .red,
+                                 worktreePath: "/wt/integration", branch: "", project: "p",
+                                 terminalID: "", message: "excluded b",
+                                 options: ["Discard edits & update", "Leave it"]))
+
+        XCTAssertEqual(IslandModel.newestSuggestions(from: q.all()).map(\.action.kind),
+                       [.integrationReport, .suggestNextOrder])
+    }
+
+    /// The kinds with no card behind them stay out of the list.
+    func testIslandLeavesNonCardKindsOut() {
+        let q = PendingOrdersQueue()
+        q.enqueue(action(.watchWaiting))
+        q.enqueue(action(.autoCommit))
+
+        XCTAssertTrue(IslandModel.newestSuggestions(from: q.all()).isEmpty)
+    }
+
+    /// A round that dropped a conflicting worktree is a notice and waits to be
+    /// found — it happens on every round while two worktrees touch the same
+    /// file. A round held back, whose only way forward destroys what is in the
+    /// checkout, pops the island.
+    func testOnlyACardWithSomethingToDecideOpensTheIsland() {
+        let notice = PendingOrder(id: "n", action: FirstMateAction(
+            kind: .integrationReport, zone: .red, worktreePath: "/wt/i", branch: "",
+            project: "p", terminalID: "", message: "excluded b"))
+        let decision = PendingOrder(id: "d", action: FirstMateAction(
+            kind: .integrationReport, zone: .red, worktreePath: "/wt/i", branch: "",
+            project: "p", terminalID: "", message: "held",
+            options: ["Discard edits & update", "Leave it"]))
+
+        XCTAssertFalse(IslandModel.shouldOpen(for: [notice]))
+        XCTAssertTrue(IslandModel.shouldOpen(for: [decision]))
+        XCTAssertTrue(IslandModel.shouldOpen(for: [notice, decision]))
+        XCTAssertFalse(IslandModel.shouldOpen(for: []))
+    }
+
     func testIslandSuggestionsAreNewestFirst() {
         let q = PendingOrdersQueue()
         q.upsert(action(.suggestNextOrder, wt: "/wt/a"))


### PR DESCRIPTION
`integrationReport` 这张卡片一直在被 enqueue —— 每一轮需要人看的集成(有冲突被排除、checkout 被 held、这轮直接失败)都会塞一张进 `PendingOrdersQueue` —— 然后**渲染在任何地方都看不到**:

```swift
// IslandModel.swift
.filter { $0.action.kind == .suggestNextOrder }   // ← integrationReport 在这儿被滤掉
```

而 First Mate 那一栏根本不画卡片(整个 `Sources/UI/` 里只有 island 的 `OpenedSurfaceView` 认识 `PendingOrder`)。

结果是:整个集成功能里**唯一不可逆的那个决定** ——「丢掉 checkout 里挡路的改动,把这轮结果检出」—— 连同它的选项和点击处理都写好了,却在界面上够不着。唯一的出路是自己知道要去打 `/integrate force`。

### 改了什么

**放行**:`newestSuggestions` 现在也收 `integrationReport`。点击链路本来就是通的(`onOptionTapped` → `handleSuggestionTapped` 里那个分支、`onDismissOrder` 按 id 清、`onReveal` 早就处理了空 terminalID),没动。

**卡片自我介绍**:集成属于 repo 而不是 pane,没有分支可显示,所以在项目名后写 `integration`,图标用 `arrow.triangle.merge`(橙)而不是建议的灯泡。不然一张没有 pane、没有分支的卡片读起来像是 repo 自己在说话,而 repo 从不说话。

**新增一条「什么才配打开 island」的规则**:

```swift
static func shouldOpen(for fresh: [PendingOrder]) -> Bool {
    fresh.contains { !($0.action.options ?? []).isEmpty }
}
```

`auto_integrate` 开着时,「排除了某个冲突的 worktree」这种通知在两个 worktree 碰同一个文件期间每轮都有 —— 次次弹开 island 就又变回呼机了。**没有选项要选的是通知,躺在列表里等你翻到;有决定要做的(held,唯一往前走的路会销毁 checkout 里的东西)照旧弹。** agent 的建议和提问永远带选项,对它们零变化。

### 验证

35 个相关单测通过,新增 3 个:integrationReport 进列表且排在最新、非卡片类型(`watchWaiting`/`autoCommit`)不进、以及通知/决定的弹开规则。

没有替仓库造一轮真的集成来截图 —— 那会重写 teamclaw 的 integration checkout。`auto_integrate` 是开的,下次有 agent 跑完就会自然来一轮。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6fmGobHGJbmtYYAFfNtCW