### PR TITLE
fix: what the chat surface says about a turn

### DIFF
--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -32,6 +32,30 @@ class TabCoordinator {
     let commandSessions = CommandSessionStore()
     private lazy var mailPaneObserver = MailPaneObserver(sessions: commandSessions)
 
+    /// The live "what it's doing right now" line in each bound Telegram chat.
+    /// Wired to the bridge here rather than in MainWindowController because
+    /// this is where the outcome stream already lands.
+    private(set) lazy var chatProgress: ChatProgressReporter = {
+        let reporter = ChatProgressReporter(sessions: commandSessions)
+        reporter.send = { chatId, text, done in
+            AgentRegistry.shared.pushToChannel("telegram", message: OutboundMessage(
+                channelId: "telegram", targetChatId: chatId, content: text, format: .markdown)
+            ) { messageId in
+                // The bridge reports the id from its own send queue; the
+                // reporter's state belongs to main, where every outcome lands.
+                DispatchQueue.main.async { done(messageId) }
+            }
+        }
+        reporter.edit = { chatId, messageId, text in
+            AgentRegistry.shared.editInChannel("telegram", chatId: chatId, messageId: messageId,
+                                               content: text)
+        }
+        reporter.remove = { chatId, messageId in
+            AgentRegistry.shared.deleteInChannel("telegram", chatId: chatId, messageId: messageId)
+        }
+        return reporter
+    }()
+
     var activeTabIndex: Int = 0
     /// Every worktree across all repos. `tree` is optional because the tree is
     /// owned by `StationManager`, not by this list, and a worktree can be between
@@ -198,6 +222,7 @@ class TabCoordinator {
             self.firstMate?.handle(outcome)
             self.integration?.handle(outcome)
             self.mailPaneObserver.ingest(outcome)
+            self.chatProgress.ingest(outcome)
             // Feed the worktree aggregator from AgentRegistry's arbitrated status
             // (scan + hook + OSC), so the dashboard reflects hook/OSC-driven
             // "running" that the scan-only path misses when the viewport text is
@@ -1718,8 +1743,41 @@ class TabCoordinator {
                                 lastMessage: lastMessage, repoPath: repoPath)
     }
 
+    /// Whether a completion is worth holding because the agent has not said it
+    /// is finished.
+    ///
+    /// A completion notice is mostly the agent's own answer, and the answer can
+    /// arrive *after* the edge that announces it. Measured on a real turn: the
+    /// notice went out at 09:06:32 and the model wrote its answer at 09:06:40.99
+    /// — nine seconds later. The screen had gone quiet while it was composing,
+    /// the scan read quiet as finished, and the notice quoted the only other
+    /// thing on the pane, a shell command. Worse, when the real Stop landed the
+    /// status was no longer `running`, so `shouldNotify` refused it and the
+    /// answer never reached the phone at all — leaving the wrong message with
+    /// the right buttons stapled underneath it.
+    ///
+    /// The signal is the *disagreement*, not the empty text. `pane explain` on
+    /// the pane above said it all: `hook_status: running`, `decided_by: screen`.
+    /// The agent's own hooks still had the turn open; only the screen thought it
+    /// was over. So hold while the two disagree, and let the agent settle it —
+    /// its Stop is what carries the answer.
+    ///
+    /// `hookStatus == .running` is also what keeps this off panes that report no
+    /// hooks at all: theirs is `.unknown`, the screen is the only witness they
+    /// have, and holding their completions would delay every one for nothing.
+    static func shouldWaitForCompletion(newStatus: AgentStatus, hookStatus: AgentStatus) -> Bool {
+        newStatus == .idle && hookStatus == .running
+    }
+
+    /// How long to hold such a completion, and how often to look again. Each
+    /// pass re-reads the pane, so the wait ends the moment the agent's own Stop
+    /// lands — the full window is only spent when it never does.
+    static let proseRetryInterval: TimeInterval = 1.5
+    static let proseAttempts = 10
+
     private func deliverPaneStatusChange(worktreePath: String, paneIndex: Int, oldStatus: AgentStatus,
-                                         newStatus: AgentStatus, lastMessage: String, repoPath: String) {
+                                         newStatus: AgentStatus, lastMessage: String, repoPath: String,
+                                         attemptsLeft: Int = TabCoordinator.proseAttempts) {
         let branch = allWorktrees.first(where: { $0.info.path == worktreePath })?.info.branch ?? ""
         let workspaceName = workspaceManager.tabs.first(where: { $0.repoPath == repoPath })?.displayName
             ?? URL(fileURLWithPath: repoPath).lastPathComponent
@@ -1738,6 +1796,29 @@ class TabCoordinator {
         // sent inside the cooldown window — see `NotificationManager.shouldNotify`.
         let source: NotificationManager.NotificationSource =
             pane?.hookStatus == newStatus ? .agent : .scan
+
+        // One line per delivery decision. This bug was diagnosed by reconstructing
+        // it from Claude's transcript timestamps against the notification history
+        // — two files that only happen to line up. The inputs are cheap to say.
+        NSLog("[notify] pane=\(terminalID.suffix(8)) \(oldStatus.rawValue)→\(newStatus.rawValue) " +
+              "hook=\(pane?.hookStatus.rawValue ?? "no-pane") prose=\(lastAssistantMessage.count) " +
+              "source=\(source == .agent ? "agent" : "scan") attempts=\(attemptsLeft)")
+
+        if attemptsLeft > 0,
+           Self.shouldWaitForCompletion(newStatus: newStatus,
+                                        hookStatus: pane?.hookStatus ?? .unknown) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.proseRetryInterval) { [weak self] in
+                guard let self else { return }
+                // Back to work in the meantime: this completion was never one.
+                // Whatever the agent is doing now will announce itself.
+                guard AgentRegistry.shared.pane(for: terminalID)?.status != .running else { return }
+                self.deliverPaneStatusChange(worktreePath: worktreePath, paneIndex: paneIndex,
+                                             oldStatus: oldStatus, newStatus: newStatus,
+                                             lastMessage: lastMessage, repoPath: repoPath,
+                                             attemptsLeft: attemptsLeft - 1)
+            }
+            return
+        }
 
         // A pending order card (AskUserQuestion / suggestion) for this pane
         // already surfaces the "needs input" state in the island and cockpit —
@@ -1760,6 +1841,8 @@ class TabCoordinator {
             lastMessage: lastMessage,
             lastUserPrompt: lastUserPrompt,
             lastAssistantMessage: lastAssistantMessage,
+            lastAssistantMessageAt: pane?.lastAssistantMessageAt,
+            lastUserPromptAt: pane?.lastUserPromptAt,
             isTargetVisible: isPaneFocused(worktreePath: worktreePath, terminalID: terminalID),
             source: source
         )

--- a/Sources/Core/AgentRegistry.swift
+++ b/Sources/Core/AgentRegistry.swift
@@ -406,6 +406,7 @@ class AgentRegistry {
             next.hookStatus = .running
             if hookRunningSince[event.terminalID] == nil { hookRunningSince[event.terminalID] = now }
             hookWaitingSince[event.terminalID] = nil
+            if next.lastUserPrompt != text { next.lastUserPromptAt = now }
             next.lastUserPrompt = text
         case .toolUse(let ev):
             next.hookStatus = .running
@@ -702,6 +703,7 @@ class AgentRegistry {
             ?? worktreeIndex.first { cwd == $0.key || cwd.hasPrefix($0.key + "/") }?.value.first
         guard let tid, var info = agents[tid] else { lock.unlock(); return nil }
         info.lastMessage = trimmed
+        if info.lastAssistantMessage != trimmed { info.lastAssistantMessageAt = Date() }
         info.lastAssistantMessage = trimmed  // preserved for suggestion-card summary
         agents[tid] = info
         lock.unlock()
@@ -922,7 +924,10 @@ class AgentRegistry {
             let text = StopHookResponder.stripSentinel(from: raw)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if !text.isEmpty {
-                lock.lock(); agents[tid]?.lastAssistantMessage = text; lock.unlock()
+                lock.lock()
+                if agents[tid]?.lastAssistantMessage != text { agents[tid]?.lastAssistantMessageAt = Date() }
+                agents[tid]?.lastAssistantMessage = text
+                lock.unlock()
             }
         }
         ingest(event2)
@@ -1237,6 +1242,26 @@ class AgentRegistry {
         lock.unlock()
 
         channel?.setButtons(chatId: chatId, messageId: messageId, buttons: buttons)
+    }
+
+    /// Rewrite a message a channel already sent, or take it back. Both are for
+    /// the progress line — see `ChatProgressReporter` — and both are best
+    /// effort: a channel that cannot edit its own messages does nothing.
+    func editInChannel(_ channelId: String, chatId: String, messageId: String,
+                       content: String, format: MessageFormat = .markdown) {
+        lock.lock()
+        let channel = externalChannels[channelId]
+        lock.unlock()
+
+        channel?.editMessage(chatId: chatId, messageId: messageId, content: content, format: format)
+    }
+
+    func deleteInChannel(_ channelId: String, chatId: String, messageId: String) {
+        lock.lock()
+        let channel = externalChannels[channelId]
+        lock.unlock()
+
+        channel?.deleteMessage(chatId: chatId, messageId: messageId)
     }
 
     /// Broadcast a message to all registered external channels

--- a/Sources/Core/ChatProgressReporter.swift
+++ b/Sources/Core/ChatProgressReporter.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// One live line per pane, in the chats that are talking to it: what the agent
+/// is doing *while* it does it.
+///
+/// Telegram has no streaming primitive, and there is nothing token-shaped to
+/// stream anyway — the agent's own prose reaches us once, whole, when the turn
+/// ends. What we do have is every tool call as it happens (`PostToolUse`), and
+/// that is the useful thing on a phone: not the words, but whether it is still
+/// working and on what.
+///
+/// So this is one message, sent late, edited in place, and taken back when the
+/// turn ends. It never carries the answer — the completion notice does, exactly
+/// as before, as its own message. That separation is deliberate: the progress
+/// line is disposable, and anything the reader needs to keep must not be.
+///
+/// Three rules keep it from becoming the noisiest thing in the chat:
+///
+///   - **Only bound chats.** A `/go #n` conversation asked to watch this pane.
+///     A fleet listener did not, and a live line per pane across a fleet is a
+///     chat nobody can read.
+///   - **Late.** A turn that ends in seconds would post and delete a message
+///     for nothing. Nothing appears until `graceSeconds` of work have passed.
+///   - **Throttled.** An edit at most every `minEditInterval`, and never one
+///     that would put up the same words — Telegram answers both with an error,
+///     and it would be right to.
+final class ChatProgressReporter {
+
+    /// Sending is asynchronous and the id comes back late; everything else
+    /// needs that id. Owner-supplied so the reporter can be tested without a
+    /// live bridge.
+    ///
+    /// All three, and `ingest`, run on the main thread — the outcome stream is
+    /// already there. The owner is responsible for hopping the send's reply
+    /// back, since a bridge answers from a queue of its own.
+    var send: ((_ chatId: String, _ text: String, _ done: @escaping (String?) -> Void) -> Void)?
+    var edit: ((_ chatId: String, _ messageId: String, _ text: String) -> Void)?
+    var remove: ((_ chatId: String, _ messageId: String) -> Void)?
+
+    private struct Line {
+        var messageId: String?
+        /// Set while a send is in flight, so a burst of tool calls cannot post
+        /// the same line twice.
+        var sending = false
+        var text = ""
+        var editedAt = Date.distantPast
+    }
+
+    /// The pane's identity for this report: the key its bound chats are filed
+    /// under, and the `#n` a reader recognises it by. Both come from the pane's
+    /// Station, which a unit test cannot build — hence the seam.
+    var identify: (PaneInfo) -> (key: String, handle: Int)? = { info in
+        let sessionKey = info.station?.paneSessionKey ?? ""
+        guard !sessionKey.isEmpty else { return nil }
+        let key = PaneHandleRegistry.key(sessionKey: sessionKey, paneId: info.id)
+        return (key, PaneHandleRegistry.shared.handle(for: key))
+    }
+
+    /// Keyed by pane handle key, then chat id.
+    private var lines: [String: [String: Line]] = [:]
+    /// When the turn now running on each pane began.
+    private var turnStartedAt: [String: Date] = [:]
+    private let sessions: CommandSessionStore
+
+    init(sessions: CommandSessionStore) {
+        self.sessions = sessions
+    }
+
+    /// How long a turn must have been running before it is worth a message.
+    static let graceSeconds: TimeInterval = 12
+    /// Telegram allows about one message a second per chat, and the notices
+    /// that matter share that budget.
+    static let minEditInterval: TimeInterval = 3
+
+    // MARK: - Ingest
+
+    func ingest(_ outcome: IngestOutcome, now: Date = Date()) {
+        guard let (paneKey, handle) = identify(outcome.info) else { return }
+
+        if Self.endsTurn(outcome) {
+            turnStartedAt[paneKey] = nil
+            clear(paneKey: paneKey)
+            return
+        }
+
+        if turnStartedAt[paneKey] == nil { turnStartedAt[paneKey] = now }
+        // A turn is only worth reporting once it has lasted; until then the
+        // completion notice will beat us to it.
+        guard let started = turnStartedAt[paneKey],
+              now.timeIntervalSince(started) >= Self.graceSeconds else { return }
+
+        let chats = chatIds(forPane: paneKey)
+        guard !chats.isEmpty else { return }
+
+        let text = Self.line(for: outcome.info, handle: handle, since: started, now: now)
+        for chatId in chats { post(text, paneKey: paneKey, chatId: chatId, now: now) }
+    }
+
+    /// Every chat whose conversation is bound to this pane. A fleet listener is
+    /// deliberately not one of them.
+    private func chatIds(forPane paneKey: String) -> [String] {
+        sessions.sessions(boundToPaneKey: paneKey)
+            .filter { $0.surface == "telegram" }
+            .map(\.id)
+    }
+
+    private func post(_ text: String, paneKey: String, chatId: String, now: Date) {
+        var line = lines[paneKey]?[chatId] ?? Line()
+        guard !line.sending else { return }
+
+        guard let messageId = line.messageId else {
+            line.sending = true
+            line.text = text
+            // The send *is* the first paint: without this the next tool call,
+            // a second later, would edit a message that has only just landed.
+            line.editedAt = now
+            lines[paneKey, default: [:]][chatId] = line
+            send?(chatId, text) { [weak self] id in
+                guard let self else { return }
+                // The turn may have ended while this was in flight; a line
+                // whose pane has since been cleared must not be left behind.
+                guard var pending = self.lines[paneKey]?[chatId] else {
+                    if let id { self.remove?(chatId, id) }
+                    return
+                }
+                pending.sending = false
+                pending.messageId = id
+                self.lines[paneKey, default: [:]][chatId] = pending
+            }
+            return
+        }
+
+        guard text != line.text,
+              now.timeIntervalSince(line.editedAt) >= Self.minEditInterval else { return }
+        line.text = text
+        line.editedAt = now
+        lines[paneKey, default: [:]][chatId] = line
+        edit?(chatId, messageId, text)
+    }
+
+    private func clear(paneKey: String) {
+        guard let open = lines.removeValue(forKey: paneKey) else { return }
+        for (chatId, line) in open {
+            guard let messageId = line.messageId else { continue }
+            remove?(chatId, messageId)
+        }
+    }
+
+    // MARK: - Pure
+
+    /// Whether this outcome ends the turn the line is reporting on.
+    ///
+    /// Every way a turn can stop counts, not just a clean finish: an agent that
+    /// errored or is waiting on a question is no longer working, and leaving
+    /// "running Bash" over a question is worse than saying nothing at all.
+    static func endsTurn(_ outcome: IngestOutcome) -> Bool {
+        if outcome.isCompletionSignal { return true }
+        guard outcome.statusChanged else { return false }
+        return outcome.newStatus == .idle || outcome.newStatus == .waiting || outcome.newStatus == .error
+    }
+
+    /// The line itself: which pane, what it is doing, how long it has been at
+    /// it. Two rows, because a phone shows two before it truncates.
+    static func line(for info: PaneInfo, handle: Int, since: Date, now: Date) -> String {
+        let target = "#\(handle) \(info.project)/\(info.branch)"
+        let elapsed = Self.elapsed(now.timeIntervalSince(since))
+        guard let latest = info.activityEvents.first else {
+            return "⏳ **\(target)** · \(elapsed)"
+        }
+        let detail = latest.detail.isEmpty ? latest.tool : "\(latest.tool) — \(latest.detail)"
+        return "⏳ **\(target)** · \(elapsed)\n\(truncated(detail))"
+    }
+
+    /// Whole units only. A status line that ticks over a decimal redraws for a
+    /// change nobody reads, and every redraw is a message edit.
+    static func elapsed(_ seconds: TimeInterval) -> String {
+        let whole = max(0, Int(seconds))
+        if whole < 60 { return "\(whole)s" }
+        let minutes = whole / 60
+        return minutes < 60 ? "\(minutes)m" : "\(minutes / 60)h\(minutes % 60)m"
+    }
+
+    static func truncated(_ text: String, limit: Int = 120) -> String {
+        let flat = text.split(whereSeparator: \.isNewline).joined(separator: " ")
+        return flat.count <= limit ? flat : "\(flat.prefix(limit - 1))…"
+    }
+}

--- a/Sources/Core/Command/CommandFormatter.swift
+++ b/Sources/Core/Command/CommandFormatter.swift
@@ -128,7 +128,10 @@ enum CommandFormatter {
     /// almost nothing about what an agent has been doing, and for a pane
     /// that reports no structured events they are empty.
     static func paneDetail(_ pane: PaneRef, activity: [String], transcript: String?, footer: String?) -> String {
-        var out = ["**\(target(pane))** · \(pane.type) — \(truncated(pane.title, limit: 90))",
+        // A pane that has said nothing yet takes its title from the agent's own
+        // OSC title, which is the agent's name — "Claude Code — Claude Code".
+        let title = pane.title.caseInsensitiveCompare(pane.type) == .orderedSame ? "" : pane.title
+        var out = ["**\(target(pane))** · \(pane.type)" + (title.isEmpty ? "" : " — \(truncated(title, limit: 90))"),
                    "\(pane.status.icon) \(pane.status.groupLabel)",
                    ""]
         if let transcript = transcript.map({ MailContentRedactor.summary($0, limit: 6_000) }),
@@ -138,7 +141,7 @@ enum CommandFormatter {
             out.append("")
         }
         let message = MailContentRedactor.summary(pane.lastMessage, limit: 1_500)
-        if !message.isEmpty {
+        if !message.isEmpty, !lifecycleLabels.contains(message) {
             out.append("**Latest**")
             out.append(message)
             out.append("")
@@ -151,6 +154,14 @@ enum CommandFormatter {
         if let footer, !footer.isEmpty { out.append(footer) }
         return out.joined(separator: "\n").trimmingCharacters(in: .newlines)
     }
+
+    /// `lastMessage` falls back to the label of the last lifecycle event when
+    /// the agent has said nothing yet (see `HookDecoder.summary`). As a status
+    /// that reads fine; under **Latest**, next to the pane's status line, it is
+    /// the same fact twice — and "Session started" is not the latest anything.
+    static let lifecycleLabels: Set<String> = [
+        "Session started", "Creating worktree", "Subagent started", "Processing prompt",
+    ]
 
     // MARK: - Errors
 

--- a/Sources/Core/ExternalChannel.swift
+++ b/Sources/Core/ExternalChannel.swift
@@ -117,6 +117,15 @@ protocol ExternalChannel: AnyObject {
     /// message repeating it.
     func setButtons(chatId: String, messageId: String, buttons: [MessageButton])
 
+    /// Rewrite the text of a message this channel already sent, and take one
+    /// back. Both exist for the same thing: a line reporting what an agent is
+    /// doing *while* it does it is one message edited over and over and then
+    /// removed, not a stream of new ones. Both are best effort — a channel that
+    /// can do neither does nothing, and the reader loses only the liveness. The
+    /// answer itself never travels this way.
+    func editMessage(chatId: String, messageId: String, content: String, format: MessageFormat)
+    func deleteMessage(chatId: String, messageId: String)
+
     /// Connection management
     func connect()
     func disconnect()
@@ -129,6 +138,9 @@ extension ExternalChannel {
     }
 
     func setButtons(chatId: String, messageId: String, buttons: [MessageButton]) {}
+
+    func editMessage(chatId: String, messageId: String, content: String, format: MessageFormat) {}
+    func deleteMessage(chatId: String, messageId: String) {}
 
     /// The common direction, named for what it means.
     func retireButtons(chatId: String, messageId: String) {

--- a/Sources/Core/PaneInfo.swift
+++ b/Sources/Core/PaneInfo.swift
@@ -13,6 +13,13 @@ struct PaneInfo {
     /// cards can show the real explanation rather than the `seahelm-suggest …` line.
     var lastAssistantMessage: String = ""
     var lastUserPrompt: String = ""    // most recent user prompt text
+    /// When each of the two above last *changed*. A completion is announced as
+    /// the answer to the prompt the pane is holding, so the two have to be in
+    /// the right order: prose recorded before the prompt landed cannot be an
+    /// answer to it. Re-recording the same text does not move these — they mark
+    /// when the words first appeared, not when they were last seen.
+    var lastAssistantMessageAt: Date?
+    var lastUserPromptAt: Date?
     var commandLine: String?           // current command from OSC 133 or text matching
     var roundDuration: TimeInterval    // seconds in current running round
     let startedAt: Date?               // for computing totalDuration live
@@ -70,6 +77,8 @@ extension PaneInfo {
         )
         copy.lastAssistantMessage = lastAssistantMessage
         copy.lastUserPrompt = lastUserPrompt
+        copy.lastAssistantMessageAt = lastAssistantMessageAt
+        copy.lastUserPromptAt = lastUserPromptAt
         copy.tasks = tasks
         copy.activityEvents = activityEvents
         copy.scanStatus = scanStatus

--- a/Sources/Core/PaneReducer.swift
+++ b/Sources/Core/PaneReducer.swift
@@ -9,7 +9,8 @@ enum PaneReducer {
                       lastMessage: String,
                       roundDuration: TimeInterval,
                       tasks: [TaskItem],
-                      lastUserPrompt: String) -> (info: PaneInfo, changed: Bool, previousStatus: AgentStatus) {
+                      lastUserPrompt: String,
+                      now: Date = Date()) -> (info: PaneInfo, changed: Bool, previousStatus: AgentStatus) {
         var next = info
         let previousStatus = info.status
         let changed = info.status != status
@@ -17,8 +18,12 @@ enum PaneReducer {
             || info.tasks.count != tasks.count
         next.status = status
         next.lastMessage = lastMessage
-        if !lastUserPrompt.isEmpty {
+        // Only on a *change*: this runs on every poll with the prompt re-passed
+        // unchanged, and stamping it each time would leave the prompt forever
+        // newer than the answer to it.
+        if !lastUserPrompt.isEmpty, lastUserPrompt != next.lastUserPrompt {
             next.lastUserPrompt = lastUserPrompt
+            next.lastUserPromptAt = now
         }
         next.roundDuration = roundDuration
         next.tasks = tasks

--- a/Sources/Core/TelegramBotAPI.swift
+++ b/Sources/Core/TelegramBotAPI.swift
@@ -304,6 +304,28 @@ final class TelegramBotAPI {
                                           deadline: Self.stallSeconds)
     }
 
+    /// Rewrite the text of a message this bot already sent.
+    ///
+    /// Telegram has no streaming primitive; a line that changes while an agent
+    /// works is this method called again on the same message id. Two of its
+    /// failures are ordinary rather than exceptional and the caller is expected
+    /// to swallow them: editing to *identical* text is a 400 ("message is not
+    /// modified"), and editing too often is a 429. Neither is worth a retry —
+    /// the next update supersedes this one anyway.
+    func editMessageText(chatId: String, messageId: Int, text: String, parseMode: String?) throws {
+        var params: [String: Any] = ["chat_id": chatId, "message_id": messageId, "text": text]
+        if let parseMode { params["parse_mode"] = parseMode }
+        // As with the keyboard edit, the answer is the edited message.
+        let _: TelegramMessage = try call("editMessageText", params: params, deadline: Self.stallSeconds)
+    }
+
+    /// Take back a message this bot sent. Telegram allows this for 48 hours,
+    /// which is far longer than a transient status line lives.
+    func deleteMessage(chatId: String, messageId: Int) throws {
+        let _: Bool = try call("deleteMessage", params: ["chat_id": chatId, "message_id": messageId],
+                               deadline: Self.stallSeconds)
+    }
+
     /// Publish the verb table to Telegram, so typing `/` in the chat lists the
     /// commands instead of requiring the user to have read `/help` once.
     ///

--- a/Sources/Core/TelegramChannel.swift
+++ b/Sources/Core/TelegramChannel.swift
@@ -47,6 +47,9 @@ final class TelegramChannel: ExternalChannel {
     /// The chat the most recent order came from: the broadcast fallback when
     /// the config names no chat and no allowed user is numeric.
     private var lastCommandChatId: String?
+    /// When each group was last told how to address the bot — see
+    /// `shouldHintAddressing`.
+    private var lastAddressingHint: [String: Date] = [:]
 
     /// Where unbound fleet notifications go: configured default, else the chat
     /// that last issued an order.
@@ -231,6 +234,49 @@ final class TelegramChannel: ExternalChannel {
         }
     }
 
+    /// Rewrite a message already sent — the progress line, on every update.
+    ///
+    /// Deliberately unretried, and deliberately quiet about the two failures
+    /// that are not faults: an edit to identical text and an edit that came too
+    /// fast are both answered with an error Telegram means as "no", and the
+    /// next update replaces this one anyway. Logging either would fill the log
+    /// with the bridge working correctly.
+    func editMessage(chatId: String, messageId: String, content: String, format: MessageFormat) {
+        guard let id = Int(messageId) else { return }
+        lock.lock()
+        let api = self.api
+        lock.unlock()
+        guard let api else { return }
+        let parseMode: String? = format == .text ? nil : "HTML"
+        let rendered = parseMode == nil ? content : TelegramFormatter.html(from: content)
+        sendQueue.async {
+            do {
+                try api.editMessageText(chatId: chatId, messageId: id, text: rendered, parseMode: parseMode)
+            } catch let error as TelegramAPIError where error.isBadRequest && parseMode != nil {
+                // Same reasoning as `sendChunk`: rather than lose the update to
+                // a stray tag, put the same words up flat.
+                try? api.editMessageText(chatId: chatId, messageId: id,
+                                         text: TelegramFormatter.stripHTML(rendered), parseMode: nil)
+            } catch {
+                // Nothing to do and nothing worth saying — see above.
+            }
+        }
+    }
+
+    /// Take a message back. Used to clear the progress line once its turn is
+    /// over: what the agent actually said arrives as its own message a moment
+    /// later, and a stale "running Bash" left above it reads as still running.
+    func deleteMessage(chatId: String, messageId: String) {
+        guard let id = Int(messageId) else { return }
+        lock.lock()
+        let api = self.api
+        lock.unlock()
+        guard let api else { return }
+        sendQueue.async {
+            try? api.deleteMessage(chatId: chatId, messageId: id)
+        }
+    }
+
     // MARK: - Config
 
     /// Swap the allowlist and rules without reconnecting — both are consulted
@@ -374,8 +420,58 @@ final class TelegramChannel: ExternalChannel {
             return
         }
 
+        // An operator's own line in a group that was not aimed at the bot. It is
+        // deliberately not an order — see `command(in:)` — but dropping it
+        // without a word is exactly what teaches someone the bot is broken in
+        // groups: they typed a sentence to it and nothing happened. Say how to
+        // reach it, once in a while, and only to someone who could have given
+        // an order in the first place.
+        if Self.isUnaddressedOrder(in: message, config: cfg, botUsername: botUsername),
+           shouldHintAddressing(chatId: chatId) {
+            reply(chatId, Self.addressingHint(botUsername: botUsername))
+            return
+        }
+
         deliverSignal(message, text: text, config: cfg)
     }
+
+    /// A line from someone on the allowlist, in a group, that would have been
+    /// an order anywhere the bot is the only listener. In other words: the one
+    /// case where `command(in:)` said no over *where* it was said rather than
+    /// *who* said it.
+    static func isUnaddressedOrder(in message: TelegramMessage, config cfg: TelegramConfig,
+                                   botUsername: String?) -> Bool {
+        guard let text = message.body?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty,
+              let from = message.from, cfg.allows(user: from),
+              !message.chat.isPrivate else { return false }
+        let body = stripBotMention(text, botUsername: botUsername)
+        guard !body.hasPrefix("/") else { return false }
+        return addressedProse(body, message: message, botUsername: botUsername) == nil
+    }
+
+    /// Both ways in, and why there is a door at all. The hint is itself one of
+    /// the bot's messages, so "reply to this" is something the reader can do
+    /// without leaving the line they are already looking at.
+    static func addressingHint(botUsername: String?) -> String {
+        let mention = (botUsername.map { "@\($0)" } ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let ways = mention.isEmpty ? "Reply to this message" : "Reply to this message, or start the line with \(mention)"
+        return "\(ways) and I'll send it on. A bare line in a group I leave alone — somebody else's sentence must not steer an agent."
+    }
+
+    /// One hint per group per window. Two operators talking to each other in a
+    /// room the bot sits in must not collect a hint under every line.
+    private func shouldHintAddressing(chatId: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let now = Date()
+        if let last = lastAddressingHint[chatId], now.timeIntervalSince(last) < Self.addressingHintWindow {
+            return false
+        }
+        lastAddressingHint[chatId] = now
+        return true
+    }
+
+    static let addressingHintWindow: TimeInterval = 600
 
     /// Answer `/start`.
     ///

--- a/Sources/Core/TerminalTranscript.swift
+++ b/Sources/Core/TerminalTranscript.swift
@@ -1,0 +1,190 @@
+import Foundation
+
+/// A terminal capture, cleaned up enough to read as a conversation.
+///
+/// `zmx history` hands back the pane's *screen*, not its transcript: an agent
+/// TUI paints a startup banner above the conversation and a composer, a
+/// statusline and mode hints below it, and all of that comes back mixed in
+/// with what was actually said. On the desktop the furniture is the point —
+/// in a Telegram message or a mail it is noise, and for a pane that has only
+/// just started (or been `/clear`ed) the capture is *nothing but* furniture.
+///
+/// The rules here are deliberately structural rather than a list of strings to
+/// match, because every agent draws a different TUI and a list would only ever
+/// describe the one we looked at last: the statusline is whatever command the
+/// user configured, and the banner carries the agent's version and model of the
+/// day. What the TUIs do have in common is that they draw with box and block
+/// glyphs (Unicode U+2500–U+259F) and hang their furniture below the composer.
+enum TerminalTranscript {
+
+    /// The readable part of a capture, one line per surviving row. Empty when
+    /// the capture held nothing but chrome — callers read that as "nothing to
+    /// show" and leave the section out entirely.
+    static func clean(_ text: String) -> String {
+        var stripped = text
+        // `\#u{…}` rather than `\u{…}`: a raw string leaves escapes uninterpreted,
+        // so the plain form would look for a literal backslash-u.
+        for pattern in [#"\#u{1B}\][^\#u{07}\#u{1B}]*(?:\#u{07}|\#u{1B}\\)"#,   // OSC …BEL/ST
+                        #"\#u{1B}\[[0-9;?]*[ -/]*[@-~]"#,                        // CSI
+                        #"\#u{1B}[@-Z\\-_]"#,                                    // lone escapes
+                        #"[\#u{00}-\#u{08}\#u{0B}\#u{0C}\#u{0E}-\#u{1F}]"#] {    // stray control bytes
+            stripped = stripped.replacingOccurrences(of: pattern, with: "", options: .regularExpression)
+        }
+        var lines = stripped.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.replacingOccurrences(of: "\r", with: "").trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        if let footer = composerFrame(in: lines) { lines.removeSubrange(footer...) }
+        return conversation(lines).joined(separator: "\n")
+    }
+
+    // MARK: - Where the conversation ends
+
+    /// The bottom of the composer's frame: the first line of the agent's own
+    /// furniture — statusline, meters, key hints, token counters. Everything
+    /// from there down goes.
+    ///
+    /// Four things have to hold before a run of box glyphs is read as the
+    /// composer rather than as something the agent printed. It has to be wide —
+    /// an agent's own `───` separators are short. It has to have another
+    /// decoration line just above it, because that is the rest of the frame: a
+    /// lone rule is just as likely to be a markdown `---`, and cutting there
+    /// would throw the answer away. It has to be near the bottom of the
+    /// capture, since the furniture below the composer is only ever a few rows.
+    /// And it must not close a box: a composer floor is a rule (Claude Code,
+    /// pi) or a half-block (OpenCode), while a `╰───╯` is a box drawn *around*
+    /// something — Codex's startup banner, Cursor Agent's trust dialog — with
+    /// the conversation still to come below it. `isFloor` carries the last two:
+    /// solid line, no closing corner.
+    ///
+    /// The composer's own text is deliberately left in: it is the operator's
+    /// words, typed and not yet sent, which is worth knowing from a phone.
+    private static func composerFrame(in lines: [String]) -> Int? {
+        let lowest = max(0, lines.count - 1 - footerHeight)
+        for index in stride(from: lines.count - 1, through: lowest, by: -1) {
+            guard isFloor(lines[index]) else { continue }
+            let above = stride(from: index - 1, through: max(0, index - frameLookback), by: -1)
+            if above.contains(where: { isDecorationLine(lines[$0]) }) { return index }
+        }
+        return nil
+    }
+
+    /// Rows the furniture below the composer can occupy. Claude Code's is the
+    /// tallest seen — statusline, meters, permission hint, IDE row — and its
+    /// statusline wraps to a second row in a narrow pane. It stays tight on
+    /// purpose: too tight only leaks a statusline, too loose loses an answer.
+    private static let footerHeight = 5
+    /// How far above a rule the rest of its frame can sit.
+    private static let frameLookback = 4
+    /// A line drawn solidly across the pane and closing nothing: the floor
+    /// under a composer. A box's own blank interior row (`│` … `│`) is all
+    /// decoration too and just as wide, which is why the run has to be solid.
+    private static func isFloor(_ line: String) -> Bool {
+        guard isDecorationLine(line), line.count >= frameWidth,
+              let last = line.last, !closingCorners.contains(last) else { return false }
+        return line.filter { !verticalFrames.contains($0) && $0 != " " }.count * 2 >= line.count
+    }
+
+    /// Narrower than this is a separator the agent printed, not a frame.
+    private static let frameWidth = 20
+    /// The bottom right of a closed box — the end of something, not the floor
+    /// under the composer.
+    private static let closingCorners = Set("╯┘╝┛╛╜")
+
+    // MARK: - What is left
+
+    private static func conversation(_ lines: [String]) -> [String] {
+        var out: [String] = []
+        var insideSuggestions = false
+        for line in lines {
+            // Rules, frames, logo rows, bare gutters: decoration and nothing else.
+            if isDecorationLine(line) || isBannerRow(line) { continue }
+            let text = unframed(line)
+            if text.isEmpty { continue }
+            if text.contains(suggestMarker) {
+                insideSuggestions = true
+                continue
+            }
+            // Seahelm's own control line wraps when it is wider than the pane,
+            // and the wrapped remainder carries no marker to match on. Its
+            // options are `|`-separated, so a continuation still looks like the
+            // list; the line that follows the list never does.
+            if insideSuggestions {
+                if text.contains("|") { continue }
+                insideSuggestions = false
+            }
+            if isChrome(text) { continue }
+            out.append(text)
+        }
+        return out
+    }
+
+    /// Furniture an agent TUI repaints around the conversation — meters, the
+    /// empty prompt caret, standing notices.
+    private static func isChrome(_ line: String) -> Bool {
+        // Meters and progress bars.
+        if line.contains(where: { isBlock($0) }) { return true }
+        if line == "❯" || line == "›" || line == ">" || line == "⏺" { return true }
+        // The line that closes a turn: "✻ Churned for 44s", "✻ Worked for 1m 7s",
+        // "✻ Sautéed for 2m 28s" — the verb is picked at random, so match the mark.
+        if line.hasPrefix("✻") { return true }
+        for marker in standingNotices where line.contains(marker) { return true }
+        return false
+    }
+
+    /// Text inside a box, or behind the gutter an agent marks its own messages
+    /// with, minus the drawing. Cursor Agent puts its whole UI inside a frame —
+    /// a blocked pane's question included — so dropping framed lines outright
+    /// would throw away the one thing worth reading.
+    private static func unframed(_ line: String) -> String {
+        guard let first = line.first, verticalFrames.contains(first) else { return line }
+        var body = line.dropFirst()
+        if let last = body.last, verticalFrames.contains(last) { body = body.dropLast() }
+        return body.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// A logo or banner row: two block glyphs before anything else, which is
+    /// what carries Claude Code's version, model and cwd rows. Two, not one —
+    /// a single `▌` is a gutter, and that line is the message.
+    private static func isBannerRow(_ line: String) -> Bool {
+        let opening = line.prefix(2)
+        return opening.count == 2 && opening.allSatisfy { isBlock($0) }
+    }
+
+    /// Notices the TUI repaints for as long as the condition holds. Each is
+    /// true and none of it is what was asked for: they are the same lines on
+    /// every read until the day someone acts on them.
+    private static let standingNotices = [
+        "⏵⏵",                                   // permission-mode hint
+        "⚠ Transcript saving",
+        "new task? /clear",                     // the token-saving nudge
+        "Update installed · Restart to update",
+        "needs authentication · run /mcp",
+    ]
+
+    /// An instruction to the agent rather than anything it said.
+    private static let suggestMarker = "::seahelm-suggest::"
+
+    private static let verticalFrames = Set("│┃║╎╏┆┇┊┋▌▐")
+
+    // MARK: - Glyphs
+
+    /// Nothing but drawing: box rules and frames, logo rows, meter bars.
+    private static func isDecorationLine(_ line: String) -> Bool {
+        !line.isEmpty && line.allSatisfy { isDecoration($0) || $0 == " " }
+    }
+
+    /// Box Drawing plus Block Elements. Taking the two Unicode blocks whole is
+    /// the point: every TUI reaches for a different corner of them, and the
+    /// half-dozen glyphs any one of them uses is not a list worth maintaining.
+    private static func isDecoration(_ character: Character) -> Bool {
+        guard character.unicodeScalars.count == 1, let scalar = character.unicodeScalars.first else { return false }
+        return (0x2500...0x259F).contains(scalar.value)
+    }
+
+    /// Block Elements alone — the shaded bars a meter is drawn from, and the
+    /// quadrants a logo is drawn from.
+    private static func isBlock(_ character: Character) -> Bool {
+        guard character.unicodeScalars.count == 1, let scalar = character.unicodeScalars.first else { return false }
+        return (0x2580...0x259F).contains(scalar.value)
+    }
+}

--- a/Sources/Core/ZmxChannel.swift
+++ b/Sources/Core/ZmxChannel.swift
@@ -64,47 +64,12 @@ class ZmxChannel: AgentChannel {
                               arguments: args, timeout: Self.commandTimeout).succeeded
     }
 
-    /// The session's own scrollback, stripped of the escape sequences a TUI
-    /// paints itself with. Reads the persistent session rather than the surface,
-    /// so it works for a pane whose tab was never opened.
+    /// The session's own scrollback, stripped of the escape sequences and the
+    /// furniture a TUI paints itself with. Reads the persistent session rather
+    /// than the surface, so it works for a pane whose tab was never opened.
     func recentTranscript(lines: Int) -> String? {
         guard let raw = readOutput(lines: lines) else { return nil }
-        return Self.stripTerminalControl(raw)
-    }
-
-    /// Enough of an ANSI/OSC scrub to make a transcript readable in a mail.
-    static func stripTerminalControl(_ text: String) -> String {
-        var out = text
-        // `\#u{…}` rather than `\u{…}`: a raw string leaves escapes uninterpreted,
-        // so the plain form would look for a literal backslash-u.
-        for pattern in [#"\#u{1B}\][^\#u{07}\#u{1B}]*(?:\#u{07}|\#u{1B}\\)"#,   // OSC …BEL/ST
-                        #"\#u{1B}\[[0-9;?]*[ -/]*[@-~]"#,                        // CSI
-                        #"\#u{1B}[@-Z\\-_]"#,                                    // lone escapes
-                        #"[\#u{00}-\#u{08}\#u{0B}\#u{0C}\#u{0E}-\#u{1F}]"#] {    // stray control bytes
-            out = out.replacingOccurrences(of: pattern, with: "", options: .regularExpression)
-        }
-        return out.split(separator: "\n", omittingEmptySubsequences: false)
-            .map { $0.replacingOccurrences(of: "\r", with: "").trimmingCharacters(in: .whitespaces) }
-            .filter { !$0.isEmpty && !isChrome($0) }
-            .joined(separator: "\n")
-    }
-
-    /// Furniture an agent TUI repaints around the conversation — rules, meters,
-    /// the prompt caret, permission banners. Reading a transcript in a mail is
-    /// about what was said, and left in, the chrome outweighs it.
-    private static func isChrome(_ line: String) -> Bool {
-        // Box-drawing rules are pure decoration once the colours are gone.
-        if let first = line.first, "─━═│┃╭╮╰╯├┤┌┐└┘".contains(first) { return true }
-        // Meters and progress bars.
-        if line.contains("█") || line.contains("░") || line.contains("▓") { return true }
-        if line == "❯" || line == ">" || line == "⏺" { return true }
-        for marker in ["⏵⏵", "✻ Churned", "⚠ Transcript saving",
-                       // Seahelm's own control line, which is an instruction to
-                       // the agent rather than anything it said.
-                       "::seahelm-suggest::"] where line.contains(marker) {
-            return true
-        }
-        return false
+        return TerminalTranscript.clean(raw)
     }
 
     /// Deadline for one zmx call. zmx talks to a local socket, so anything past

--- a/Sources/Status/NotificationManager.swift
+++ b/Sources/Status/NotificationManager.swift
@@ -205,6 +205,30 @@ class NotificationManager: NSObject {
         return "\(status.rawValue)|\(lastUserPrompt.trimmingCharacters(in: .whitespacesAndNewlines))|\(trimmed)"
     }
 
+    /// Whether the agent's prose can be read as the answer to the prompt the
+    /// pane is holding.
+    ///
+    /// A completion notice says "finished" and then quotes the agent. When an
+    /// order lands and the agent has not spoken since, that quote is the answer
+    /// to the *previous* order — and announcing it puts a reply to "hi" under a
+    /// heading that names the order after it, out of order and, on a phone,
+    /// indistinguishable from the agent having answered. Worse, the turn
+    /// fingerprint carries the prompt, so the new prompt made a *new*
+    /// fingerprint out of the *old* words and walked straight through the
+    /// once-per-turn gate: the same answer, sent twice.
+    ///
+    /// Only the agent's own prose is held to this. A pane with none — anything
+    /// read off the screen rather than reported — has nothing to be out of
+    /// order with, and blocking it would silence every agent that reports no
+    /// hooks at all. The real completion arrives moments later with a fresh
+    /// timestamp and announces itself then.
+    static func answersCurrentPrompt(lastAssistantMessage: String,
+                                     assistantAt: Date?, promptAt: Date?) -> Bool {
+        guard !lastAssistantMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let promptAt, let assistantAt else { return true }
+        return assistantAt >= promptAt
+    }
+
     /// Whether a pending (delayed) notification for `targetStatus` should still
     /// fire, given the latest observed status for its key. Pure — extracted so the
     /// stability-gate decision is unit-testable without a live Timer.
@@ -546,6 +570,8 @@ class NotificationManager: NSObject {
         lastMessage: String,
         lastUserPrompt: String = "",
         lastAssistantMessage: String = "",
+        lastAssistantMessageAt: Date? = nil,
+        lastUserPromptAt: Date? = nil,
         isTargetVisible: Bool = false,
         source: NotificationSource = .scan
     ) {
@@ -555,6 +581,10 @@ class NotificationManager: NSObject {
         // pending stability timer can detect the agent moved on (e.g. an idle
         // flicker that flips back to running mid-turn).
         latestStatus[key] = newStatus
+
+        guard Self.answersCurrentPrompt(lastAssistantMessage: lastAssistantMessage,
+                                        assistantAt: lastAssistantMessageAt,
+                                        promptAt: lastUserPromptAt) else { return }
 
         let turn = Self.turnFingerprint(status: newStatus, lastAssistantMessage: lastAssistantMessage,
                                         lastMessage: lastMessage, lastUserPrompt: lastUserPrompt)

--- a/Tests/ChatProgressReporterTests.swift
+++ b/Tests/ChatProgressReporterTests.swift
@@ -1,0 +1,226 @@
+import XCTest
+@testable import seahelm
+
+final class ChatProgressReporterTests: XCTestCase {
+
+    private var store: CommandSessionStore!
+    private var reporter: ChatProgressReporter!
+    private var sent: [(chat: String, text: String)] = []
+    private var edited: [(chat: String, id: String, text: String)] = []
+    private var removed: [(chat: String, id: String)] = []
+    /// What the next send reports back as the message id.
+    private var nextMessageId: String? = "100"
+
+    private let paneId = "T1"
+    private let sessionKey = "seahelm-task-alpha"
+    private var paneKey: String { PaneHandleRegistry.key(sessionKey: sessionKey, paneId: paneId) }
+
+    override func setUp() {
+        super.setUp()
+        sent = []; edited = []; removed = []; nextMessageId = "100"
+        store = CommandSessionStore(url: nil, legacyMailURL: nil)
+        reporter = ChatProgressReporter(sessions: store)
+        reporter.send = { [weak self] chat, text, done in
+            self?.sent.append((chat, text))
+            done(self?.nextMessageId)
+        }
+        reporter.edit = { [weak self] chat, id, text in self?.edited.append((chat, id, text)) }
+        reporter.remove = { [weak self] chat, id in self?.removed.append((chat, id)) }
+        reporter.identify = { [weak self] _ in self.map { ($0.paneKey, 26) } }
+    }
+
+    // MARK: - Fixtures
+
+    private func bindChat(_ chatId: String) {
+        store.bind(CommandSession.key(surface: "telegram", id: chatId),
+                   toPaneKey: paneKey, paneId: paneId, worktreePath: "/repo/alpha")
+    }
+
+    private func pane(activity: [ActivityEvent] = [], status: AgentStatus = .running) -> PaneInfo {
+        var info = PaneInfo(id: paneId, worktreePath: "/repo/alpha", agentType: .claudeCode,
+                            project: "alpha", branch: "feat-x", status: status,
+                            lastMessage: "", commandLine: nil, roundDuration: 0, startedAt: nil,
+                            station: nil, channel: nil, taskProgress: TaskProgress())
+        info.activityEvents = activity
+        return info
+    }
+
+    private func tool(_ name: String, _ detail: String = "") -> ActivityEvent {
+        ActivityEvent(tool: name, detail: detail, isError: false, timestamp: Date())
+    }
+
+    private func outcome(_ info: PaneInfo, statusChanged: Bool = false,
+                         newStatus: AgentStatus = .running, completion: Bool = false) -> IngestOutcome {
+        IngestOutcome(info: info, statusChanged: statusChanged, oldStatus: .running,
+                      newStatus: newStatus, holdSeconds: 0, isCompletionSignal: completion,
+                      event: NormalizedEvent(terminalID: paneId, source: .hook("claude-code"),
+                                             kind: .toolUse(tool("Bash"))))
+    }
+
+    private func ingest(_ o: IngestOutcome, at offset: TimeInterval) {
+        reporter.ingest(o, now: start.addingTimeInterval(offset))
+    }
+
+    /// One tool event on a running pane.
+    private func working(_ toolName: String = "Bash", _ detail: String = "") -> IngestOutcome {
+        outcome(pane(activity: [tool(toolName, detail)]))
+    }
+
+    private let start = Date(timeIntervalSince1970: 1_800_000_000)
+
+    // MARK: - When the line appears
+
+    /// A turn that ends in seconds must leave no trace: posting a line and
+    /// taking it back again is worse than never having posted it.
+    func testAShortTurnNeverPostsAnything() {
+        bindChat("555")
+        ingest(working(), at: 0)
+        ingest(working("Read"), at: 4)
+        ingest(outcome(pane(status: .idle), statusChanged: true, newStatus: .idle), at: 8)
+        XCTAssertTrue(sent.isEmpty, "\(sent)")
+        XCTAssertTrue(removed.isEmpty)
+    }
+
+    func testALongTurnPostsOnceAndThenEditsInPlace() {
+        bindChat("555")
+        ingest(working("Bash", "pnpm test"), at: 0)
+        ingest(working("Bash", "pnpm test"), at: 20)
+        XCTAssertEqual(sent.count, 1)
+        XCTAssertEqual(sent.first?.chat, "555")
+        XCTAssertTrue(sent[0].text.contains("Bash — pnpm test"), sent[0].text)
+
+        ingest(working("Read", "main.swift"), at: 30)
+        XCTAssertEqual(sent.count, 1, "the line is edited, never re-sent")
+        XCTAssertEqual(edited.count, 1)
+        XCTAssertEqual(edited[0].id, "100")
+        XCTAssertTrue(edited[0].text.contains("Read — main.swift"), edited[0].text)
+    }
+
+    /// Only chats that asked to watch this pane. A fleet listener hears
+    /// completions, not a running commentary on every pane in the fleet.
+    func testAnUnboundChatGetsNoLine() {
+        ingest(working(), at: 0)
+        ingest(working(), at: 20)
+        XCTAssertTrue(sent.isEmpty)
+    }
+
+    // MARK: - Throttling
+
+    func testEditsAreThrottledAndNeverRepeatTheSameWords() {
+        bindChat("555")
+        ingest(working(), at: 0)
+        ingest(working("Bash", "one"), at: 20)   // posts
+        ingest(working("Bash", "two"), at: 21)   // too soon
+        XCTAssertTrue(edited.isEmpty, "\(edited)")
+
+        ingest(working("Bash", "two"), at: 24)   // past the window
+        XCTAssertEqual(edited.count, 1)
+
+        // Same tool, same second-count: nothing to say, so nothing is said.
+        ingest(working("Bash", "two"), at: 24)
+        XCTAssertEqual(edited.count, 1)
+    }
+
+    // MARK: - When the turn ends
+
+    func testTheLineIsTakenBackWhenTheTurnEnds() {
+        bindChat("555")
+        ingest(working(), at: 0)
+        ingest(working(), at: 20)
+        ingest(outcome(pane(status: .idle), statusChanged: true, newStatus: .idle), at: 40)
+        XCTAssertEqual(removed.map(\.id), ["100"])
+
+        // And the next turn starts clean rather than editing a message that is gone.
+        ingest(working(), at: 100)
+        ingest(working(), at: 120)
+        XCTAssertEqual(sent.count, 2)
+    }
+
+    /// The send is asynchronous. A turn that ends while it is in flight must
+    /// still take back the message that lands afterwards.
+    func testALineThatArrivesAfterItsTurnEndedIsStillTakenBack() {
+        bindChat("555")
+        var late: ((String?) -> Void)?
+        reporter.send = { [weak self] chat, text, done in
+            self?.sent.append((chat, text))
+            late = done
+        }
+        ingest(working(), at: 0)
+        ingest(working(), at: 20)
+        XCTAssertEqual(sent.count, 1)
+
+        ingest(outcome(pane(status: .idle), statusChanged: true, newStatus: .idle), at: 25)
+        XCTAssertTrue(removed.isEmpty, "nothing to take back yet — no id")
+
+        late?("100")
+        XCTAssertEqual(removed.map(\.id), ["100"])
+    }
+
+    /// A send that reported no id (the bridge was down) must not be edited or
+    /// deleted by id later, and must not wedge the pane's line forever.
+    func testASendThatFailedDoesNotWedgeTheLine() {
+        bindChat("555")
+        nextMessageId = nil
+        ingest(working(), at: 0)
+        ingest(working("Read"), at: 20)
+        XCTAssertEqual(sent.count, 1)
+        ingest(working("Edit"), at: 30)
+        XCTAssertEqual(sent.count, 2, "with no id to edit, the next update posts afresh")
+        XCTAssertTrue(edited.isEmpty)
+    }
+
+    // MARK: - The line
+
+    func testTheLineNamesThePaneWhatItIsDoingAndForHowLong() {
+        let text = ChatProgressReporter.line(
+            for: pane(activity: [tool("Bash", "pnpm test")]), handle: 26,
+            since: start, now: start.addingTimeInterval(95))
+        XCTAssertTrue(text.contains("#26 alpha/feat-x"), text)
+        XCTAssertTrue(text.contains("Bash — pnpm test"), text)
+        XCTAssertTrue(text.contains("1m"), text)
+    }
+
+    /// A turn that has reported no tool yet is still worth a line — it says the
+    /// pane is alive, which is the whole point.
+    func testTheLineStandsWithoutAnyToolYet() {
+        let text = ChatProgressReporter.line(for: pane(), handle: 3,
+                                             since: start, now: start.addingTimeInterval(30))
+        XCTAssertTrue(text.contains("#3 alpha/feat-x"), text)
+        XCTAssertTrue(text.contains("30s"), text)
+    }
+
+    /// Whole units only: a line that ticks every second is a message edit every
+    /// second, and Telegram would rightly refuse most of them.
+    func testElapsedIsCoarse() {
+        XCTAssertEqual(ChatProgressReporter.elapsed(0.4), "0s")
+        XCTAssertEqual(ChatProgressReporter.elapsed(59.9), "59s")
+        XCTAssertEqual(ChatProgressReporter.elapsed(60), "1m")
+        XCTAssertEqual(ChatProgressReporter.elapsed(3_600), "1h0m")
+        XCTAssertEqual(ChatProgressReporter.elapsed(3_930), "1h5m")
+    }
+
+    func testAToolDetailIsFlattenedAndCut() {
+        let long = ChatProgressReporter.truncated("a\nb " + String(repeating: "x", count: 200))
+        XCTAssertFalse(long.contains("\n"))
+        XCTAssertEqual(long.count, 120)
+        XCTAssertTrue(long.hasSuffix("…"))
+    }
+
+    // MARK: - When a turn is over
+
+    func testEveryWayATurnStopsEndsTheLine() {
+        XCTAssertTrue(ChatProgressReporter.endsTurn(outcome(pane(), completion: true)))
+        for status: AgentStatus in [.idle, .waiting, .error] {
+            XCTAssertTrue(ChatProgressReporter.endsTurn(
+                outcome(pane(), statusChanged: true, newStatus: status)), status.rawValue)
+        }
+    }
+
+    /// Still working is not the end of anything, and neither is a status that
+    /// was re-reported rather than changed.
+    func testWorkingOnDoesNotEndTheLine() {
+        XCTAssertFalse(ChatProgressReporter.endsTurn(outcome(pane())))
+        XCTAssertFalse(ChatProgressReporter.endsTurn(
+            outcome(pane(), statusChanged: false, newStatus: .idle)))
+    }
+}

--- a/Tests/CommandFormatterTests.swift
+++ b/Tests/CommandFormatterTests.swift
@@ -130,25 +130,17 @@ final class CommandFormatterTests: XCTestCase {
         XCTAssertFalse(text.contains("**Session**"), text)
     }
 
-    /// An agent TUI repaints meters, rules and a permission banner around the
-    /// conversation; in a mail that furniture outweighs what was actually said.
-    func testStripsAgentTUIChrome() {
-        let raw = [
-            "real answer here",
-            "❯",
-            "✻ Churned for 44s",
-            "Context █░░░░░░░░░ 7% │ Usage ██░░░░░░░░ 19% (resets in 2h)",
-            "⏵⏵ bypass permissions on (shift+tab to cycle)",
-            "⚠ Transcript saving is off — inherited marker",
-            "::seahelm-suggest:: a | b",
-            "second real line",
-        ].joined(separator: "\n")
-        XCTAssertEqual(ZmxChannel.stripTerminalControl(raw), "real answer here\nsecond real line")
-    }
-
-    func testStripsTerminalControlSequences() {
-        let raw = "\u{1B}[1;32mready\u{1B}[0m\n\u{1B}]0;title\u{07}\n────────\n$ ls"
-        XCTAssertEqual(ZmxChannel.stripTerminalControl(raw), "ready\n$ ls")
+    /// A pane that has said nothing takes its title from the agent's own OSC
+    /// title, and printing both reads as "Claude Code — Claude Code".
+    func testPaneDetailDropsATitleThatIsJustTheAgentName() {
+        let pane = PaneRef(handle: 26, handleKey: "k26", id: "d", sessionKey: "k26",
+                           project: "saas-mono", branch: "task/betly-app", worktreePath: "/repo/betly",
+                           type: "Claude Code", title: "claude code", status: .idle,
+                           lastMessage: "Session started")
+        let text = CommandFormatter.paneDetail(pane, activity: [], transcript: nil, footer: nil)
+        XCTAssertTrue(text.contains("· Claude Code"), text)
+        XCTAssertFalse(text.contains("—"), "the title repeats the agent name")
+        XCTAssertFalse(text.contains("Latest"), "a lifecycle label is not the latest anything")
     }
 
     // MARK: - Errors

--- a/Tests/NotificationManagerTests.swift
+++ b/Tests/NotificationManagerTests.swift
@@ -340,4 +340,41 @@ final class NotificationManagerTests: XCTestCase {
         XCTAssertEqual(NotificationManager.turnFingerprint(
             status: .idle, lastAssistantMessage: "  ", lastMessage: "", lastUserPrompt: "x"), "")
     }
+
+    // MARK: - Answering the prompt the pane is actually holding
+
+    private func answers(prose: String = "Hi! Ready when you are.",
+                         assistant: TimeInterval?, prompt: TimeInterval?) -> Bool {
+        let base = Date()
+        return NotificationManager.answersCurrentPrompt(
+            lastAssistantMessage: prose,
+            assistantAt: assistant.map { base.addingTimeInterval($0) },
+            promptAt: prompt.map { base.addingTimeInterval($0) })
+    }
+
+    func testProseWrittenAfterThePromptIsTheAnswerToIt() {
+        XCTAssertTrue(answers(assistant: 3, prompt: 0))
+    }
+
+    /// The bug this exists for: an order lands, the agent has not spoken since,
+    /// and a completion edge quotes the *previous* turn's answer under the new
+    /// order's name. It also slipped the once-per-turn gate, because the new
+    /// prompt made a new fingerprint out of the old words.
+    func testProseOlderThanThePromptIsNotAnnounced() {
+        XCTAssertFalse(answers(assistant: 3, prompt: 30))
+    }
+
+    /// A pane that reports no prose has nothing to be out of order with —
+    /// holding it to this would silence every agent without hooks.
+    func testAPaneWithNoProseIsNeverHeld() {
+        XCTAssertTrue(answers(prose: "", assistant: nil, prompt: 30))
+        XCTAssertTrue(answers(prose: "   ", assistant: 3, prompt: 30))
+    }
+
+    /// Nothing to compare against: a restored snapshot, or a pane that has been
+    /// given no prompt this run.
+    func testMissingTimestampsDoNotBlock() {
+        XCTAssertTrue(answers(assistant: nil, prompt: 30))
+        XCTAssertTrue(answers(assistant: 3, prompt: nil))
+    }
 }

--- a/Tests/TabCoordinatorTests.swift
+++ b/Tests/TabCoordinatorTests.swift
@@ -333,4 +333,36 @@ final class TabCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.livePaneSessionNames(),
                        ["seahelm-repo-a-main", "seahelm-repo-b-main"])
     }
+    // MARK: - Holding a completion until the agent has spoken
+
+    /// The bug: a completion edge can beat the answer it is supposed to quote.
+    /// On a real turn the notice went out nine seconds before the model wrote
+    /// its final message, so the phone got a shell command where the answer
+    /// should have been — and the answer, arriving after the status had left
+    /// `running`, was never announced at all.
+    func testAScreenCompletionWaitsWhileTheHooksSayRunning() {
+        XCTAssertTrue(TabCoordinator.shouldWaitForCompletion(newStatus: .idle, hookStatus: .running))
+    }
+
+    /// The agent has said it is done, so there is nothing to wait for — this is
+    /// the edge that carries the answer.
+    func testTheAgentsOwnCompletionGoesOutAtOnce() {
+        XCTAssertFalse(TabCoordinator.shouldWaitForCompletion(newStatus: .idle, hookStatus: .idle))
+    }
+
+    /// A pane seen only through the screen has no second witness. Holding its
+    /// completions would delay every one of them to wait for nothing.
+    func testAScanOnlyPaneNeverWaits() {
+        XCTAssertFalse(TabCoordinator.shouldWaitForCompletion(newStatus: .idle, hookStatus: .unknown))
+    }
+
+    /// Only a completion. A pane that stopped to ask something has its question
+    /// in hand already, and an error is worth saying immediately.
+    func testOnlyACompletionWaits() {
+        for status: AgentStatus in [.waiting, .error, .running] {
+            XCTAssertFalse(TabCoordinator.shouldWaitForCompletion(
+                newStatus: status, hookStatus: .running), status.rawValue)
+        }
+    }
+
 }

--- a/Tests/TelegramBridgeTests.swift
+++ b/Tests/TelegramBridgeTests.swift
@@ -191,6 +191,45 @@ final class TelegramBridgeTests: XCTestCase {
         XCTAssertEqual(cmd?.body, "yes, do that")
     }
 
+    // MARK: - Telling the operator why nothing happened
+
+    /// The bug this exists for: an order typed into a group, unaddressed, was
+    /// dropped without a word — which reads exactly like a broken bot.
+    func testAnOperatorsBareGroupLineEarnsAHint() {
+        XCTAssertTrue(TelegramChannel.isUnaddressedOrder(
+            in: message("你看看这个 issue 的 bug 还在不在", chat: group),
+            config: ownerConfig, botUsername: "seahelm_bot"))
+    }
+
+    /// Everything that already works must stay silent: there is nothing to
+    /// explain to someone whose line was taken.
+    func testNothingThatWorksEarnsAHint() {
+        for taken in [message("fix the flaky test"),                                    // private prose
+                      message("/status", chat: group),                                  // group command
+                      message("@seahelm_bot ship it", chat: group),                     // group mention
+                      message("yes, do that", chat: group, replyingTo: "seahelm_bot")] { // group reply
+            XCTAssertFalse(TelegramChannel.isUnaddressedOrder(
+                in: taken, config: ownerConfig, botUsername: "seahelm_bot"), taken.body ?? "")
+        }
+    }
+
+    /// A colleague's chatter is not an order and not the operator's problem.
+    /// Hinting at it would make the bot the noisiest member of the room.
+    func testAStrangersGroupLineEarnsNoHint() {
+        let stranger = TelegramUser(id: 7, isBot: false, firstName: "X", username: nil)
+        XCTAssertFalse(TelegramChannel.isUnaddressedOrder(
+            in: message("lunch?", from: stranger, chat: group),
+            config: ownerConfig, botUsername: "seahelm_bot"))
+    }
+
+    func testTheHintNamesBothWaysIn() {
+        let hint = TelegramChannel.addressingHint(botUsername: "seahelm_bot")
+        XCTAssertTrue(hint.contains("@seahelm_bot"), hint)
+        XCTAssertTrue(hint.lowercased().contains("reply"), hint)
+        // A bot whose username we never learned still has a reply to offer.
+        XCTAssertFalse(TelegramChannel.addressingHint(botUsername: nil).contains("@"))
+    }
+
     /// The gate the group rule was always protecting: prose aimed at somebody
     /// else — another bot, a colleague's message — must not reach an agent.
     func testGroupProseAimedElsewhereIsStillNotAnOrder() {

--- a/Tests/TerminalTranscriptTests.swift
+++ b/Tests/TerminalTranscriptTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+@testable import seahelm
+
+final class TerminalTranscriptTests: XCTestCase {
+
+    private let rule = String(repeating: "─", count: 40)
+
+    func testStripsTerminalControlSequences() {
+        let raw = "\u{1B}[1;32mready\u{1B}[0m\n\u{1B}]0;title\u{07}\n────────\n$ ls"
+        XCTAssertEqual(TerminalTranscript.clean(raw), "ready\n$ ls")
+    }
+
+    /// An agent TUI repaints meters, rules and a permission banner around the
+    /// conversation; read in a chat, that furniture outweighs what was said.
+    func testStripsAgentTUIChrome() {
+        let raw = [
+            "real answer here",
+            "❯",
+            "✻ Churned for 44s",
+            "Context █░░░░░░░░░ 7% │ Usage ██░░░░░░░░ 19% (resets in 2h)",
+            "⏵⏵ bypass permissions on (shift+tab to cycle)",
+            "⚠ Transcript saving is off — inherited marker",
+            "::seahelm-suggest:: a | b",
+            "second real line",
+        ].joined(separator: "\n")
+        XCTAssertEqual(TerminalTranscript.clean(raw), "real answer here\nsecond real line")
+    }
+
+    /// The verb in the churn line is picked at random, so it cannot be matched
+    /// on: "Churned", "Worked", "Sautéed" are all the same line.
+    func testStripsEveryChurnVerb() {
+        let raw = "answer\n✻ Sautéed for 2m 28s · done 6:50 PM\n✻ Worked for 1m 7s"
+        XCTAssertEqual(TerminalTranscript.clean(raw), "answer")
+    }
+
+    /// The control line wraps when it is wider than the pane, and the wrapped
+    /// remainder carries no marker of its own.
+    func testStripsAWrappedSuggestLine() {
+        let raw = [
+            "the answer",
+            "::seahelm-suggest:: 授权后重跑 From 写入 | 开始做落库那部分改动 |",
+            "给 issue 打 ai:auto 进自动队列 | 先查 1:1 失败的 58 条明细",
+            "next real line",
+        ].joined(separator: "\n")
+        XCTAssertEqual(TerminalTranscript.clean(raw), "the answer\nnext real line")
+    }
+
+    // MARK: - The composer box
+
+    /// Everything below the composer is the agent's own furniture, and the
+    /// statusline down there is whatever command the user configured — no list
+    /// of strings could keep up with it, so the cut is positional.
+    func testCutsEverythingBelowTheComposerBox() {
+        let raw = [
+            "⏺ the answer",
+            rule,
+            "❯ 提 PR",
+            rule,
+            "[Opus 5 (1M context)] │ mei-yi-ge git:(task/mei-yi-ge)                    /rc",
+            "Context ████░░ 41% │ Usage 7d: █████░ 49% (resets in 4d 7h)",
+            "⏵⏵ bypass permissions on (shift+tab to cycle) · ← 5 agents",
+            "⧉  apps-login-domain",
+        ].joined(separator: "\n")
+        // The composer's own text stays: it is the operator's words, unsent.
+        XCTAssertEqual(TerminalTranscript.clean(raw), "⏺ the answer\n❯ 提 PR")
+    }
+
+    /// A lone rule is just as likely to be a markdown `---` the agent printed.
+    /// Cutting there would throw away the answer, so the *pair* is the signal.
+    func testKeepsProseBelowASingleRule() {
+        let raw = ["## Findings", rule, "the part that matters", "and its conclusion"].joined(separator: "\n")
+        XCTAssertEqual(TerminalTranscript.clean(raw), "## Findings\nthe part that matters\nand its conclusion")
+    }
+
+    /// A pane sitting at a shell has no composer box at all.
+    func testKeepsAPlainShellCaptureWhole() {
+        let raw = "warning: `teamclu` (lib) generated 1 warning\nBuilding 953/954"
+        XCTAssertEqual(TerminalTranscript.clean(raw), raw)
+    }
+
+    // MARK: - The startup banner
+
+    /// A pane that has just started — or just been `/clear`ed — is nothing but
+    /// banner, notices and statusline. The whole capture should come back empty
+    /// so `/show` leaves the section out rather than printing furniture.
+    func testAFreshPaneHasNothingToShow() {
+        let raw = [
+            "▐▛███▛█   Claude Code v2.1.263",
+            "▝▜██████▀  Opus 5 (1M context) with xhigh effort · Claude Max",
+            "  ▝▝ ▝▝    /Volumes/openbeta/workspace/saas-mono-worktrees/task/https-github-com-bet",
+            "⚠ 1 MCP server needs authentication · run /mcp",
+            "✔ Update installed · Restart to update",
+            rule,
+            "❯",
+            rule,
+            "[Opus 5 (1M context)] │ https-github-com-bet git:(task/betly-app)          /rc",
+            "Context ░░░░░░ 0% │ Usage 7d: ███░░░ 33% (resets in 3d 17h)",
+            "⏵⏵ bypass permissions on (shift+tab to cycle) · ← 5 agents",
+        ].joined(separator: "\n")
+        XCTAssertEqual(TerminalTranscript.clean(raw), "")
+    }
+
+    /// One block glyph is a gutter, not a banner — Codex prefixes its own
+    /// messages with `▌`, and that line is the message. The gutter itself is
+    /// drawing, so it goes and the words stay.
+    func testUnframesAGutteredMessage() {
+        XCTAssertEqual(TerminalTranscript.clean("▌ the agent's own words"), "the agent's own words")
+    }
+
+    // MARK: - The other agents
+
+    /// Cursor Agent puts its whole UI inside a box, a blocked pane's question
+    /// included. Dropping every framed line — which is what a first-character
+    /// test does — threw away the one thing worth reading from a phone.
+    func testReadsCursorAgentsFramedDialog() {
+        let raw = [
+            "╭──────────────────────────────────────────────────────────────╮",
+            "│                                                              │",
+            "│  ⚠ Workspace Trust Required                                  │",
+            "│                                                              │",
+            "│  Do you trust the contents of this directory?                │",
+            "│                                                              │",
+            "│    [a] Trust this workspace                                  │",
+            "│    [q] Quit                                                  │",
+            "╰──────────────────────────────────────────────────────────────╯",
+        ].joined(separator: "\n")
+        XCTAssertEqual(TerminalTranscript.clean(raw), """
+        ⚠ Workspace Trust Required
+        Do you trust the contents of this directory?
+        [a] Trust this workspace
+        [q] Quit
+        """)
+    }
+
+    /// OpenCode frames its composer with `┃` sides and a half-block floor, and
+    /// hangs key hints, a tip and its statusline under it. None of those glyphs
+    /// are the ones Claude Code draws with, which is why the rules take the box
+    /// and block Unicode ranges whole.
+    func testCutsOpenCodesFooter() {
+        let raw = [
+            "█▀▀█ █▀▀█ █▀▀█ █▀▀▄ █▀▀▀ █▀▀█ █▀▀█ █▀▀█",
+            "┃",
+            "┃  Ask anything...",
+            "╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀",
+            "tab agents  ctrl+p commands",
+            "● Tip Run /compact to summarize long sessions near context limits",
+            "/private/tmp/probe:main            1.18.18",
+        ].joined(separator: "\n")
+        XCTAssertEqual(TerminalTranscript.clean(raw), "Ask anything...")
+    }
+
+    /// Codex draws no frame around its composer, so its startup box is the only
+    /// pair of rules in the capture — and it sits eight rows up, with the tip
+    /// and the MCP warnings below it. Reading that as a composer would take all
+    /// of them down, so the cut only ever looks at the last few rows.
+    func testDoesNotMistakeCodexsStartupBoxForAComposer() {
+        let raw = [
+            "╭───────────────────────────────────────────╮",
+            "│ >_ OpenAI Codex (v0.153.4)                │",
+            "│                                           │",
+            "│ model:     gpt-5.6-luna xhigh             │",
+            "╰───────────────────────────────────────────╯",
+            "Tip: give it a hard problem, a half-formed idea,",
+            "or anything you have been meaning to build.",
+            "⚠ The supabase MCP server requires OAuth reauthentication.",
+            "⚠ MCP startup incomplete (failed: supabase)",
+            "› Ask Codex to do anything",
+        ].joined(separator: "\n")
+        let text = TerminalTranscript.clean(raw)
+        XCTAssertTrue(text.contains("⚠ MCP startup incomplete (failed: supabase)"), text)
+        XCTAssertTrue(text.hasPrefix(">_ OpenAI Codex (v0.153.4)"), text)
+    }
+}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		34295E2A78AAF5B432E08698 /* PiExtensionInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5477C17977F4C27B7B01CB /* PiExtensionInstallerTests.swift */; };
 		346BF50E3F02C947F8D62DB5 /* JetBrainsMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 887D8D47490B9D11BC6072DA /* JetBrainsMono-Regular.ttf */; };
 		3498F0F3D7028F811DF7DF34 /* HeadlessCommandHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FEA86B38AB3BEE8AA18906A /* HeadlessCommandHost.swift */; };
+		350E1C39CF2682EBE1BC9E3D /* TerminalTranscript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F029A5E271BDEEF49A54B1E /* TerminalTranscript.swift */; };
 		35B413CAB65CDFC7F5994E84 /* ActivityEventExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7282FEF43CB2989F9CE4859B /* ActivityEventExtractor.swift */; };
 		36A3C27B63B14CBA52BC3A4D /* OverviewFocusModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78D1BBB07A2822E90114369F /* OverviewFocusModel.swift */; };
 		371A789DDD991B083F733DB8 /* PaneStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C8FE4C75F1A4EF074C03C2 /* PaneStatusTests.swift */; };
@@ -233,6 +234,7 @@
 		7CD31456EADFD7DFF1185D9D /* ReturnToPort.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910A1A1AF1F5DDDA3A675836 /* ReturnToPort.swift */; };
 		7D04C2A61105F5AD7BD48E3F /* CommandSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7018E7ABB432ABCFCB9723F /* CommandSpec.swift */; };
 		7D09CC05B794C0D59CA4146B /* WindowChromeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105E0FAF9CFF482771DB785 /* WindowChromeController.swift */; };
+		7DCD8971DE8D081747EA3A9A /* TerminalTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BC82FB2BA068E9AAA2C118 /* TerminalTranscriptTests.swift */; };
 		7DD2666A7F2FE0E895A38F8B /* WorktreeTaskStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2F9EA56DB31E6555203E06 /* WorktreeTaskStoreTests.swift */; };
 		7E73C1FAA15054E71BDFDEF8 /* GitHubReturnPRClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E584B1D165D21C28521196B /* GitHubReturnPRClient.swift */; };
 		7ED2875B97C74F9DF0DF3F79 /* PaneWorkingDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5DCCDD64708BEB08D20C0A /* PaneWorkingDirectory.swift */; };
