### PR TITLE
fix: close last pane and delete past stale running status

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -2077,7 +2077,10 @@ extension MainWindowController: SplitContainerDelegate {
     }
 
     func splitContainer(_ view: SplitContainerView, didRequestClosePane leafId: String) {
-        closeFocusedPane()
+        // Close the pane that was actually clicked, in its own container —
+        // routing through the active container's focused leaf can hit a
+        // different worktree's pane or nothing at all.
+        terminalCoordinator.closePane(leafId: leafId, in: view)
     }
 
     func splitContainer(_ view: SplitContainerView, didRequestSleepPane leafId: String) {

--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -2734,6 +2734,10 @@ extension MainWindowController: TerminalCoordinatorDelegate {
             }
         }
     }
+
+    func terminalCoordinator(_ coordinator: TerminalCoordinator, didCloseLastPaneInWorktree path: String) {
+        tabCoordinator.worktreeSessionDidEnd(path)
+    }
 }
 
 // MARK: - Bridge Actions

--- a/Sources/App/TabCoordinator.swift
+++ b/Sources/App/TabCoordinator.swift
@@ -1417,6 +1417,17 @@ class TabCoordinator {
         delegate?.tabCoordinatorRequestUpdateTitleBar(self)
     }
 
+    /// The worktree's last pane was closed — its session ended, but the
+    /// worktree stays on disk and in `allWorktrees`. Drop the dead split
+    /// container and repaint the row as session-less. The light counterpart of
+    /// `worktreeDidDelete`, which also removes the row.
+    func worktreeSessionDidEnd(_ path: String) {
+        dashboardVC?.invalidateSplitContainer(forPath: path)
+        dashboardVC?.updatePanes(buildWorktreeRowInfos())
+        statusPublisher.updateSurfaces(terminalCoordinator.stationManager.all)
+        delegate?.tabCoordinatorRequestUpdateTitleBar(self)
+    }
+
     // MARK: - Close Repo
 
     func performCloseRepo(projectName: String) {

--- a/Sources/App/TerminalCoordinator.swift
+++ b/Sources/App/TerminalCoordinator.swift
@@ -353,7 +353,20 @@ class TerminalCoordinator {
     func closeFocusedPane() {
         guard let container = activeSplitContainer(),
               let tree = container.tree else { return }
+        closePane(leafId: tree.focusedId, in: container)
+    }
 
+    /// Close a specific pane in a specific container — the path a pane's own
+    /// context menu takes. Acting on the clicked container and leaf matters:
+    /// the "active" container and its focused leaf can be a different worktree
+    /// (or nothing at all) than the pane the user right-clicked, and a close
+    /// routed there either hits the wrong pane or vanishes silently.
+    func closePane(leafId: String, in container: SplitContainerView) {
+        guard let tree = container.tree,
+              tree.root.findLeaf(id: leafId) != nil else { return }
+        // The close paths below key off the focused leaf; point it at the
+        // pane that was actually clicked first.
+        tree.focusedId = leafId
         switch Self.closePlan(leafCount: tree.leafCount) {
         case .closeLeaf:
             closeFocusedLeaf(container: container, tree: tree)

--- a/Sources/App/TerminalCoordinator.swift
+++ b/Sources/App/TerminalCoordinator.swift
@@ -6,6 +6,11 @@ protocol TerminalCoordinatorDelegate: AnyObject {
     /// A pane and its session are gone. Anything keyed by its terminal id — most
     /// visibly a pending suggestion card — has to go with it.
     func terminalCoordinator(_ coordinator: TerminalCoordinator, didClosePane terminalID: String)
+    /// The worktree's last pane was closed: its session is dead and the tree is
+    /// gone, but the worktree itself stays on disk and in the fleet. The
+    /// dashboard must detach the dead split container and repaint the row as
+    /// session-less.
+    func terminalCoordinator(_ coordinator: TerminalCoordinator, didCloseLastPaneInWorktree path: String)
 }
 
 class TerminalCoordinator {
@@ -331,10 +336,81 @@ class TerminalCoordinator {
         }
     }
 
+    /// What a close request means for the tree as it stands: drop one leaf, or —
+    /// when the focused leaf is the tree's only leaf — end the worktree's whole
+    /// session. Pure so the policy is testable without stations or a window; the
+    /// last-leaf case kills a live zmx session, which is why it also gets the
+    /// confirmation in `closeFocusedPane`.
+    enum ClosePlan {
+        case closeLeaf
+        case closeLastLeaf
+    }
+
+    static func closePlan(leafCount: Int) -> ClosePlan {
+        leafCount > 1 ? .closeLeaf : .closeLastLeaf
+    }
+
     func closeFocusedPane() {
         guard let container = activeSplitContainer(),
               let tree = container.tree else { return }
 
+        switch Self.closePlan(leafCount: tree.leafCount) {
+        case .closeLeaf:
+            closeFocusedLeaf(container: container, tree: tree)
+        case .closeLastLeaf:
+            confirmCloseLastPane(container: container, tree: tree)
+        }
+    }
+
+    /// Closing the tree's only pane ends the worktree's terminal session — the
+    /// zmx session is killed, and with it whatever the shell is still running —
+    /// so it asks first. The worktree on disk is untouched.
+    private func confirmCloseLastPane(container: SplitContainerView, tree: SplitTree) {
+        let name = URL(fileURLWithPath: tree.worktreePath).lastPathComponent
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Close the session in \u{201C}\(name)\u{201D}?"
+        alert.informativeText = "This is the worktree's last pane. Its terminal session will be ended and anything still running in that shell will be terminated. The worktree itself stays on disk."
+        alert.addButton(withTitle: "Close Session")
+        alert.addButton(withTitle: "Cancel")
+        alert.buttons[0].hasDestructiveAction = true
+
+        let handle: (NSApplication.ModalResponse) -> Void = { [weak self, weak container] response in
+            guard response == .alertFirstButtonReturn, let container else { return }
+            self?.closeLastPane(container: container, tree: tree)
+        }
+        if let window = container.window {
+            alert.beginSheetModal(for: window, completionHandler: handle)
+        } else {
+            handle(alert.runModal())
+        }
+    }
+
+    /// Tear down a worktree's session once its last pane is closed: kill the zmx
+    /// session, drop the tree, and forget the saved layout so a later click on
+    /// the fleet row starts a fresh session instead of restoring a dead pane.
+    /// The mirror of `finalizeDeletedWorktree`, minus the git deletion.
+    private func closeLastPane(container: SplitContainerView, tree: SplitTree) {
+        guard let leaf = tree.allLeaves.first else { return }
+        let worktreePath = tree.worktreePath
+
+        SessionManager.killSession(leaf.paneSessionKey, backend: runtimeBackend)
+        config.agentSessions.removeValue(forKey: leaf.paneSessionKey)
+        AgentRegistry.shared.unregister(terminalID: leaf.stationId)
+        delegate?.terminalCoordinator(self, didClosePane: leaf.stationId)
+
+        config.splitLayouts.removeValue(forKey: worktreePath)
+        config.focusedPaneIds.removeValue(forKey: worktreePath)
+        config.save()
+
+        // removeTree destroys the station and unregisters it; the delegate then
+        // detaches the (now empty) container from the dashboard.
+        stationManager.removeTree(forPath: worktreePath)
+        delegate?.terminalCoordinatorDidUpdateSurfaces(self)
+        delegate?.terminalCoordinator(self, didCloseLastPaneInWorktree: worktreePath)
+    }
+
+    private func closeFocusedLeaf(container: SplitContainerView, tree: SplitTree) {
         guard let closed = tree.closeFocusedLeaf() else { return }
 
         // Kill zmx session
@@ -554,18 +630,30 @@ class TerminalCoordinator {
     /// that can take seconds) or the delete itself is in flight — without it
     /// the click reads as a no-op until a sheet finally appears.
     func confirmAndDeleteWorktree(_ info: WorktreeInfo, window: NSWindow?,
+                                  forcePastRunningGuard: Bool = false,
                                   onPendingChange: ((Bool) -> Void)? = nil) {
         guard !info.isMainWorktree else { return }
         guard let window else { return }
         // Same rule as `/return`: a worktree with an agent at work is not
         // pulled out from under it. Close the pane first if that is meant.
-        if AgentRegistry.shared.hasRunningPane(inWorktree: info.path) {
+        // The status pipeline can hold a stale `.running` for a pane whose
+        // agent already exited (its last TUI frame still matches a running
+        // rule), so the warning offers a way through: Delete Anyway skips only
+        // this guard — the dirty-worktree assessment still applies.
+        if !forcePastRunningGuard, AgentRegistry.shared.hasRunningPane(inWorktree: info.path) {
             let alert = NSAlert()
             alert.alertStyle = .warning
             alert.messageText = "\u{201C}\(info.displayName)\u{201D} has an agent running"
-            alert.informativeText = "Wait for it to finish, or close its pane, then delete the worktree."
+            alert.informativeText = "Wait for it to finish, or close its pane, then delete the worktree. If the agent has already exited, its status may be stale — Delete Anyway removes the worktree regardless. Uncommitted changes and unpublished commits still get a confirmation next."
             alert.addButton(withTitle: "OK")
-            alert.beginSheetModal(for: window)
+            alert.addButton(withTitle: "Delete Anyway")
+            alert.buttons[1].hasDestructiveAction = true
+            alert.beginSheetModal(for: window) { [weak self] response in
+                guard let self, response == .alertSecondButtonReturn else { return }
+                self.confirmAndDeleteWorktree(info, window: window,
+                                              forcePastRunningGuard: true,
+                                              onPendingChange: onPendingChange)
+            }
             return
         }
 
@@ -644,8 +732,14 @@ class TerminalCoordinator {
             // force-remove so git doesn't refuse on a dirty worktree.
             let shouldForce = force || WorktreeDeleter.hasUncommittedChanges(worktreePath: path)
             DispatchQueue.main.async {
-                self?.performDeleteWorktree(info, repoPath: repoPath,
-                                            deleteBranch: deleteBranch, force: shouldForce) {
+                // Clear the pending flag even if the coordinator is gone —
+                // a stuck one disables the fleet row's Delete item for good.
+                guard let self else {
+                    onPendingChange?(false)
+                    return
+                }
+                self.performDeleteWorktree(info, repoPath: repoPath,
+                                           deleteBranch: deleteBranch, force: shouldForce) {
                     onPendingChange?(false)
                 }
             }

--- a/Tests/TerminalCoordinatorTests.swift
+++ b/Tests/TerminalCoordinatorTests.swift
@@ -127,4 +127,16 @@ final class TerminalCoordinatorTests: XCTestCase {
             idleAfter: 600, now: t0.addingTimeInterval(10))
         XCTAssertNil(plan.offscreenSince["gone"], "ids that no longer exist must not accumulate")
     }
+
+    // MARK: - Close policy
+
+    func testClosePlanEndsTheSessionWhenOneLeafRemains() {
+        XCTAssertEqual(TerminalCoordinator.closePlan(leafCount: 1), .closeLastLeaf,
+                       "the last pane carries the worktree's whole session with it")
+    }
+
+    func testClosePlanDropsOneLeafWhenOthersRemain() {
+        XCTAssertEqual(TerminalCoordinator.closePlan(leafCount: 2), .closeLeaf)
+        XCTAssertEqual(TerminalCoordinator.closePlan(leafCount: 5), .closeLeaf)
+    }
 }


### PR DESCRIPTION
Closes #122.

## What changed (user-visible)

- **Close Pane now works on a worktree's last pane.** It asks first — "Close the session in X? This is the worktree's last pane. Its terminal session will be ended…" — then kills the zmx session and tears down the tree. The worktree stays on disk; its fleet row reverts to the no-live-session state, and clicking it later starts a fresh session. Previously this was a silent no-op (`SplitTree.removeLeaf` refuses the last leaf), so spent sessions could never be dismissed.
- **Delete offers an escape hatch when "agent running" misfires.** The warning sheet gains a **Delete Anyway** button for the case where the agent has exited but its status is stale `.running`. It skips only that guard — the dirty-worktree/unpublished-commits assessment and its confirmation sheet still apply.
- Fixes a stuck `pending` flag in `deleteWorktreeWithoutConfirm` that could permanently disable a fleet row's Delete item.

## Notes for review

- `SplitTree.removeLeaf`'s last-leaf invariant is unchanged (pane moves/adoption rely on it); the policy lives in `TerminalCoordinator` as a pure, tested `closePlan(leafCount:)`.
- Status detection (`AgentRegistry`/`StatusDetector`) is deliberately untouched — the escape hatch covers the misfire without changing detection semantics.
- New delegate hook `terminalCoordinator(_:didCloseLastPaneInWorktree:)` → `TabCoordinator.worktreeSessionDidEnd` detaches the dead split container and repaints the row (mirrors `worktreeDidDelete`, minus row removal).

## Validation

- New unit tests for `closePlan` in `Tests/TerminalCoordinatorTests.swift`.
- Full unit suite: 1997 tests, 0 failures. (UI test runner would not initialize in my shell — "timed out while enabling automation mode" — so UITests were not run; no UITest covers Close Pane.)
- Manual on a live setup: Close Pane on a spent single-pane session → confirmation → session gone from `zmx list`, row goes session-less. Delete on a row blocked by stale status → Delete Anyway proceeds through the normal assessment.
