### PR TITLE
fix: dedupe repeated Telegram question cards

### DIFF
--- a/Sources/App/MainWindowController.swift
+++ b/Sources/App/MainWindowController.swift
@@ -3188,7 +3188,8 @@ extension MainWindowController {
         for chatId in chats {
             AgentRegistry.shared.pushToChannel("telegram", message: OutboundMessage(
                 channelId: "telegram", targetChatId: chatId, content: text,
-                format: .markdown, buttons: buttons)
+                format: .markdown, buttons: buttons,
+                packetKey: Self.questionCardPacketKey(order))
             ) { [weak self] messageId in
                 guard let messageId else { return }
                 DispatchQueue.main.async {
@@ -3197,6 +3198,15 @@ extension MainWindowController {
                 }
             }
         }
+    }
+
+    /// Stable across a queue flicker. It deliberately names the card contents,
+    /// not a transient event sequence, so rediscovering the same approval is
+    /// the same Telegram packet.
+    static func questionCardPacketKey(_ order: PendingOrder) -> String {
+        let action = order.action
+        return [order.id, action.message, (action.options ?? []).joined(separator: "\u{1E}")]
+            .joined(separator: "\u{1F}")
     }
 
 

--- a/Sources/Core/ExternalChannel.swift
+++ b/Sources/Core/ExternalChannel.swift
@@ -47,6 +47,10 @@ struct OutboundMessage {
     let replyToMessageId: String?
     let streaming: Bool
     let streamId: String?
+    /// An optional logical packet id. Channels may coalesce duplicate sends of
+    /// the same packet without suppressing ordinary messages that happen to
+    /// have identical text.
+    let packetKey: String?
     /// Drawn under the message by channels that can. Always a shortcut for
     /// something the text says how to type, so dropping them costs nothing.
     let buttons: [MessageButton]
@@ -55,6 +59,15 @@ struct OutboundMessage {
          content: String, format: MessageFormat = .text,
          replyToMessageId: String? = nil, streaming: Bool = false, streamId: String? = nil,
          buttons: [MessageButton] = []) {
+        self.init(channelId: channelId, targetChatId: targetChatId, targetUserId: targetUserId,
+                  content: content, format: format, replyToMessageId: replyToMessageId,
+                  streaming: streaming, streamId: streamId, buttons: buttons, packetKey: nil)
+    }
+
+    init(channelId: String, targetChatId: String? = nil, targetUserId: String? = nil,
+         content: String, format: MessageFormat = .text,
+         replyToMessageId: String? = nil, streaming: Bool = false, streamId: String? = nil,
+         buttons: [MessageButton] = [], packetKey: String?) {
         self.channelId = channelId
         self.targetChatId = targetChatId
         self.targetUserId = targetUserId
@@ -64,6 +77,7 @@ struct OutboundMessage {
         self.streaming = streaming
         self.streamId = streamId
         self.buttons = buttons
+        self.packetKey = packetKey
     }
 }
 

--- a/Sources/Core/PendingOrdersQueue.swift
+++ b/Sources/Core/PendingOrdersQueue.swift
@@ -26,13 +26,35 @@ struct SuggestionSeenSet {
     }
 
     private var seen: [String: Fingerprint] = [:]
+    /// A viewport can miss an approval dialog for a frame while it is still
+    /// blocking the agent. Do not turn that brief absence into a brand-new
+    /// card on the next frame: the island would re-open and Telegram would
+    /// send another full question card. Real new cards still win immediately
+    /// when their contents differ.
+    private var recentlyAbsent: [String: (fingerprint: Fingerprint, at: Date)] = [:]
+    static let reappearanceGrace: TimeInterval = 60 * 60
 
     /// Record `orders` as the full set now on offer and return the ones this
     /// surface has not shown yet. Cards that left the queue are forgotten, so a
     /// re-raised card counts as new again.
-    mutating func absorb(_ orders: [PendingOrder]) -> [PendingOrder] {
-        let fresh = orders.filter { Self.isFresh($0, seen: seen[$0.id]) }
+    mutating func absorb(_ orders: [PendingOrder], now: Date = Date()) -> [PendingOrder] {
+        let incomingIDs = Set(orders.map(\.id))
+        for (id, fingerprint) in seen where !incomingIDs.contains(id) {
+            recentlyAbsent[id] = (fingerprint, now)
+        }
+        recentlyAbsent = recentlyAbsent.filter { _, absent in
+            now.timeIntervalSince(absent.at) < Self.reappearanceGrace
+        }
+
+        let fresh = orders.filter { order in
+            if let current = seen[order.id] {
+                return Self.isFresh(order, seen: current)
+            }
+            guard let absent = recentlyAbsent[order.id] else { return true }
+            return Self.isFresh(order, seen: absent.fingerprint)
+        }
         seen = Dictionary(orders.map { ($0.id, Fingerprint($0)) }, uniquingKeysWith: { _, last in last })
+        for id in incomingIDs { recentlyAbsent[id] = nil }
         return fresh
     }
 

--- a/Sources/Core/TelegramChannel.swift
+++ b/Sources/Core/TelegramChannel.swift
@@ -29,6 +29,7 @@ final class TelegramChannel: ExternalChannel {
     private var generation = 0
     private let lock = NSLock()
     private let sendQueue = DispatchQueue(label: "com.seahelm.telegram.send", qos: .utility)
+    private let packets = TelegramPacketBook()
     /// Lets `disconnect` cut a retry backoff short instead of waiting it out.
     private let wake = DispatchSemaphore(value: 0)
 
@@ -149,6 +150,19 @@ final class TelegramChannel: ExternalChannel {
             return
         }
 
+        let packetKey = message.packetKey.map { "\(target)\u{1F}\($0)" }
+        if let packetKey {
+            switch packets.begin(key: packetKey, completion: completion) {
+            case .send:
+                break
+            case .joined:
+                return
+            case .delivered(let id):
+                completion?(id)
+                return
+            }
+        }
+
         let parseMode: String? = message.format == .text ? nil : "HTML"
         let rendered = parseMode == nil ? message.content : TelegramFormatter.html(from: message.content)
 
@@ -171,12 +185,15 @@ final class TelegramChannel: ExternalChannel {
                     // with nothing to mark the cut reads as the agent having
                     // said only that much.
                     NSLog("[Telegram] Gave up with \(chunks.count - index) of \(chunks.count) chunk(s) unsent")
-                    completion?(nil)
+                    if let packetKey { self.packets.finish(key: packetKey, messageID: nil) }
+                    else { completion?(nil) }
                     return
                 }
                 lastId = id
             }
-            completion?(lastId.map(String.init))
+            let id = lastId.map(String.init)
+            if let packetKey { self.packets.finish(key: packetKey, messageID: id) }
+            else { completion?(id) }
         }
     }
 

