### PR TITLE
fix: prevent pane session name collisions

### DIFF
--- a/Sources/Core/Config.swift
+++ b/Sources/Core/Config.swift
@@ -247,7 +247,9 @@ struct Config: Codable {
         }
         do {
             let data = try Data(contentsOf: configPath)
-            return try JSONDecoder().decode(Config.self, from: data)
+            var config = try JSONDecoder().decode(Config.self, from: data)
+            if config.migrateCollidingPaneSessions() { config.save() }
+            return config
         } catch {
             NSLog("Failed to load config: \(error)")
             // A corrupt/undecodable config is NOT a fresh install — falling back
@@ -256,6 +258,41 @@ struct Config: Codable {
             fallback.onboardingCompleted = true
             return fallback
         }
+    }
+
+    /// Older split panes used `<base>-N`. That can equal another worktree's
+    /// base name when its directory ends in `-N`, making both cards attach the
+    /// same zmx session. Keep the true base owner on its existing session and
+    /// move only the colliding extra pane to the collision-proof `--pane-N`
+    /// namespace. Non-colliding legacy panes are deliberately left untouched.
+    @discardableResult
+    mutating func migrateCollidingPaneSessions() -> Bool {
+        var pathsByKey: [String: Set<String>] = [:]
+        for (path, layout) in splitLayouts {
+            for key in layout.paneSessionKeys where !key.isEmpty {
+                pathsByKey[key, default: []].insert(path)
+            }
+        }
+        var claimed = Set(pathsByKey.keys)
+        var changed = false
+        for (key, paths) in pathsByKey where paths.count > 1 {
+            guard let owner = paths.first(where: { SessionManager.persistentSessionName(for: $0) == key }) else {
+                continue
+            }
+            for path in paths where path != owner {
+                let base = SessionManager.persistentSessionName(for: path)
+                var index = 1
+                var replacement = SessionManager.indexedSessionName(base: base, index: index)
+                while claimed.contains(replacement) {
+                    index += 1
+                    replacement = SessionManager.indexedSessionName(base: base, index: index)
+                }
+                splitLayouts[path] = splitLayouts[path]?.replacingPaneSessionKeys([key: replacement])
+                claimed.insert(replacement)
+                changed = true
+            }
+        }
+        return changed
     }
 
     private static let saveQueue = DispatchQueue(label: "com.seahelm.config-save", qos: .utility)