@@ -653,6 +655,7 @@
 		5189888D351C4E3BE7FD1B0C /* SettingsRowLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsRowLayoutTests.swift; sourceTree = "<group>"; };
 		520082A00702435AC8280D60 /* AddWorktreePopoverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddWorktreePopoverTests.swift; sourceTree = "<group>"; };
 		529E3EDAF8D57902FD901649 /* PanelCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelCoordinatorTests.swift; sourceTree = "<group>"; };
+		52BC82FB2BA068E9AAA2C118 /* TerminalTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTranscriptTests.swift; sourceTree = "<group>"; };
 		52EF0C4896EE233186B21980 /* GatewayState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatewayState.swift; sourceTree = "<group>"; };
 		532D40CAB3DC6BC206BB94C4 /* StationRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationRegistry.swift; sourceTree = "<group>"; };
 		536A8D31229E4F3D3D5D4DE8 /* ControlSocketServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlSocketServerTests.swift; sourceTree = "<group>"; };
@@ -770,6 +773,7 @@
 		8E004E8B96865467209D3F2D /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		8E895D84F1DB6343D08BAB30 /* PaneInfoDisplayStatusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneInfoDisplayStatusTests.swift; sourceTree = "<group>"; };
 		8EA68D37F6726B55761155E3 /* AgentRegistryBackgroundBusyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryBackgroundBusyTests.swift; sourceTree = "<group>"; };
+		8F029A5E271BDEEF49A54B1E /* TerminalTranscript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTranscript.swift; sourceTree = "<group>"; };
 		902196E72A614F0FF9C90514 /* AVKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVKit.framework; path = System/Library/Frameworks/AVKit.framework; sourceTree = SDKROOT; };
 		90BFD1E80754F390DB43E63A /* SeahelmHookInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeahelmHookInstallerTests.swift; sourceTree = "<group>"; };
 		90EF92DD407F1B5BBC3F3FC1 /* IntegrationWorktreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationWorktreeTests.swift; sourceTree = "<group>"; };
@@ -1137,6 +1141,7 @@
 				AFC635E261560E69EFA29FEE /* TelegramRule.swift */,
 				5C8C29ABAFC62F8A953F2CD9 /* TelegramRuleCoalescer.swift */,
 				3D90518E8BFCA59E2D344513 /* TerminalEnvironment.swift */,