--- a/Sources/Core/TelegramPacketBook.swift
+++ b/Sources/Core/TelegramPacketBook.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Coalesces duplicate logical Telegram sends. A card can be rediscovered by
+/// several status sources before the first HTTP request comes back; that must
+/// remain one Telegram message, not a queue of identical cards.
+final class TelegramPacketBook {
+    enum Decision: Equatable {
+        case send
+        case joined
+        case delivered(String?)
+    }
+
+    private struct Delivered {
+        let messageID: String?
+        let at: Date
+    }
+
+    private var inFlight: [String: [(String?) -> Void]] = [:]
+    private var delivered: [String: Delivered] = [:]
+    private let lock = NSLock()
+    static let retention: TimeInterval = 60 * 60
+
+    func begin(key: String, completion: ((String?) -> Void)?, now: Date = Date()) -> Decision {
+        lock.lock()
+        defer { lock.unlock() }
+        delivered = delivered.filter { now.timeIntervalSince($0.value.at) < Self.retention }
+        if let prior = delivered[key] {
+            return .delivered(prior.messageID)
+        }
+        if inFlight[key] != nil {
+            if let completion { inFlight[key, default: []].append(completion) }
+            return .joined
+        }
+        inFlight[key] = completion.map { [$0] } ?? []
+        return .send
+    }
+
+    func finish(key: String, messageID: String?, now: Date = Date()) {
+        lock.lock()
+        let completions = inFlight.removeValue(forKey: key) ?? []
+        // A failed packet should be allowed to try again on the next real
+        // event; only a message Telegram accepted earns the retention entry.
+        if messageID != nil { delivered[key] = Delivered(messageID: messageID, at: now) }
+        lock.unlock()
+        completions.forEach { $0(messageID) }
+    }
+}

