### PR TITLE
fix: keep routine integration reports out of island

### DIFF
--- a/Sources/UI/Island/IslandModel.swift
+++ b/Sources/UI/Island/IslandModel.swift
@@ -80,13 +80,22 @@ final class IslandModel {
     /// The cards the island draws, newest first.
     ///
     /// `suggestNextOrder` covers an agent's next-step chips and its questions
-    /// alike — they share the kind and differ by payload. `integrationReport`
-    /// is here because the island is the only place its one irreversible
-    /// option is offered: the card was raised on every held round and drawn
-    /// nowhere, so the decision existed and could not be reached.
+    /// alike — they share the kind and differ by payload. An integration report
+    /// only belongs here when it has an option to act on; routine reports such
+    /// as excluded conflicts stay available in the checkout's status surface
+    /// without interrupting the user.
     static func newestSuggestions(from orders: [PendingOrder]) -> [PendingOrder] {
         Array(orders.lazy
-            .filter { $0.action.kind == .suggestNextOrder || $0.action.kind == .integrationReport }
+            .filter {
+                switch $0.action.kind {
+                case .suggestNextOrder:
+                    return true
+                case .integrationReport:
+                    return !($0.action.options ?? []).isEmpty
+                default:
+                    return false
+                }
+            }
             .reversed())
     }
 

--- a/Tests/PendingOrdersQueueTests.swift
+++ b/Tests/PendingOrdersQueueTests.swift
@@ -82,6 +82,17 @@ final class PendingOrdersQueueTests: XCTestCase {
                        [.integrationReport, .suggestNextOrder])
     }
 
+    /// A conflict report is useful in the integration status surface, but it
+    /// has no decision for the user and must not occupy the attention island.
+    func testIslandLeavesNonActionableIntegrationReportsOut() {
+        let q = PendingOrdersQueue()
+        q.upsert(FirstMateAction(kind: .integrationReport, zone: .red,
+                                 worktreePath: "/wt/integration", branch: "", project: "p",
+                                 terminalID: "", message: "integrated a · excluded b"))
+
+        XCTAssertTrue(IslandModel.newestSuggestions(from: q.all()).isEmpty)
+    }
+
     /// The kinds with no card behind them stay out of the list.
     func testIslandLeavesNonCardKindsOut() {
         let q = PendingOrdersQueue()


### PR DESCRIPTION
## Summary\n\n- keep routine integration reports, such as excluded conflicts, out of the attention island\n- continue showing integration reports that have an actionable decision\n- add regression coverage for non-actionable integration reports\n\n## Validation\n\n- xcodebuild focused tests: 33 passed\n- git diff --check passed\n\nThe change is based on main and is limited to the Seahelm UI model and its tests.