+				8F029A5E271BDEEF49A54B1E /* TerminalTranscript.swift */,
 				77ABED3BE7AAC378B4E6B068 /* TodoStore.swift */,
 				D01D0EBCC80C1AA901CA8E5B /* VTEvent.swift */,
 				F0982B809334A31181947736 /* WatchFeed.swift */,
@@ -1580,6 +1585,7 @@
 				0BC6460413988FF775BDA1B3 /* TelegramRuleTests.swift */,
 				DCE458A11E72A34C3556092F /* TerminalCoordinatorTests.swift */,
 				472ACEFBD0F23747FC60EB0D /* TerminalHeaderViewTests.swift */,
+				52BC82FB2BA068E9AAA2C118 /* TerminalTranscriptTests.swift */,
 				3F67CBC84404085C3483C910 /* TestViewHelpers.swift */,
 				DBC2859D1D589D68F33F0552 /* TodoStoreTests.swift */,
 				574B7FE2D9B877BB71343689 /* UsageReadoutTests.swift */,
@@ -2143,6 +2149,7 @@
 				47229EE74F8F3BEA93AB0B6A /* TelegramRuleTests.swift in Sources */,
 				B2D3C5CCB2735F1895E271BE /* TerminalCoordinatorTests.swift in Sources */,
 				9C35BEC65A084B6F21FF11DB /* TerminalHeaderViewTests.swift in Sources */,
