### PR TITLE
Site: fill the hole the example fleet left, and make the agent matrix readable

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -89,14 +89,6 @@
         watches who is working and who is waiting on you, and after a reboot every session is where
         you left it. Twelve agent CLIs work out of the box.
       </p>
-    </div>
-  </div>
-</section>
-
-<!-- ══════════════ THE WATERLINE · getting aboard ══════════════ -->
-<section class="deck surface">
-  <div class="wrap">
-    <div class="berth">
       <div class="hero-cta">
         <div class="cmd"><span class="prompt">$</span> curl -fsSL https://seahelm.dev/install.sh | sh</div>
         <a class="linkout" href="https://github.com/BetaYao/seahelm">github.com/BetaYao/seahelm</a>

--- a/site/style.css
+++ b/site/style.css
@@ -257,11 +257,14 @@ td.tick { font: 400 .85rem/1.4 var(--f-mono); }
 .row dd { margin: 0; font-size: .95rem; line-height: 1.55; color: var(--ink-2); }
 .row dd code, .desc code, .lede code { font: 400 .85em/1 var(--f-mono); color: var(--ink); }
 
-/* two lifted callouts — these get the border, the rows do not */
+/* Notes lifted out of the prose, in the same panel the legend and the code
+   blocks use: a hairline border, the pale sea fill, no accent stripe down the
+   side. The panel is what marks them as lifted; a coloured bar on top of it is
+   decoration that says "look here" without saying anything more. */
 .lift { margin-top: 2rem; display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
 .lift > div {
-  border-left: 3px solid var(--accent);
-  border-radius: 0 6px 6px 0; padding: 1.1rem 1.2rem; background: var(--sea-1);
+  border: 1px solid var(--rule); border-radius: 8px;
+  background: var(--sea-1); padding: 1.1rem 1.2rem;
   display: grid; gap: .5rem; align-content: start;
 }
 .lift h3 { font-size: 1.1rem; }

--- a/site/style.css
+++ b/site/style.css
@@ -93,11 +93,10 @@ a:focus-visible, button:focus-visible { outline: 2px solid var(--accent); outlin
 /* The descent, top to bottom. Each gradient ends on the colour the next one
    starts with, so the only hard edges are the two that mean something. */
 .sky      { background: linear-gradient(180deg, #f6fafc 0%, #eaf3f7 100%); }
-/* The horizon. The seam between .sky and .surface is where the fleet sits;
-   a one-pixel darker line gives the edge the eye expects there. */
-.surface  { background: linear-gradient(180deg, #cfe5ea 0%, #b5d9e1 100%); }
+/* The horizon: where the page enters the water, and the tour sits just under
+   it. A one-pixel darker line gives the edge the eye expects there. */
+.surface  { background: linear-gradient(180deg, #cfe5ea 0%, #a2cfda 100%); }
 .sky + .surface { border-top: 1px solid #a3ccd6; }
-.surface + .surface { background: linear-gradient(180deg, #b5d9e1 0%, #a2cfda 100%); }
 .shallows { background: linear-gradient(180deg, #a2cfda 0%, #74b2c1 100%); }
 /* The drop-off: the hold is the one section that starts dark against light,
    and the waterline across its top is the helm colour fading out either way. */
@@ -146,12 +145,8 @@ p  { margin: 0; }
    width by default, and the install command is one unbreakable line. On a
    phone that line is wider than the screen, the track grew to fit it, and
    everything in the hero — the lede, the fleet strip — went with it. */
-.hero { padding: 2.1rem 0 2.2rem; display: grid; grid-template-columns: minmax(0, 1fr); gap: 1.35rem; }
+.hero { padding: 2.1rem 0 3.2rem; display: grid; grid-template-columns: minmax(0, 1fr); gap: 1.35rem; }
 .hero h1 { max-width: 17ch; }
-/* The fleet strip, the caption and the install line, sitting on the water.
-   Same minmax as .hero and for the same reason: the install command is one
-   unbreakable line and must not widen the track on a phone. */
-.berth { padding: 1.8rem 0 2.4rem; display: grid; grid-template-columns: minmax(0, 1fr); gap: 1.35rem; }
 .hero .lede { max-width: 56ch; }
 .hero-cta { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; margin-top: .35rem; }
 .cmd {

--- a/site/style.css
+++ b/site/style.css
@@ -53,6 +53,15 @@
   --accent: #076c83;
   --accent-soft: rgba(7,108,131,.12);
   --shadow: 0 1px 0 rgba(6,40,52,.14);
+  /* The status colours were tuned against near-white and were left behind
+     here, where the water is two thirds of the way down: the green ✓ came out
+     at 1.5:1 against it and the `—` at 1.3:1. These are the same five hues,
+     dropped to where they clear 4.5:1 on this section's panel — the deep
+     sections have done exactly this since they were written. */
+  --run:    #15784b;
+  --wait:   #7f5200;
+  --err:    #b3211a;
+  --idle:   #5f6a78;
 }
 
 /* Deep water: the hold, the rendezvous, the seabed. */
@@ -233,13 +242,22 @@ figcaption code { font: 400 .82em/1 var(--f-mono); font-style: normal; color: va
 .svg-dash { stroke: var(--ink-2); stroke-width: 1.2; fill: none; stroke-dasharray: 4 4; }
 
 /* ── layer table ──────────────────────────────────────────────── */
-.tbl-scroll { overflow-x: auto; margin-top: 2rem; }
+/* On a panel rather than straight on the water. Small mono text cannot reach
+   4.5:1 against the bottom of a gradient without going so dark the hue is
+   gone; on `--sea-1` it is a known background at every scroll position, and
+   it is what the legend and the code blocks in the same sections already do. */
+.tbl-scroll {
+  overflow-x: auto; margin-top: 2rem;
+  border: 1px solid var(--rule); border-radius: 8px;
+  background: var(--sea-1); padding: 1rem 1.1rem;
+}
 table { border-collapse: collapse; width: 100%; min-width: 560px; color: var(--ink); }
 th, td { text-align: left; padding: .72rem .9rem; border-bottom: 1px solid var(--rule-2); vertical-align: baseline; }
 thead th {
   font: 500 .68rem/1 var(--f-mono); text-transform: uppercase; letter-spacing: .14em;
   color: var(--ink-2); border-bottom: 1px solid var(--rule); padding-bottom: .55rem;
 }
+tbody tr:last-child td { border-bottom: 0; }
 tbody td:first-child { font: 600 .95rem/1.3 var(--f-cond); color: var(--ink); white-space: nowrap; }
 td.path { font: 400 .8rem/1.4 var(--f-mono); color: var(--accent); white-space: nowrap; }
 td.num  { font: 400 .82rem/1.4 var(--f-mono); font-variant-numeric: tabular-nums; text-align: right; color: var(--ink-2); }

--- a/site/zh/index.html
+++ b/site/zh/index.html
@@ -88,14 +88,6 @@
         里坐着一个 agent。Seahelm 用 Ghostty 引擎把它们逐个画出来，盯着谁在干活、谁在等你，
         重启之后每个会话都还在原位。十二种 agent CLI 开箱即用。
       </p>
-    </div>
-  </div>
-</section>
-
-<!-- ══════════════ THE WATERLINE · getting aboard ══════════════ -->
-<section class="deck surface">
-  <div class="wrap">
-    <div class="berth">
       <div class="hero-cta">
         <div class="cmd"><span class="prompt">$</span> curl -fsSL https://seahelm.dev/install.sh | sh</div>
         <a class="linkout" href="https://github.com/BetaYao/seahelm">github.com/BetaYao/seahelm</a>


### PR DESCRIPTION
删掉示例舰队(#113)之后的收尾,加上两处你指出来的问题。三个 commit,一件事一个。

### 1. 安装命令挪进 hero,空掉的那段删掉

那段「水线」区段只剩一行命令,却还端着为整条舰队图准备的留白 —— 一整条水色带里飘着一行字。命令挪到 lede 下面,区段删掉。

顺带修渐变链:原来是两个 `.surface` 接力下降,现在剩一个,让它独自走完 `#cfe5ea → #a2cfda`,CSS 里那句「每段渐变都结束在下一段开始的颜色上」的约定保住了。`.berth` 跟着它服务的区段一起删。

### 2. 抬出来的旁注:面板,不是色条

带色竖条的浅底卡片是全网生成式 callout 的标准长相,而且它是整个站上**唯一**一处 `border-left`。改成和状态图例、代码块同款的 1px 边框 + 浅色底 —— 那两个变量每个区段本来就会按自己的深度重定义,所以在哪一节都对。面板本身就足以说明「这段是抬出来的」;色条只是把「看这里」喊得更大声。

### 3. agent 对照表在水里看不清

量过的,不是感觉问题(WCAG,小字要 4.5:1,背景取 `.shallows` 渐变底部 `#74b2c1`):

| | 改前 | 改后 |
|---|---|---|
| 绿色 `✓` | **1.47** | 4.91 |
| `model-volunteered` | 1.63 | 6.03 |
| `—` | **1.31** | 4.91 |
| 列头 | 4.00 | 8.45 |

根因是调色板漏了一块,不是审美取舍:`.shallows` 给自己重定义了 `--ink / --ink-2 / --rule / --accent`,**唯独没给状态色**,于是 `--run/--wait/--err/--idle` 还停在照着近白底调的值上。深色那组 `.hold/.deep/.seabed` 从写下来那天就把这四个一起覆盖了 —— 这一节只是漏了。补的是同样五个色相,压到能读的深度。

表格同时搬上面板(和旁边的图例一样)。理由是渐变上根本没有一个固定背景可以去够比值:要让 `✓` 在最深处到 4.5:1,绿色得压到不再是绿色;放在 `--sea-1` 上,滚到哪儿背景都是已知的。深色那节的层级表由同一条规则获得同款面板,用的是那套调色板自己的 `--sea-1`。

---

本地起服务器逐条看过,中英两版都过了标签配对检查。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6fmGobHGJbmtYYAFfNtCW