--- a/Tests/SuggestionSeenSetTests.swift
+++ b/Tests/SuggestionSeenSetTests.swift
@@ -49,12 +49,22 @@ final class SuggestionSeenSetTests: XCTestCase {
         XCTAssertTrue(seen.absorb([upgraded]).isEmpty)
     }
 
-    func testResolvedCardIsFreshWhenRaisedAgain() {
+    func testBrieflyVanishedCardDoesNotReopen() {
         var seen = SuggestionSeenSet()
         let card = order(message: "shipped", options: ["test", "commit"])
-        _ = seen.absorb([card])
-        _ = seen.absorb([])
-        XCTAssertEqual(seen.absorb([card]).count, 1)
+        let now = Date()
+        _ = seen.absorb([card], now: now)
+        _ = seen.absorb([], now: now.addingTimeInterval(1))
+        XCTAssertTrue(seen.absorb([card], now: now.addingTimeInterval(2)).isEmpty)
+    }
+
+    func testLongGoneCardCanBeRaisedAgain() {
+        var seen = SuggestionSeenSet()
+        let card = order(message: "shipped", options: ["test", "commit"])
+        let now = Date()
+        _ = seen.absorb([card], now: now)
+        _ = seen.absorb([], now: now.addingTimeInterval(1))
+        XCTAssertEqual(seen.absorb([card], now: now.addingTimeInterval(SuggestionSeenSet.reappearanceGrace + 2)).count, 1)
     }
 
     func testFreshEntriesAreReturnedNotJustCounted() {

--- a/Tests/TelegramPacketBookTests.swift
+++ b/Tests/TelegramPacketBookTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import seahelm
+
+final class TelegramPacketBookTests: XCTestCase {
+    func testInFlightDuplicatesJoinOnePacket() {
+        let book = TelegramPacketBook()
+        var first: String?
+        var second: String?
+        XCTAssertEqual(book.begin(key: "chat|card", completion: { first = $0 }), .send)
+        XCTAssertEqual(book.begin(key: "chat|card", completion: { second = $0 }), .joined)
+
+        book.finish(key: "chat|card", messageID: "42")
+
+        XCTAssertEqual(first, "42")
+        XCTAssertEqual(second, "42")
+    }
+
+    func testDeliveredPacketIsNotSentAgain() {
+        let book = TelegramPacketBook()
+        XCTAssertEqual(book.begin(key: "chat|card", completion: nil), .send)
+        book.finish(key: "chat|card", messageID: "42")
+
+        XCTAssertEqual(book.begin(key: "chat|card", completion: nil), .delivered("42"))
+    }
+
+    func testFailedPacketMayTryAgain() {
+        let book = TelegramPacketBook()
+        XCTAssertEqual(book.begin(key: "chat|card", completion: nil), .send)
+        book.finish(key: "chat|card", messageID: nil)
+
+        XCTAssertEqual(book.begin(key: "chat|card", completion: nil), .send)
+    }
+}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		02D9F0D1B7092AAE247A22A1 /* WorktreeDiscoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22DBAC51DE05D73135AD2889 /* WorktreeDiscoveryTests.swift */; };
 		0302EB911AF4960365D33FB1 /* HostGatewaySession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7842E00A1A18C4FAD50AF0ED /* HostGatewaySession.swift */; };
 		0334F26D1F43B1A6530D2D6A /* GrowingTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FB76BDD5A8BB0E59DA78D13 /* GrowingTextView.swift */; };