+				7DCD8971DE8D081747EA3A9A /* TerminalTranscriptTests.swift in Sources */,
 				FA7FE7F8722B6916762E68E3 /* TestViewHelpers.swift in Sources */,
 				62FF9B7688CD065BE7DEBF35 /* TodoStoreTests.swift in Sources */,
 				67534BADE19F84A44C2CE74E /* UsageReadoutTests.swift in Sources */,
@@ -2429,6 +2436,7 @@
 				0658FAE09BDFAD7932B01617 /* TerminalCoordinator.swift in Sources */,
 				913DBD2B1D15867351B0DEE0 /* TerminalEnvironment.swift in Sources */,
 				AD608FF60D293BA96BCB01B8 /* TerminalHeaderView.swift in Sources */,
+				350E1C39CF2682EBE1BC9E3D /* TerminalTranscript.swift in Sources */,
 				CBB8B4ECA774CBFE1EF1A070 /* Theme.swift in Sources */,
 				964D05E6C8C5D093CB6633E2 /* ThemedBackgroundView.swift in Sources */,
 				A3C6B5F047EBF420EA393C13 /* TodoStore.swift in Sources */,

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 		5B886E1FEAC1891962201C01 /* GmailMailConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17703086C94D05EDA9B85B21 /* GmailMailConfigTests.swift */; };
 		5BFD525836B15C48CC54A5D8 /* WatchFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0982B809334A31181947736 /* WatchFeed.swift */; };
 		5D6CF18A7384A74B640EFAAC /* WorktreeStatusAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4775959C72857610AC1F12DC /* WorktreeStatusAggregator.swift */; };
