### PR TITLE
fix(web): keep the terminal caret when chrome is clicked

### DIFF
--- a/clients/seahelm-web/README.md
+++ b/clients/seahelm-web/README.md
@@ -45,6 +45,9 @@ Wire 格式:
 | `mqtt.min.js` | vendored MQTT.js — **仅 devbroker / 遗留 MQTT 调试** |
 | `xterm.js` / `xterm.css` | vendored xterm.js 5.5.0 |
 | `xterm-addon-webgl.js` | vendored WebGL renderer — loaded on first terminal open, not at page load |
+| `touch-scroll.js` | 触控竖滑 → 终端 wheel，手机上回看历史 |
+| `vt-apply.js` | VT 帧串行写入；等 `term.write` 完成再应用下一帧 |
+| `term-focus.js` | chrome 点击不抢终端 caret；真实输入框除外 |
 | `devbroker/` | 本地 MQTT 调试台(**非生产路径**) |
 
 ## 本地 MQTT 调试(dev-only)
@@ -86,7 +89,7 @@ MAC=live npm run mock:zmx # 终端 B: ZMX_PANES=1,真实 zmx session → MQTT pa
 | ≤ 1100px | 日志栏自动隐藏 |
 | ≤ 760px | 单栏,First Mate 抽屉(☰) |
 
-终端按宽度贴合;字号下限 9px;右下角「↓ 最新」在回看时出现。
+终端按宽度贴合;字号下限 9px;手机单指上下滑回看历史（横滑不拦截）;右下角「↓ 最新」在回看时出现。
 
 ### VT 订阅模式
 
@@ -131,6 +134,8 @@ cd clients/seahelm-web/devbroker
 npm run broker && npm run mock
 node protocol-test.js   # 22 项 §15
 node vt-test.js         # VT 端到端
