### PR TITLE
fix: avoid stale trunk worktree changes

### DIFF
--- a/Sources/Git/GitDiff.swift
+++ b/Sources/Git/GitDiff.swift
@@ -318,12 +318,23 @@ enum GitDiff {
     /// What seahelm recorded when it created the worktree beats guessing at a
     /// trunk name: a worktree stacked on another agent's branch has a base no
     /// entry in `preferredBaseRefs` can name, and comparing it against trunk
-    /// reports the branch below it as its own work. A recorded base that no
-    /// longer resolves — merged and pruned, or renamed — falls through to the
-    /// trunk guess rather than leaving the panel with no base at all.
+    /// reports the branch below it as its own work. The exception is a recorded
+    /// local trunk: use its remote-tracking ref when present, otherwise a root
+    /// checkout that has not pulled makes already-merged files look outstanding.
+    /// A recorded base that no longer resolves — merged and pruned, or renamed
+    /// — falls through to the trunk guess rather than leaving the panel baseless.
     static func resolveBaseRef(worktreePath: String, recordedBase: String?) -> String? {
-        if let recordedBase, refExists(recordedBase, worktreePath: worktreePath) {
-            return recordedBase
+        if let recordedBase {
+            let trimmed = recordedBase.trimmingCharacters(in: .whitespacesAndNewlines)
+            if (trimmed == "main" || trimmed == "master") {
+                let remoteTracking = "origin/\(trimmed)"
+                if refExists(remoteTracking, worktreePath: worktreePath) {
+                    return remoteTracking
+                }
+            }
+            if refExists(trimmed, worktreePath: worktreePath) {
+                return trimmed
+            }
         }
         for ref in preferredBaseRefs where refExists(ref, worktreePath: worktreePath) {
             return ref

--- a/Tests/StackedWorktreeBaseTests.swift
+++ b/Tests/StackedWorktreeBaseTests.swift
@@ -44,6 +44,20 @@ final class StackedWorktreeBaseTests: XCTestCase {
         )
     }
 
+    /// A worktree cut from trunk records the local branch name, but the root
+    /// checkout can be behind its remote after another worktree's PR merges.
+    /// Prefer the remote-tracking tip so already-merged files do not linger in
+    /// Changes as branch-relative work.
+    func testRecordedTrunkPrefersRemoteTrackingTip() throws {
+        let repo = try makeStackedRepo()
+        runGit(["update-ref", "refs/remotes/origin/main", "main"], in: repo.root)
+
+        XCTAssertEqual(
+            GitDiff.resolveBaseRef(worktreePath: repo.uiWorktree, recordedBase: "main"),
+            "origin/main"
+        )
+    }
+
     /// A base merged upstream and pruned must not leave the panel baseless.
     func testDeletedBaseFallsBackToTrunk() throws {
         let repo = try makeStackedRepo()


### PR DESCRIPTION
## Summary
- prefer origin/main or origin/master when a worktree recorded the local trunk as its base
- retain recorded non-trunk bases for stacked worktrees
- add regression coverage for stale local trunk refs

## Validation
- xcodebuild -project seahelm.xcodeproj -scheme seahelmTests -configuration Debug -skipPackagePluginValidation -skipMacroValidation test -only-testing:seahelmTests/StackedWorktreeBaseTests