+		0624E489B118EC8FAD59FEB1 /* TelegramPacketBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D293FA0847660A497A11838 /* TelegramPacketBook.swift */; };
 		0658FAE09BDFAD7932B01617 /* TerminalCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D82D53B83B8C48E71D9E57 /* TerminalCoordinator.swift */; };
 		069BA91DFCD8158F008EDDFA /* MailHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFBF763CE6B932E7040E0DF7 /* MailHTMLTests.swift */; };
 		06CF922E9ABD675BEC1F7502 /* SidebarHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC6CEDF0BAE28FF326D89F9 /* SidebarHeaderView.swift */; };
@@ -473,6 +474,7 @@
 		F446418FE70E2E34614F9CEA /* HookDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D716EF8AB2E7C89A0D9DBEB /* HookDecoder.swift */; };
 		F609F16851D769F1513883D2 /* zmx-attach.py in Resources */ = {isa = PBXBuildFile; fileRef = 091FF7815D565EA0D1CD27E4 /* zmx-attach.py */; };
 		F62D784C6BDA373D99051F3A /* MailBodyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B463225AE9F973C259F06772 /* MailBodyTests.swift */; };
+		F72F97A5DE0B316E3B90BDB5 /* TelegramPacketBookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803B8F8E6947C76080BAE3C2 /* TelegramPacketBookTests.swift */; };
 		F7AE5D618DD874989BE4F93C /* SemanticColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15A95E0337AEDBCE9546B8F /* SemanticColors.swift */; };
 		F822A1F30137CB7940F82296 /* PRListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF331BF96A89F1DC3E9C1BD /* PRListView.swift */; };
 		F88018C1DE074B7B23AABDA3 /* SplitPaneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D06307CBEFF44025C8E9AD3 /* SplitPaneTests.swift */; };
@@ -750,6 +752,7 @@
 		7F2C37E0232BF78E7DCFAAC4 /* WorktreeDeleter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDeleter.swift; sourceTree = "<group>"; };
 		7F4985A21CB0E9D8B4708E26 /* AgentRegistryWebhookPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryWebhookPathTests.swift; sourceTree = "<group>"; };
 		7FB76BDD5A8BB0E59DA78D13 /* GrowingTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrowingTextView.swift; sourceTree = "<group>"; };
+		803B8F8E6947C76080BAE3C2 /* TelegramPacketBookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelegramPacketBookTests.swift; sourceTree = "<group>"; };
 		8106508B943DF9C7053C6A11 /* GmailOAuthCallbackPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GmailOAuthCallbackPage.swift; sourceTree = "<group>"; };
 		810968D6A752BC9C5B9C5F27 /* WorktreeDeleterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeDeleterTests.swift; sourceTree = "<group>"; };
 		811DF1463E1F5D6EFC56F68A /* IntegrationStatusStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationStatusStore.swift; sourceTree = "<group>"; };
@@ -797,6 +800,7 @@
 		99EAA5845DC0E1B3FD6DD1E8 /* CodexUsageSummaryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageSummaryProviderTests.swift; sourceTree = "<group>"; };
 		9A9E6A0A2CF3F54AA987F20A /* OSC133Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSC133Parser.swift; sourceTree = "<group>"; };
 		9B96BFA805FFD64725FFB924 /* NotificationHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHistory.swift; sourceTree = "<group>"; };
+		9D293FA0847660A497A11838 /* TelegramPacketBook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelegramPacketBook.swift; sourceTree = "<group>"; };
 		9D89A6016405AEDB17C3FB5E /* QRCodeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeRenderer.swift; sourceTree = "<group>"; };
 		9DA8AD6F8AC7CDE47F86245A /* WorktreeReturnRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeReturnRunnerTests.swift; sourceTree = "<group>"; };
 		9DFC7C439D7D5CB85100DB4D /* SettingsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPage.swift; sourceTree = "<group>"; };
@@ -1142,6 +1146,7 @@
 				371F0BC6C00D849566000118 /* TelegramChannel.swift */,
 				A78FEF7EF31BF2E3DD44AD5F /* TelegramConfig.swift */,
 				367C0A6616137695AEDA9D74 /* TelegramFormatter.swift */,