+		5DEB3FBD2ED30FCAA6BA00C1 /* ChatProgressReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51A16B0468001FB40538FB2 /* ChatProgressReporter.swift */; };
 		5E77C3E6AA55F970F5DD877E /* HostGatewayDecisions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399B19A39BB25DDA3D401B60 /* HostGatewayDecisions.swift */; };
 		5F16B6F4A4D85F5E6F515A4E /* WebhookSuggestEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54322E1FB43B65F94D1AAC20 /* WebhookSuggestEventTests.swift */; };
 		5F7CEFC99E339F7621D6509A /* ZmxLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063BC4CAFB28A7B7DEA60474 /* ZmxLocatorTests.swift */; };
@@ -484,6 +485,7 @@
 		FAF2ABF4372E190D0A42EE2A /* HostGatewayConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF8548571F540C914ACA11E /* HostGatewayConfigTests.swift */; };
 		FB0F579F23F5FBCAEE4FB294 /* PairRateLimiterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9D36C4513804B095CBABA5 /* PairRateLimiterTests.swift */; };
 		FB6A28074D9ADC1B5DB97F53 /* StationHealthCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0F7D7F30A3F031DC191AFF /* StationHealthCheckTests.swift */; };
+		FBB5DF751FCBF459971307E2 /* ChatProgressReporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5FC7AAD7C1A63FAB4E534D /* ChatProgressReporterTests.swift */; };
 		FC2829917F91412C222E569F /* TelegramChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371F0BC6C00D849566000118 /* TelegramChannel.swift */; };
 		FC3680C2E8486D8066CCEE37 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB77CC892E8D4F3F9285B90 /* OnboardingViewController.swift */; };
 		FC6620AFE070216CBEDBEB30 /* UsageSummaryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22314B62F8F244CAE44DE94D /* UsageSummaryFormatterTests.swift */; };