+node vt-apply-test.js   # write 串行 / 背压丢帧
+node term-focus-test.js # chrome 不抢终端 caret
 ```
 
 ## 相关文档

--- a/clients/seahelm-web/devbroker/term-focus-test.js
+++ b/clients/seahelm-web/devbroker/term-focus-test.js
@@ -1,0 +1,85 @@
+// term-focus-test.js — chrome clicks must not steal the terminal caret.
+//
+// Run:  node devbroker/term-focus-test.js
+//
+// In a browser every <button> is focusable. Click the list, a chip, or a
+// shortcut, and xterm's helper textarea loses the IME — the pane still looks
+// selected. The Mac never has this split because Ghostty is first responder.
+'use strict';
+
+const { shouldRestoreTerminal, install } = require('../term-focus.js');
+
+let pass = 0, fail = 0;
+const check = (ok, name, extra = '') => {
+  if (ok) { pass++; console.log(`  ok   ${name}`); }
+  else { fail++; console.log(`  FAIL ${name} ${extra}`); }
+};
+
+console.log('term focus');
+
+check(shouldRestoreTerminal(null) === true, 'nothing focused → restore');
+check(shouldRestoreTerminal({ tagName: 'BODY' }) === true, 'body → restore');
+check(shouldRestoreTerminal({ tagName: 'BUTTON' }) === true, 'a button is not an input');
+check(shouldRestoreTerminal({ tagName: 'DIV' }) === true, 'a row / chip container is not an input');
+check(shouldRestoreTerminal({ tagName: 'INPUT', type: 'text' }) === false, 'a text field keeps the caret');
+check(shouldRestoreTerminal({ tagName: 'INPUT', type: 'number' }) === false, 'so does a numeric field');
+check(shouldRestoreTerminal({ tagName: 'TEXTAREA' }) === false, 'and a textarea (pairing / IME)');
+check(shouldRestoreTerminal({ tagName: 'SELECT' }) === false, 'and a select');
+check(shouldRestoreTerminal({ tagName: 'DIV', isContentEditable: true }) === false,
+      'contenteditable keeps the caret');
+check(shouldRestoreTerminal({ tagName: 'INPUT', type: 'hidden' }) === true,
+      'a hidden input is not a place to type');
+check(shouldRestoreTerminal({ tagName: 'INPUT', type: 'button' }) === true,
+      'an input-as-button is chrome');
+
+{
+  let restored = 0;
+  let prevented = false;
+  let tabindex;
+  const listeners = {};
+  const button = {
+    tagName: 'BUTTON',
+    setAttribute(name, value) { if (name === 'tabindex') tabindex = value; },
+  };
+  const doc = {
+    activeElement: button,
+    addEventListener(type, fn) {
+      (listeners[type] = listeners[type] || []).push(fn);
+    },
+  };
+  const later = [];
+  install(doc, () => { restored++; }, { setTimer: (fn) => later.push(fn) });
+
+  const ev = {
+    target: { closest: () => button },
+    preventDefault() { prevented = true; },
+  };
+  for (const fn of listeners.mousedown || []) fn(ev);
+  check(prevented, 'mousedown on chrome does not move focus');
+  check(tabindex === '-1', 'and the control leaves the tab order');
+
+  for (const fn of listeners.click || []) fn(ev);
+  check(restored === 0, 'restore waits until the click handler finishes');
+  for (const fn of later) fn();
+  check(restored === 1, 'then the terminal is given the keyboard back');
+}
+
+{
+  let restored = 0;
+  const listeners = {};
+  const input = { tagName: 'INPUT', type: 'text' };
+  const doc = {
+    activeElement: input,
+    addEventListener(type, fn) {
+      (listeners[type] = listeners[type] || []).push(fn);
+    },
+  };
+  const later = [];
+  install(doc, () => { restored++; }, { setTimer: (fn) => later.push(fn) });
+  for (const fn of listeners.click || []) fn({});
+  for (const fn of later) fn();
+  check(restored === 0, 'does not steal the caret from a real input');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/clients/seahelm-web/devbroker/touch-scroll-test.js
+++ b/clients/seahelm-web/devbroker/touch-scroll-test.js
@@ -1,0 +1,127 @@
+// touch-scroll-test.js — one-finger vertical swipe → terminal scroll.
+//
+// Run:  node devbroker/touch-scroll-test.js
+//
+// xterm.js (and ghostty-web) listen for wheel, not touch. On a phone the
+// WebGL canvas eats the gesture, so this module is the thing that turns a
+// swipe into the same delta a mouse wheel would have produced.
+'use strict';
+
+const { createTouchScroller } = require('../touch-scroll.js');
+
+let pass = 0, fail = 0;
+const check = (ok, name, extra = '') => {
+  if (ok) { pass++; console.log(`  ok   ${name}`); }
+  else { fail++; console.log(`  FAIL ${name} ${extra}`); }
+};
+
+function harness(over = {}) {
+  const deltas = [];
+  const s = createTouchScroller(Object.assign({
+    slop: 10,
+    scroll: (deltaY) => deltas.push(deltaY),
+  }, over));
+  return { s, deltas };
+}
+
+function swipe(s, from, to, steps) {
+  s.start({ x: from.x, y: from.y, touches: 1 });
+  const n = steps || 2;
+  let consumed = false;
+  for (let i = 1; i <= n; i++) {
+    const x = from.x + (to.x - from.x) * (i / n);
+    const y = from.y + (to.y - from.y) * (i / n);
+    const r = s.move({ x, y, touches: 1 });
+    if (r && r.consume) consumed = true;
+  }
+  s.end();
+  return consumed;
+}
+
+console.log('touch scroll');
+
+{
+  const { s, deltas } = harness();
+  const consumed = swipe(s, { x: 40, y: 80 }, { x: 42, y: 84 });
+  check(deltas.length === 0, 'a tap does not scroll');
+  check(!consumed, 'and does not eat the tap');
+}
+
+{
+  const { s, deltas } = harness();
+  swipe(s, { x: 40, y: 40 }, { x: 40, y: 100 });
+  const total = deltas.reduce((a, b) => a + b, 0);
+  check(total < 0, 'finger down scrolls toward older output', `(${total})`);
+}
+
+{
+  const { s, deltas } = harness();
+  swipe(s, { x: 40, y: 100 }, { x: 40, y: 40 });
+  const total = deltas.reduce((a, b) => a + b, 0);
+  check(total > 0, 'finger up scrolls toward live output', `(${total})`);
+}
+
+{
+  const { s, deltas } = harness();
+  swipe(s, { x: 40, y: 80 }, { x: 40, y: 140 });
+  const total = Math.abs(deltas.reduce((a, b) => a + b, 0));
+  check(total === 60, 'the wheel delta matches the swipe in pixels', `(${total})`);
+}
+
+{
+  const { s, deltas } = harness();
+  const consumed = swipe(s, { x: 20, y: 80 }, { x: 120, y: 84 });
+  check(deltas.length === 0, 'a horizontal swipe does not scroll');
+  check(!consumed, 'and is left for the TUI');
+}
+
+{
+  const { s, deltas } = harness();
+  s.start({ x: 40, y: 40, touches: 1 });
+  s.move({ x: 40, y: 80, touches: 1 });           // lock vertical
+  s.move({ x: 70, y: 110, touches: 1 });          // then drift sideways
+  const total = deltas.reduce((a, b) => a + b, 0);
+  check(total === -70, 'a vertical lock keeps scrolling on a diagonal drift', `(${total})`);
+}
+
+{
+  const { s, deltas } = harness();
+  s.start({ x: 20, y: 80, touches: 1 });
+  s.move({ x: 80, y: 82, touches: 1 });           // lock horizontal
+  const later = s.move({ x: 90, y: 140, touches: 1 });
+  check(deltas.length === 0, 'a horizontal lock ignores a later vertical move');
+  check(!later.consume, 'and still does not eat the gesture');
+}
+
+{
+  const { s, deltas } = harness();
+  s.start({ x: 40, y: 40, touches: 2 });
+  s.move({ x: 40, y: 120, touches: 2 });
+  check(deltas.length === 0, 'pinch / two-finger does not scroll');
+}
+
+{
+  const { s, deltas } = harness();
+  s.start({ x: 40, y: 40, touches: 1 });
+  s.move({ x: 40, y: 80, touches: 1 });
+  s.move({ x: 40, y: 120, touches: 2 });
+  check(deltas.reduce((a, b) => a + b, 0) === -40,
+        'a second finger mid-swipe stops further scrolling');
+}
+
+{
+  const { s, deltas } = harness();
+  swipe(s, { x: 20, y: 80 }, { x: 120, y: 84 });  // horizontal, lock
+  swipe(s, { x: 40, y: 40 }, { x: 40, y: 100 });  // next gesture
+  const total = deltas.reduce((a, b) => a + b, 0);
+  check(total === -60, 'end() clears the lock for the next gesture', `(${total})`);
+}
+
+{
+  const { s, deltas } = harness();
+  const consumed = swipe(s, { x: 40, y: 40 }, { x: 40, y: 100 });
+  check(consumed, 'a committed vertical swipe is consumed (no page bounce)');
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/clients/seahelm-web/devbroker/vt-apply-test.js
+++ b/clients/seahelm-web/devbroker/vt-apply-test.js
@@ -1,0 +1,88 @@
+// vt-apply-test.js — VT frames must apply in order, including the write itself.
+//
+// Run:  node devbroker/vt-apply-test.js
+//
+// Inflation was already chained; term.write() was not. A snapshot's reset()
+// could land while the previous write was still draining, which is how a TUI
+// prompt's cursor ended up off the input box.
+'use strict';
+
+const { createApplyQueue, writeTerminal } = require('../vt-apply.js');
+
+let pass = 0, fail = 0;
+const check = (ok, name, extra = '') => {
+  if (ok) { pass++; console.log(`  ok   ${name}`); }
+  else { fail++; console.log(`  FAIL ${name} ${extra}`); }
+};
+
+function flush() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+console.log('vt apply');
+
+{
+  let done = false;
+  const term = {
+    write(_bytes, cb) { setTimeout(() => { done = true; if (cb) cb(); }, 0); },
+  };
+  const p = writeTerminal(term, new Uint8Array([1]));
+  check(done === false, 'writeTerminal does not resolve before the write callback');
+  Promise.resolve(p).then(() => {
+    check(done === true, 'and resolves once the callback fires');
+    afterWriteTerminal();
+  });
+}
+
+function afterWriteTerminal() {
+  {
+    let called = false;
+    writeTerminal({ write() { called = true; } }, new Uint8Array(0)).then(() => {
+      check(called === false, 'an empty payload does not call write');
+      afterEmpty();
+    });
+  }
+}
+
+function afterEmpty() {
+  const order = [];
+  const q = createApplyQueue({ maxData: 8 });
+  let finishSnap;
+  q.enqueue('p', 'vt.snapshot', () => new Promise((resolve) => {
+    order.push('snap-start');
+    finishSnap = () => { order.push('snap-end'); resolve(); };
+  }));
+  q.enqueue('p', 'vt.data', async () => { order.push('data'); });
+  flush().then(() => {
+    check(order.join(',') === 'snap-start',
+          'vt.data waits for an in-flight snapshot write', `(${order.join(',')})`);
+    finishSnap();
+    return q.enqueue('p', 'vt.data', async () => {});
+  }).then(() => flush()).then(() => {
+    check(order.join(',') === 'snap-start,snap-end,data',
+          'then the waiting frame applies', `(${order.join(',')})`);
+    afterSerialize();
+  });
+}
+
+function afterSerialize() {
+  const dropped = [];
+  const q = createApplyQueue({
+    maxData: 2,
+    onDrop: (key) => dropped.push(key),
+  });
+  let release;
+  const hold = () => new Promise((r) => { release = r; });
+  q.enqueue('p', 'vt.data', hold);
+  q.enqueue('p', 'vt.data', async () => {});
+  q.enqueue('p', 'vt.data', async () => {});
+  flush().then(() => {
+    check(dropped.length === 1 && dropped[0] === 'p',
+          'excess vt.data is dropped once the queue is full');
+    q.enqueue('p', 'vt.snapshot', async () => {});
+    check(dropped.length === 1, 'a snapshot is never dropped');
+    release();
+    console.log(`\n${pass} passed, ${fail} failed`);
+    process.exit(fail ? 1 : 0);
+  });
+}

--- a/clients/seahelm-web/index.html
+++ b/clients/seahelm-web/index.html
@@ -161,7 +161,7 @@
     padding:3px 7px;background:var(--panel);border-bottom:1px solid var(--line-12);
     white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
   .vt-leaf.on .vt-leaf-title{color:var(--accent)}
-  .vt-host{flex:1 1 auto;min-height:0;min-width:0;overflow:hidden}
+  .vt-host{flex:1 1 auto;min-height:0;min-width:0;overflow:hidden;touch-action:none}
   /* Single-pane fallback: the strip stands in for the panes we stopped drawing,
      so the layout is still legible even though only one of them is on screen. */
   .vt-single{flex:1 1 auto;min-height:0;min-width:0;display:flex}
@@ -387,7 +387,10 @@
 <link rel="stylesheet" href="./xterm.css" />
 <script src="./xterm.js"></script>
 <script src="./input-coalescer.js"></script>
+<script src="./touch-scroll.js"></script>
 <script src="./reconnect.js"></script>
+<script src="./vt-apply.js"></script>
+<script src="./term-focus.js"></script>
 <script src="./e2ee.js"></script>
 <script>
 // ── state ─────────────────────────────────────────────────────────────────
@@ -713,36 +716,19 @@ async function inflateRaw(bytes){
 // Inflation is async, and a terminal that applies two chunks out of order is
 // corrupted — not slow, corrupted. Every frame for a pane is therefore threaded
 // through one promise chain, so decode can overlap but application cannot.
-const vtWriteChains = new Map();
 // Under decode backlog, drop intermediate vt.data rather than growing forever.
 // Snapshots always enqueue (they reset the terminal).
 const VT_APPLY_MAX = 8;
-const vtApplyDepth = new Map();
-
-function enqueueVTApply(key, type, work){
-  const depth = vtApplyDepth.get(key) || 0;
-  if (type === 'vt.data' && depth >= VT_APPLY_MAX) {
-    log('sys', '(vt drop)', key);
-    return;
-  }
-  vtApplyDepth.set(key, depth + 1);
-  const prior = vtWriteChains.get(key) || Promise.resolve();
-  const next = prior.then(async () => {
-    try {
-      await work();
-    } catch (e) {
-      log('sys', '(vt)', `frame dropped: ${e && e.message}`);
-    } finally {
-      vtApplyDepth.set(key, Math.max(0, (vtApplyDepth.get(key) || 1) - 1));
-    }
-  });
-  vtWriteChains.set(key, next);
-}
-
+const vtApply = SeahelmVTApply.createApplyQueue({
+  maxData: VT_APPLY_MAX,
+  onDrop: (key) => log('sys', '(vt drop)', key),
+  onError: (_key, e) => log('sys', '(vt)', `frame dropped: ${e && e.message}`),
+});
+function enqueueVTApply(key, type, work){ return vtApply.enqueue(key, type, work); }
 /// A pane that goes away takes its chain with it — the map is keyed by pane and
 /// nothing else ever removed an entry, so worktree churn grew it for the life of
 /// the page.
-function releaseVTChain(key){ vtWriteChains.delete(key); }
+function releaseVTChain(key){ vtApply.release(key); }
 
 function onGatewayBinaryFrame(buf){
   const f = parseVTFrame(buf);
@@ -751,7 +737,7 @@ function onGatewayBinaryFrame(buf){
 
   enqueueVTApply(f.key, f.type, async () => {
     const bytes = f.deflated ? await inflateRaw(f.body) : f.body;
-    handleVT(f.key, { type: f.type, bytes, cols: f.cols, rows: f.rows });
+    await handleVT(f.key, { type: f.type, bytes, cols: f.cols, rows: f.rows });
   });
 }
 
@@ -790,7 +776,7 @@ function onGatewayNotify(method, params){
     const key = params.pane_session_key || params.pane_id;
     const type = method === 'vt.snapshot' ? 'vt.snapshot' : 'vt.data';
     enqueueVTApply(key, type, async () => {
-      handleVT(key, {
+      await handleVT(key, {
         type, b64: params.b64, cols: params.cols, rows: params.rows,
       });
     });
@@ -1577,6 +1563,7 @@ function mountSinglePane(key){
   for (const [k, entry] of S.vt.panes){
     if (isLinked()) sendCommand('pane.vt_close', { pane_session_key: k });
     if (entry.keys) entry.keys.cancel();
+    if (entry.touch) entry.touch();
     releaseVTChain(k);
     try { entry.term.dispose(); } catch (e) {}
   }
@@ -1617,6 +1604,7 @@ function unmountPanes(){
   for (const [key, entry] of S.vt.panes){
     if (isLinked()) sendCommand('pane.vt_close', { pane_session_key: key });
     if (entry.keys) entry.keys.cancel();
+    if (entry.touch) entry.touch();
     releaseVTChain(key);
     try { entry.term.dispose(); } catch (e) {}
   }
@@ -1681,7 +1669,14 @@ function buildLayoutLeaf(node){
   // pane can own its own outbound path — no routing table, no focus bookkeeping.
   t.onData((data) => entry.keys.push(data));
   t.onScroll(() => { if (S.vt.focus === key) updateToBottom(); });
+  // xterm/ghostty-web scroll on wheel. The canvas swallows touch, so a
+  // swipe has to be translated — vertical only; a tap or a horizontal
+  // drag is left alone (focus, selection, TUI).
+  entry.touch = SeahelmTouchScroll.attach(host, {
+    target: () => host.querySelector('.xterm-viewport') || t.element || host,
+  });
   el.addEventListener('mousedown', () => focusPane(key));
+  el.addEventListener('touchstart', () => focusPane(key), { passive: true });
 
   // xterm paints its selection onto the canvas, so the browser has no DOM range
   // covering it. A native copy therefore falls back to whatever the browser does
@@ -1737,16 +1732,23 @@ function attachWebglRenderer(term){
       try { addon.dispose(); } catch (e) {}
     });
     term.loadAddon(addon);
+    // Renderer swap rebuilds the screen and commonly blurs the helper
+    // textarea; the pane highlight does not move, so give the keyboard back.
+    restoreTermFocus();
   }).catch((e) => {
     log('sys', '(webgl)', `不可用,回退 DOM 渲染: ${e && e.message}`);
   });
 }
 
+function restoreTermFocus(){
+  const entry = S.vt.focus && S.vt.panes.get(S.vt.focus);
+  if (entry) { try { entry.term.focus(); } catch (e) {} }
+}
+
 function focusPane(key){
   S.vt.focus = key;
   for (const [k, entry] of S.vt.panes) entry.el.classList.toggle('on', k === key);
-  const entry = key && S.vt.panes.get(key);
-  if (entry) { try { entry.term.focus(); } catch (e) {} }
+  restoreTermFocus();
   updateToBottom();
   renderTermKeys();
 }
@@ -1831,7 +1833,7 @@ function sendKeysPayload(paneKey, utf8Bytes){
 }
 
 /** Shared VT path for MQTT topic payloads and Gateway notify frames. */
-function handleVT(paneKey, v){
+async function handleVT(paneKey, v){
   if (!v) return;
   const entry = S.vt.panes.get(paneKey);
   if (!entry) return;                       // a pane we are not mirroring right now
@@ -1857,12 +1859,12 @@ function handleVT(paneKey, v){
       }
     }
     t.reset();
-    if (bytes.length) t.write(bytes, () => fitPaneFont(entry));
-    else fitPaneFont(entry);
+    await SeahelmVTApply.writeTerminal(t, bytes);
+    fitPaneFont(entry);
     if (S.vt.focus === paneKey) updateToBottom();
     return;
   }
-  t.write(bytes);
+  await SeahelmVTApply.writeTerminal(t, bytes);
 }
 
 /** The "back to live" affordance tracks whichever pane has focus. */
@@ -1970,6 +1972,9 @@ applyLogVisibility();
 $('logVtBtn').onclick = () => setShowVTFrames(!showVTFrames);
 setShowVTFrames(showVTFrames);
 $('clearLog').onclick=()=>$('log').innerHTML='';
+// Buttons steal the caret in a browser; the pane highlight does not move.
+// Keep xterm's helper textarea focused unless the user is in a real field.
+SeahelmTermFocus.install(document, restoreTermFocus);
 </script>
 </body>
 </html>

--- a/clients/seahelm-web/term-focus.js
+++ b/clients/seahelm-web/term-focus.js
@@ -1,0 +1,52 @@
+// Keep the terminal's hidden textarea as the caret, even when chrome is clicked.
+//
+// A browser <button> takes focus on mousedown. The pane highlight does not
+// move, so the page looks selected while Esc / IME / ordinary keys go
+// nowhere. preventDefault on chrome mousedown leaves the existing focus
+// alone; a trailing restore covers the case where nothing held it yet.
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.SeahelmTermFocus = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  const KEEP = { INPUT: 1, TEXTAREA: 1, SELECT: 1 };
+  const CHROME_INPUT = { hidden: 1, button: 1, submit: 1, reset: 1, checkbox: 1, radio: 1, file: 1, image: 1 };
+
+  /** True when the caret is not in a field the user is actually typing into. */
+  function shouldRestoreTerminal(el) {
+    if (!el || !el.tagName) return true;
+    if (el.isContentEditable) return false;
+    const tag = el.tagName;
+    if (!KEEP[tag]) return true;
+    if (tag === 'INPUT' && CHROME_INPUT[el.type]) return true;
+    return false;
+  }
+
+  /**
+   * @param {Document} doc
+   * @param {()=>void} restore
+   * @param {{setTimer?: Function}} [opts]
+   */
+  function install(doc, restore, opts) {
+    if (!doc || typeof doc.addEventListener !== 'function') return;
+    const setTimer = (opts && opts.setTimer) || ((fn, ms) => setTimeout(fn, ms));
+
+    doc.addEventListener('mousedown', (e) => {
+      const t = e && e.target;
+      const btn = t && t.closest && t.closest('button, [role="button"]');
+      if (!btn) return;
+      if (typeof btn.setAttribute === 'function') btn.setAttribute('tabindex', '-1');
+      if (typeof e.preventDefault === 'function') e.preventDefault();
+    }, true);
+
+    doc.addEventListener('click', () => {
+      setTimer(() => {
+        if (shouldRestoreTerminal(doc.activeElement)) restore();
+      }, 0);
+    });
+  }
+
+  return { shouldRestoreTerminal, install };
+});

--- a/clients/seahelm-web/touch-scroll.js
+++ b/clients/seahelm-web/touch-scroll.js
@@ -1,0 +1,127 @@
+// One-finger vertical swipe → the same delta a mouse wheel would have sent.
+//
+// xterm.js (and ghostty-web) scroll on wheel, not touch. The WebGL canvas
+// sits on top of the viewport and eats the gesture, so a phone has no way
+// to read scrollback. This turns a swipe into that wheel delta; the
+// terminal then either moves its own buffer or, in mouse mode, reports the
+// wheel to the TUI.
+//
+// Horizontal stays untouched: a TUI that wants a drag still gets one, and
+// a tap that never clears `slop` is left for focus / selection.
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.SeahelmTouchScroll = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  /**
+   * @param {object} o
+   * @param {(deltaY:number)=>void} o.scroll   wheel convention: + toward live
+   * @param {number} [o.slop=10]               px before the axis locks
+   */
+  function createTouchScroller(o) {
+    const scroll = o.scroll;
+    const slop = o.slop == null ? 10 : o.slop;
+
+    let originX = 0, originY = 0, lastY = 0;
+    let lock = null;          // null | 'vert' | 'horiz'
+    let active = false;
+
+    function reset() {
+      lock = null;
+      active = false;
+    }
+
+    return {
+      start(p) {
+        if (!p || p.touches !== 1) { reset(); return; }
+        originX = p.x; originY = p.y; lastY = p.y;
+        lock = null;
+        active = true;
+      },
+      move(p) {
+        if (!active) return { consume: false };
+        if (!p || p.touches !== 1) { reset(); return { consume: false }; }
+
+        if (!lock) {
+          const dx = p.x - originX;
+          const dy = p.y - originY;
+          if (Math.max(Math.abs(dx), Math.abs(dy)) < slop) return { consume: false };
+          lock = Math.abs(dy) >= Math.abs(dx) ? 'vert' : 'horiz';
+        }
+
+        if (lock === 'vert') {
+          const dy = p.y - lastY;
+          lastY = p.y;
+          if (dy) scroll(-dy);
+          return { consume: true };
+        }
+        lastY = p.y;
+        return { consume: false };
+      },
+      end() { reset(); },
+    };
+  }
+
+  /**
+   * Bind the scroller to a pane host. Returns a detach function.
+   * Dispatches a wheel event onto xterm's viewport (or the host, for
+   * ghostty-web) so mouse-tracking TUIs still see the scroll.
+   */
+  function attach(element, opts) {
+    if (!element) return function () {};
+    const targetOf = (opts && opts.target) || function () {
+      return element.querySelector('.xterm-viewport') || element;
+    };
+    const scroller = createTouchScroller({
+      slop: opts && opts.slop,
+      scroll(deltaY) {
+        const target = targetOf();
+        if (!target || typeof target.dispatchEvent !== 'function') return;
+        target.dispatchEvent(new WheelEvent('wheel', {
+          deltaY,
+          deltaMode: 0,
+          bubbles: true,
+          cancelable: true,
+        }));
+      },
+    });
+
+    function point(e) {
+      const t = e.changedTouches && e.changedTouches[0];
+      if (!t) return null;
+      const n = e.touches ? e.touches.length : 0;
+      return { x: t.pageX, y: t.pageY, touches: n };
+    }
+
+    function onStart(e) {
+      const p = point(e);
+      if (p) scroller.start(p);
+    }
+    function onMove(e) {
+      const p = point(e);
+      if (!p) return;
+      // touchmove reports currently-down fingers in `touches`; a 1→2
+      // transition would otherwise still look like a one-finger move.
+      p.touches = e.touches ? e.touches.length : p.touches;
+      const r = scroller.move(p);
+      if (r && r.consume) e.preventDefault();
+    }
+    function onEnd() { scroller.end(); }
+
+    element.addEventListener('touchstart', onStart, { passive: true });
+    element.addEventListener('touchmove', onMove, { passive: false });
+    element.addEventListener('touchend', onEnd);
+    element.addEventListener('touchcancel', onEnd);
+
+    return function detach() {
+      element.removeEventListener('touchstart', onStart);
+      element.removeEventListener('touchmove', onMove);
+      element.removeEventListener('touchend', onEnd);
+      element.removeEventListener('touchcancel', onEnd);
+    };
+  }
+
+  return { createTouchScroller, attach };
+});

--- a/clients/seahelm-web/vt-apply.js
+++ b/clients/seahelm-web/vt-apply.js
@@ -1,0 +1,80 @@
+// Serialize VT application so a snapshot's reset() cannot land mid-write.
+//
+// Decode (inflate) can overlap; applying cannot. The page used to await the
+// work function but not term.write(), so a later snapshot reset the terminal
+// while the previous chunk was still draining — the TUI cursor then sat off
+// the prompt. writeTerminal turns that callback into the thing the queue waits
+// on.
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.SeahelmVTApply = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  /**
+   * Wait until `term.write` has finished. Empty payloads are a no-op so a
+   * snapshot that is only a resize still fits the font afterwards.
+   *
+   * xterm.js and ghostty-web both take `(data, cb)`. ghostty fires the cb on
+   * the next animation frame; xterm fires it when its parse buffer drains.
+   */
+  function writeTerminal(term, bytes) {
+    return new Promise((resolve, reject) => {
+      if (!bytes || !bytes.length) { resolve(); return; }
+      if (!term || typeof term.write !== 'function') { resolve(); return; }
+      let settled = false;
+      const done = () => { if (!settled) { settled = true; resolve(); } };
+      try {
+        const ret = term.write(bytes, done);
+        if (ret && typeof ret.then === 'function') ret.then(done, reject);
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+
+  /**
+   * @param {object} [o]
+   * @param {number} [o.maxData=8]     drop further vt.data past this in-flight depth
+   * @param {(key:string)=>void} [o.onDrop]
+   * @param {(key:string, err:Error)=>void} [o.onError]
+   */
+  function createApplyQueue(o) {
+    const maxData = o && o.maxData != null ? o.maxData : 8;
+    const onDrop = (o && o.onDrop) || function () {};
+    const onError = (o && o.onError) || function () {};
+    const chains = new Map();
+    const depth = new Map();
+
+    function enqueue(key, type, work) {
+      const d = depth.get(key) || 0;
+      if (type === 'vt.data' && d >= maxData) {
+        onDrop(key);
+        return Promise.resolve();
+      }
+      depth.set(key, d + 1);
+      const prior = chains.get(key) || Promise.resolve();
+      const next = prior.then(async () => {
+        try {
+          await work();
+        } catch (e) {
+          onError(key, e);
+        } finally {
+          depth.set(key, Math.max(0, (depth.get(key) || 1) - 1));
+        }
+      });
+      chains.set(key, next);
+      return next;
+    }
+
+    function release(key) {
+      chains.delete(key);
+      depth.delete(key);
+    }
+
+    return { enqueue, release };
+  }
+
+  return { createApplyQueue, writeTerminal };
+});


### PR DESCRIPTION
## Summary
- Chrome clicks no longer steal the caret from xterm's helper textarea (pane highlight used to stay on while Esc / IME went nowhere). WebGL attach re-focuses the current pane.
- VT frames wait for `term.write` to finish before the next one applies, so a snapshot `reset()` cannot land mid-write and leave a TUI cursor off the prompt.
- One-finger vertical swipes become wheel events so phones can read scrollback; a tap or horizontal drag is left for focus / selection / the TUI.

## Test plan
- [ ] Open the web client, select a pane, click First Mate grouping / a pane chip / 日志 / the shortcut bar, then type — keys should still reach the terminal
- [ ] Pairing-code field still keeps the caret (clicking 配对并连接 must not jump focus to a missing terminal)
- [ ] On a phone, swipe vertically in a pane to move scrollback; a tap still focuses; a horizontal drag still reaches the TUI
- [ ] `cd clients/seahelm-web && node devbroker/vt-apply-test.js && node devbroker/term-focus-test.js && node devbroker/touch-scroll-test.js`


Made with [Cursor](https://cursor.com)