+				9D293FA0847660A497A11838 /* TelegramPacketBook.swift */,
 				40B24B841AC2BEE7F645B456 /* TelegramPairing.swift */,
 				AFC635E261560E69EFA29FEE /* TelegramRule.swift */,
 				5C8C29ABAFC62F8A953F2CD9 /* TelegramRuleCoalescer.swift */,
@@ -1585,6 +1590,7 @@
 				DC183C3A20588D380EF62682 /* TabSelectionTests.swift */,
 				249CA31487C12997605E1512 /* TaskProgressParserTests.swift */,
 				59CF8253BD7CAF318D05885C /* TelegramBridgeTests.swift */,
+				803B8F8E6947C76080BAE3C2 /* TelegramPacketBookTests.swift */,
 				89AF451E1FC9B6E21F9B67A6 /* TelegramPairingTests.swift */,
 				D2A3B9CBE08762DDD19AA2C5 /* TelegramRuleCoalescerTests.swift */,
 				A8152F9618985364E35ACB50 /* TelegramRuleTargetTests.swift */,
@@ -2150,6 +2156,7 @@
 				65BBAC7799C70383810BFEE3 /* TabSelectionTests.swift in Sources */,
 				B658CA193508F17D6F6BA66D /* TaskProgressParserTests.swift in Sources */,
 				0202D5F27E405DFF0764DBA3 /* TelegramBridgeTests.swift in Sources */,
+				F72F97A5DE0B316E3B90BDB5 /* TelegramPacketBookTests.swift in Sources */,
 				9095B660E7047E1815E67212 /* TelegramPairingTests.swift in Sources */,
 				A30993302260CC1F5B1F7179 /* TelegramRuleCoalescerTests.swift in Sources */,
 				33FD30DC361BCDE94308706C /* TelegramRuleTargetTests.swift in Sources */,
@@ -2436,6 +2443,7 @@
 				FC2829917F91412C222E569F /* TelegramChannel.swift in Sources */,
 				0ACBFB116D839F9A3BC9DD7C /* TelegramConfig.swift in Sources */,
 				B27CC6F1E02F01BDF914C664 /* TelegramFormatter.swift in Sources */,
+				0624E489B118EC8FAD59FEB1 /* TelegramPacketBook.swift in Sources */,
 				75D489DADDF9A46F3AA3F96D /* TelegramPairing.swift in Sources */,
 				BBC84EA31C8C52BCB30F54B1 /* TelegramRule.swift in Sources */,
 				18BBDCD41186F44EFEBC6950 /* TelegramRuleCoalescer.swift in Sources */,


### PR DESCRIPTION
## Summary\n- suppress same approval card reappearing within a one-hour grace window\n- coalesce concurrent/repeated Telegram card deliveries by packet key\n- retain retries when a Telegram delivery fails\n\n## Validation\n- swiftc -parse changed source and tests\n- xcodebuild focused tests: SuggestionSeenSetTests, TelegramPacketBookTests, ChatQuestionCardTests (15 passed)\n- git diff --check\n\nThe unrelated local change in Sources/Core/StopHookResponder.swift is intentionally excluded.