@@ -531,6 +533,7 @@
 		0BE2B74AFEED5F242C1B2763 /* ProjectColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectColor.swift; sourceTree = "<group>"; };
 		0C2BF20167E8DC36DDF09077 /* WorktreeSidePanelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSidePanelViewController.swift; sourceTree = "<group>"; };
 		0D19639EE57241F8A021EBD2 /* PaneStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneStatus.swift; sourceTree = "<group>"; };
+		0D5FC7AAD7C1A63FAB4E534D /* ChatProgressReporterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatProgressReporterTests.swift; sourceTree = "<group>"; };
 		0DCA172C011937C216A42CCE /* seahelmUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = seahelmUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		12FFAF61BC60167FFCC8DB9E /* FirstMateCoordinatorOutcomeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateCoordinatorOutcomeTests.swift; sourceTree = "<group>"; };
 		1300118EBD67FF59FD7D8BF5 /* GmailOAuthAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GmailOAuthAuthorization.swift; sourceTree = "<group>"; };
@@ -953,6 +956,7 @@
 		E4347F9E7EF04217AB29D93E /* ChromeIconButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeIconButton.swift; sourceTree = "<group>"; };
 		E48EF7634B86F69D2FCA6759 /* WorktreeReturnPlannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeReturnPlannerTests.swift; sourceTree = "<group>"; };
 		E4BEF7BAC8EF2918D2F601F7 /* ghostty.conf */ = {isa = PBXFileReference; path = ghostty.conf; sourceTree = "<group>"; };