--- a/Sources/Core/SessionManager.swift
+++ b/Sources/Core/SessionManager.swift
@@ -60,7 +60,7 @@ enum SessionManager {
 
     /// Generate an indexed session name for an additional pane.
     static func indexedSessionName(base: String, index: Int) -> String {
-        "\(base)-\(index)"
+        "\(base)--pane-\(index)"
     }
 
     static func parseZmxSessionNames(listOutput: String) -> [String] {

--- a/Sources/Core/StationManager.swift
+++ b/Sources/Core/StationManager.swift
@@ -51,7 +51,7 @@ class StationManager {
     /// does: the pane that moved away kept that exact name — zmx has no rename —
     /// so the replacement would attach to the live session the departed agent is
     /// still running in, and both panes would drive the same terminal. Claims the
-    /// first free `<base>`, `<base>-2`, `<base>-3` … instead.
+    /// first free `<base>`, `<base>--pane-1`, `<base>--pane-2` … instead.
     func replacementTree(for info: WorktreeInfo, backend: String) -> SplitTree {
         if let existing = trees[info.path] { return existing }
 
@@ -60,9 +60,9 @@ class StationManager {
             let base = SessionManager.persistentSessionName(for: info.path)
             let taken = claimedSessionNames
             paneSessionKey = base
-            var index = 2
+            var index = 1
             while taken.contains(paneSessionKey) {
-                paneSessionKey = "\(base)-\(index)"
+                paneSessionKey = SessionManager.indexedSessionName(base: base, index: index)
                 index += 1
             }
         }

--- a/Sources/Terminal/SplitNode.swift
+++ b/Sources/Terminal/SplitNode.swift
@@ -53,8 +53,9 @@ indirect enum SplitNode {
             if name == baseName {
                 continue
             }
-            if name.hasPrefix(baseName + "-"),
-               let suffix = Int(name.dropFirst(baseName.count + 1)) {
+            let panePrefix = baseName + "--pane-"
+            if name.hasPrefix(panePrefix),
+               let suffix = Int(name.dropFirst(panePrefix.count)) {
                 maxIndex = max(maxIndex, suffix)
             }
         }
@@ -205,6 +206,24 @@ indirect enum CodableSplitNode: Codable {
 }
 
 extension CodableSplitNode {
+    var paneSessionKeys: [String] {
+        switch self {
+        case .leaf(let key, _): return [key]
+        case .split(_, _, let first, let second): return first.paneSessionKeys + second.paneSessionKeys
+        }
+    }
+
+    func replacingPaneSessionKeys(_ replacements: [String: String]) -> CodableSplitNode {
+        switch self {
+        case .leaf(let key, let title):
+            return .leaf(paneSessionKey: replacements[key] ?? key, title: title)
+        case .split(let axis, let ratio, let first, let second):
+            return .split(axis: axis, ratio: ratio,
+                          first: first.replacingPaneSessionKeys(replacements),
+                          second: second.replacingPaneSessionKeys(replacements))
+        }
+    }
+
     /// Wire shape for remote clients mirroring this window's layout.
     ///
     /// Leaves carry `pane_session_key` — the same key `pane.vt_open` takes — so a

--- a/Sources/Terminal/SplitTree.swift
+++ b/Sources/Terminal/SplitTree.swift
@@ -25,7 +25,7 @@ class SplitTree {
 
     func nextSessionName() -> String {
         let index = root.nextPaneIndex(baseName: baseSessionName)
-        return "\(baseSessionName)-\(index)"
+        return SessionManager.indexedSessionName(base: baseSessionName, index: index)
     }
 
     /// Split the focused leaf. Returns the new leaf id and the id of the split

--- a/Tests/SessionManagerTests.swift
+++ b/Tests/SessionManagerTests.swift
@@ -42,6 +42,13 @@ class SessionManagerTests: XCTestCase {
         XCTAssertNotEqual(a, b)
     }
 
+    func testIndexedPaneNameCannotEqualAnotherWorktreeBaseName() {
+        let base = SessionManager.persistentSessionName(for: "/workspace/task/https-github-com-dif")
+        let otherBase = SessionManager.persistentSessionName(for: "/workspace/task/https-github-com-dif-2")
+        XCTAssertEqual(SessionManager.indexedSessionName(base: base, index: 1), "\(base)--pane-1")
+        XCTAssertNotEqual(SessionManager.indexedSessionName(base: base, index: 1), otherBase)
+    }
+
     func testParseZmxSessionNamesReadsNameEqualsFormat() {
         let output = """
         name=seahelm-repo-main pid=123 cwd=/tmp/repo

--- a/Tests/SplitNodeTests.swift
+++ b/Tests/SplitNodeTests.swift
@@ -134,9 +134,9 @@ final class SplitTreeTests: XCTestCase {
 
     func testNextSessionName() {
         let tree = SplitTree(worktreePath: "/repo/main", rootLeafId: "a", stationId: "s1", paneSessionKey: "seahelm-repo-main")
-        XCTAssertEqual(tree.nextSessionName(), "seahelm-repo-main-1")
-        _ = tree.splitFocusedLeaf(axis: .horizontal, newLeafId: "b", newStationId: "s2", newSessionName: "seahelm-repo-main-1")
-        XCTAssertEqual(tree.nextSessionName(), "seahelm-repo-main-2")
+        XCTAssertEqual(tree.nextSessionName(), "seahelm-repo-main--pane-1")
+        _ = tree.splitFocusedLeaf(axis: .horizontal, newLeafId: "b", newStationId: "s2", newSessionName: "seahelm-repo-main--pane-1")
+        XCTAssertEqual(tree.nextSessionName(), "seahelm-repo-main--pane-2")
     }
 
     func testAllSurfaceIds() {

--- a/Tests/TerminalCoordinatorTests.swift
+++ b/Tests/TerminalCoordinatorTests.swift
@@ -15,6 +15,24 @@ final class TerminalCoordinatorTests: XCTestCase {
         XCTAssertNotNil(coordinator.config.splitLayouts["/tmp/test"])
     }
 
+    func testMigratesAnExtraPaneThatCollidesWithAnotherWorktreeBase() {
+        let first = "/workspace/task/https-github-com-dif"
+        let second = "/workspace/task/https-github-com-dif-2"
+        let firstBase = SessionManager.persistentSessionName(for: first)
+        let secondBase = SessionManager.persistentSessionName(for: second)
+        var config = Config()
+        config.splitLayouts = [
+            first: .split(axis: "horizontal", ratio: 0.5,
+                          first: .leaf(paneSessionKey: firstBase, title: nil),
+                          second: .leaf(paneSessionKey: secondBase, title: nil)),
+            second: .leaf(paneSessionKey: secondBase, title: nil),
+        ]
+
+        XCTAssertTrue(config.migrateCollidingPaneSessions())
+        XCTAssertEqual(config.splitLayouts[second]?.paneSessionKeys, [secondBase])
+        XCTAssertEqual(config.splitLayouts[first]?.paneSessionKeys, [firstBase, "\(firstBase)--pane-1"])
+    }
+
     func testSplitFocusedPaneWithNilRepoVCIsNoop() {
         let coordinator = TerminalCoordinator(config: Config(), activeSplitContainer: { nil })
         // Should not crash when no repoVC


### PR DESCRIPTION
## Summary
- use a dedicated double-dash pane-N namespace for additional and replacement pane sessions
- migrate only persisted session keys shared by multiple worktrees
- preserve the base session for its owning worktree and separate the conflicting pane

## Validation
- focused SessionManager, SplitNode, TerminalCoordinator, and Config tests
- Debug app rebuild and startup
- git diff --check

The local TeamClu collision between the https-github-com-dif and https-github-com-dif-2 worktrees was migrated during verification.