+		E51A16B0468001FB40538FB2 /* ChatProgressReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatProgressReporter.swift; sourceTree = "<group>"; };
 		E599A3810CED6E82EBD8BBC9 /* FirstMateCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateCoordinator.swift; sourceTree = "<group>"; };
 		E664A1C5B1466EF19108D6B8 /* ShortcutHintBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutHintBar.swift; sourceTree = "<group>"; };
 		E7B9CCF0AFEC7E34EB93A779 /* AgentSessionRef.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionRef.swift; sourceTree = "<group>"; };
@@ -1050,6 +1054,7 @@
 				BF702127762EBDF898385B56 /* Analytics.swift */,
 				81F38890EF85FE22F83ED385 /* ChatCallbackRegistry.swift */,
 				1B2F4C9A4491CF0E397E1D0F /* ChatNoticeBook.swift */,
+				E51A16B0468001FB40538FB2 /* ChatProgressReporter.swift */,
 				2D90204521BAE476A8EF340E /* ClaudeHooksSetup.swift */,
 				26EFCABEFB8EEA92A8B6FA13 /* ClaudeStatuslineBridgeInstaller.swift */,
 				A51B009382FE3586E735355D /* CodexHooksSetup.swift */,
@@ -1453,6 +1458,7 @@
 				F4D445453693B8D5A3D088F1 /* AgentTypeTests.swift */,
 				01DB279E827314DBFA97331B /* ChatCallbackRegistryTests.swift */,
 				B8816ECB0847ABFD594B1AB3 /* ChatNoticeBookTests.swift */,
+				0D5FC7AAD7C1A63FAB4E534D /* ChatProgressReporterTests.swift */,
 				C257053E5A9E9DC19BB550EB /* ChatQuestionCardTests.swift */,
 				5E88C517CE4270179492479E /* ChoiceOptionParserTests.swift */,
 				38FD43578EB5A227077BAA11 /* ChromeCollapseAnimationTests.swift */,
@@ -2017,6 +2023,7 @@
 				53D46BF1B3E00A35B53A86C4 /* AgentTypeTests.swift in Sources */,
 				E898E9379622EC8D16777977 /* ChatCallbackRegistryTests.swift in Sources */,
 				1055CF6524AAB2DC4EE2C835 /* ChatNoticeBookTests.swift in Sources */,
+				FBB5DF751FCBF459971307E2 /* ChatProgressReporterTests.swift in Sources */,
 				F8D552BE492D81AD67DBB488 /* ChatQuestionCardTests.swift in Sources */,
 				9F3608916964651FE502DAD3 /* ChoiceOptionParserTests.swift in Sources */,
 				3D18A10A7522058688B2A1F7 /* ChromeCollapseAnimationTests.swift in Sources */,
@@ -2233,6 +2240,7 @@
 				7BDCC195CBE9B564845BB8D3 /* CenterOverlayView.swift in Sources */,
 				0AE7E3F52B1D7EFFF5D01E6A /* ChatCallbackRegistry.swift in Sources */,
 				79A076BEF314843CD19EE657 /* ChatNoticeBook.swift in Sources */,
+				5DEB3FBD2ED30FCAA6BA00C1 /* ChatProgressReporter.swift in Sources */,
 				72EA963BA7948ECBF5DABF5C /* ChoiceOptionParser.swift in Sources */,
 				3BE5AE4B30540C9F80527B7F /* ChromeDividerView.swift in Sources */,
 				DCD355D8BE1EF13AECD21332 /* ChromeHeaderDelegate.swift in Sources */,


### PR DESCRIPTION
Five faults on the phone-facing surface, found by driving Telegram against a live fleet and then reading the notification history against Claude's own transcript timestamps.

## `/show` was mostly the agent's own furniture

`zmx history` returns the pane's *screen*, not its transcript. A `/show` arrived carrying a startup banner, a statusline, the context meter and the permission hint — and for a pane just `/clear`ed, nothing else at all.

The old filter listed the glyphs Claude Code happens to draw with, which describes one TUI and no others. Checked against real captures from five agents it left OpenCode's floor, hints, tip and statusline in place, left pi's statusline in place, and dropped **Cursor Agent's entire trust dialog** — every line starts with a box glyph, and the old rule threw those away whole, so a pane blocked on a question showed nothing.

Now structural, because no blocklist keeps up with a statusline the user configured themselves: the two Unicode ranges taken whole, frames unwrapped rather than dropped, and the composer's floor as the end of the conversation — under four conditions, since a lone rule is just as likely to be a markdown `---` and Codex's startup box is a pair of rules with its release notes underneath.

| agent | before | after |
|---|---|---|
| Claude Code | 5 lines of chrome | clean |
| OpenCode | logo, floor, hints, tip, statusline | 13 lines → 2 |
| pi | statusline | cut |
| Cursor Agent | **whole dialog dropped** | readable |
| Codex | box frame | frame cleaned; statusline still leaks (its composer has no frame — no structural signal) |

## A notice quoting the previous turn's answer

An order lands, the agent has not spoken since, and a completion edge announces what it said *last* time under the new order's name. The once-per-turn gate let it past because the fingerprint carries the prompt: a new prompt made a new fingerprint out of the old words. It also burned the 30s cooldown, so the real answer arrived minutes late — after the reader had already tapped a button on the stale card.

## A notice that beat the answer by nine seconds

Measured on a real turn: notice at 09:06:32, the model finished writing at 09:06:40.99. The screen went quiet while it was composing, the scan read quiet as finished, and the notice quoted the only other thing on the pane — a shell command. When the real Stop landed the status was no longer `running`, so `shouldNotify` refused it: **the wrong message was the only message**, with the right buttons stapled underneath.

Completions now wait while the pane's own hooks still say it is running. `pane explain` had been reporting `hook_status: running, decided_by: screen` the whole time.

## A group order dropped in silence

In a group only `/commands`, `@thebot` and replies steer an agent — somebody else's sentence must not. But an operator's *own* unaddressed line was dropped without a word, which is indistinguishable from a broken bot. One hint now, once per group per ten minutes, and only for someone who could have given an order in the first place.

## Nothing at all while an agent works

Telegram has no streaming primitive, and there is nothing token-shaped to stream — the prose arrives once, whole, at the end. But every tool call is already an event, so a pane's bound chats get one live line: sent late (a turn ending in seconds must leave no trace), edited in place at most every 3s, taken back when the turn ends. It never carries the answer; the completion notice still does, as its own message.

## Testing

- 1993 unit tests green, including 38 new ones
- The transcript rules validated against ten real captures — six Claude panes (one a plain `cargo build` that must come through untouched) plus OpenCode, pi, Codex and Cursor Agent, each run in a throwaway zmx session
- Two tests caught real bugs while being written: the progress line could be edited one second after it was posted, and a box's blank interior row was wide enough to be read as a composer floor
- UI tests not run — they hijack the live app's control socket

## Note

Ships one `[notify]` log line per delivery decision. Reconstructing the nine-second race needed Claude's transcript timestamps cross-referenced against the notification history; the inputs are cheap to say out loud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6fmGobHGJbmtYYAFfNtCW
