### PR TITLE
fix(terminal): a link under Cmd+click actually opens

### DIFF
--- a/Sources/Core/TerminalLinkPolicy.swift
+++ b/Sources/Core/TerminalLinkPolicy.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Where a link action's target came from.
+enum TerminalLinkOrigin: Equatable {
+    /// A URL matched in the visible grid text. What the user clicked is exactly
+    /// what will open, so the click itself is the consent.
+    case visibleText
+
+    /// An OSC 8 hyperlink. The producer chooses the target independently of the
+    /// text it is drawn under, so the target is untrusted.
+    case hyperlink
+}
+
+/// What to do with a link target, before anything touches Launch Services.
+enum TerminalLinkDecision: Equatable {
+    /// Hand the URL to the default application.
+    case open(URL)
+
+    /// Show the target and let the user decide first.
+    case confirm(URL)
+
+    /// Refuse, and say why. Reserved for targets that are dangerous or
+    /// deceptive: the user needs to know the click was seen and declined.
+    case deny(String)
+
+    /// Nothing to open, and nothing worth saying.
+    case ignore
+}
+
+/// Decides whether a link action from libghostty may open, and what exactly it
+/// would open.
+///
+/// Kept free of AppKit so the rules are unit-testable; `TerminalLinkOpener`
+/// carries out the verdict.
+enum TerminalLinkPolicy {
+    static func decide(origin: TerminalLinkOrigin, raw: String) -> TerminalLinkDecision {
+        switch origin {
+        case .hyperlink:
+            return decision(forUntrusted: raw)
+
+        case .visibleText:
+            return decision(forVisibleText: raw)
+        }
+    }
+
+    /// An OSC 8 target is producer-controlled, so it goes through the same
+    /// allow/confirm/deny policy Ghostty's own macOS app applies.
+    private static func decision(forUntrusted raw: String) -> TerminalLinkDecision {
+        switch UntrustedURL(raw).decision {
+        case .allow(let url):
+            return .open(url)
+
+        case .confirm(let url):
+            return .confirm(url)
+
+        case .deny(let reason):
+            return .deny(reason.message)
+        }
+    }
+
+    /// A URL-shaped token, or a path libghostty already resolved against the
+    /// pane's working directory. It does that resolution before it sends the
+    /// action, so a scheme-less target here is a path and never a relative
+    /// reference.
+    private static func decision(forVisibleText raw: String) -> TerminalLinkDecision {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .ignore }
+
+        if let url = URL(string: trimmed), let scheme = url.scheme, !scheme.isEmpty {
+            // `file:` is the one shape a visible target can still lie about: the
+            // path may name an executable, and Launch Services will run it.
+            // Every other scheme goes straight out — the user pointed at that
+            // exact text and pressed the modifier.
+            return url.isFileURL ? visibleFileDecision(for: url.absoluteString) : .open(url)
+        }
+
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        // libghostty resolves a relative path against the pane's working
+        // directory before it sends the action, and only when the file is
+        // actually there. One that is still relative names nothing we can
+        // reach, and clicking a stale path is a no-op in every other terminal.
+        guard expanded.hasPrefix("/") else { return .ignore }
+        return visibleFileDecision(for: URL(filePath: expanded).absoluteString)
+    }
+
+    private static func visibleFileDecision(for urlString: String) -> TerminalLinkDecision {
+        switch UntrustedURL(urlString).decision {
+        case .allow(let url):
+            return .open(url)
+
+        case .confirm(let url):
+            return .confirm(url)
+
+        case .deny(let reason):
+            // A path that merely does not exist is not worth an alert — the
+            // output scrolled, or the click missed the token. A path that could
+            // *execute* is the exception: staying silent there reads as a
+            // broken menu rather than as a refusal.
+            return reason == .unsafeFile ? .deny(reason.message) : .ignore
+        }
+    }
+}

--- a/Sources/Core/UntrustedURL.swift
+++ b/Sources/Core/UntrustedURL.swift
@@ -1,0 +1,266 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// A URL supplied by a source that should not be allowed to dispatch directly
+/// to the operating system, such as terminal output.
+///
+/// Ported from Ghostty's macOS apprt (`macos/Sources/Helpers/UntrustedURL.swift`),
+/// which is the reference implementation for the same policy: the terminal pane
+/// links through the same core, so it must apply the same rules.
+struct UntrustedURL: Equatable {
+    enum DenialReason: Equatable {
+        case malformedURL
+        case unsafeCharacters
+        case invalidWebURL
+        case inaccessibleFile
+        case unsafeFile
+
+        var message: String {
+            switch self {
+            case .malformedURL:
+                return "The target is not an absolute URL with a scheme."
+            case .unsafeCharacters:
+                return "The target contains invisible or line-breaking characters."
+            case .invalidWebURL:
+                return "The web target does not contain a valid host."
+            case .inaccessibleFile:
+                return "The local target does not exist or is not a regular file or directory."
+            case .unsafeFile:
+                return "Opening this local target could execute code."
+            }
+        }
+    }
+
+    enum Decision: Equatable {
+        /// Open schemes with non-executing, well-understood behavior directly.
+        case allow(URL)
+
+        /// Ask before dispatching a custom scheme to its registered handler.
+        case confirm(URL)
+
+        /// Never dispatch malformed targets or executable local files.
+        case deny(DenialReason)
+    }
+
+    let string: String
+
+    init(_ string: String) {
+        self.string = string
+    }
+
+    var decision: Decision {
+        guard !string.isEmpty else { return .deny(.malformedURL) }
+
+        // Foundation accepts many Unicode control and formatting characters in
+        // a URL. UI frameworks can render those same characters as line breaks,
+        // zero-width text, or bidirectional overrides, so reject them before
+        // parsing changes their representation.
+        guard !string.unicodeScalars.contains(where: Self.isUnsafeCharacter) else {
+            return .deny(.unsafeCharacters)
+        }
+
+        // URL(string:) also accepts relative references. An untrusted target
+        // must include an explicit scheme so it cannot be reinterpreted as a
+        // local path by a later layer.
+        guard
+            let url = URL(string: string),
+            let scheme = url.scheme?.lowercased(),
+            !scheme.isEmpty
+        else {
+            return .deny(.malformedURL)
+        }
+
+        switch scheme {
+        case "http", "https":
+            // Reject values such as "https:relative". They have a scheme, but
+            // no authority, and different consumers may resolve them against a
+            // base URL differently.
+            guard let host = url.host, !host.isEmpty else {
+                return .deny(.invalidWebURL)
+            }
+            return .allow(url)
+
+        case "mailto":
+            // URLComponents places the address portion of a mailto URL in the
+            // path. Require one so a bare "mailto:" cannot dispatch an empty
+            // request to the user's mail application.
+            guard
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                !components.path.isEmpty
+            else {
+                return .deny(.malformedURL)
+            }
+            return .allow(url)
+
+        case "file":
+            return fileDecision(for: url)
+
+        default:
+            // A custom scheme can invoke any application registered with
+            // Launch Services. The caller must show the target and handler
+            // before allowing that dispatch.
+            return .confirm(url)
+        }
+    }
+
+    /// A single-line representation of the effective target. Paths are
+    /// standardized before display so traversal and repeated separators cannot
+    /// cause the visible and opened targets to differ.
+    var displayString: String {
+        let normalized: String
+        if let url = URL(string: string), url.scheme != nil {
+            // File URLs are standardized exactly as they are before opening,
+            // including symlink resolution. Keep non-file URLs byte-for-byte
+            // equivalent because repeated separators can be meaningful to a
+            // web or custom-scheme handler.
+            normalized = url.isFileURL
+                ? url.standardizedFileURL.resolvingSymlinksInPath().path
+                : string
+        } else {
+            // Scheme-less values are never allowed to open, but they still
+            // appear in the blocked-target UI. Standardizing them prevents
+            // slash padding and dot traversal from hiding the effective path.
+            normalized = URL(filePath: string).standardizedFileURL.path
+        }
+
+        // Escaping happens after normalization so any unsafe scalar that
+        // remains is visible as text and cannot create a second display line.
+        var result = String()
+        result.reserveCapacity(normalized.count)
+        for scalar in normalized.unicodeScalars {
+            if Self.isUnsafeCharacter(scalar) {
+                result += "\\u{\(String(scalar.value, radix: 16, uppercase: true))}"
+            } else {
+                result.unicodeScalars.append(scalar)
+            }
+        }
+
+        return result
+    }
+}
+
+private extension UntrustedURL {
+    func fileDecision(for url: URL) -> Decision {
+        // Only local file URLs are meaningful here. Queries and fragments do
+        // not identify part of a filesystem object and may be interpreted
+        // inconsistently by Launch Services handlers.
+        guard url.isFileURL, url.query == nil, url.fragment == nil else {
+            return .deny(.malformedURL)
+        }
+
+        // An empty host and localhost both refer to this machine. Do not allow
+        // file URLs that name a remote host and could trigger network access.
+        if let host = url.host,
+           !host.isEmpty,
+           host.caseInsensitiveCompare("localhost") != .orderedSame {
+            return .deny(.malformedURL)
+        }
+
+        // Classify the effective object, not the spelling supplied by terminal
+        // output. This collapses dot traversal and prevents a harmless-looking
+        // symlink name from hiding an executable target.
+        let canonicalURL = url.standardizedFileURL.resolvingSymlinksInPath()
+        let resourceValues: URLResourceValues
+        do {
+            // Reading all relevant resource keys together also proves that the
+            // canonical target exists and is accessible.
+            resourceValues = try canonicalURL.resourceValues(forKeys: [
+                .contentTypeKey,
+                .isDirectoryKey,
+                .isExecutableKey,
+                .isRegularFileKey,
+            ])
+        } catch {
+            return .deny(.inaccessibleFile)
+        }
+
+        // Exclude devices, sockets, and other special filesystem objects. A
+        // directory is safe to reveal in Finder unless its extension or UTI
+        // identifies it as an application bundle.
+        guard resourceValues.isDirectory == true || resourceValues.isRegularFile == true else {
+            return .deny(.inaccessibleFile)
+        }
+        guard !Self.isUnsafeFile(canonicalURL, resourceValues: resourceValues) else {
+            return .deny(.unsafeFile)
+        }
+
+        return .allow(canonicalURL)
+    }
+
+    static func isUnsafeFile(
+        _ url: URL,
+        resourceValues: URLResourceValues
+    ) -> Bool {
+        // Launch Services uses extensions when choosing a handler. Block known
+        // executable containers even when their POSIX executable bit is clear.
+        if unsafePathExtensions.contains(url.pathExtension.lowercased()) {
+            return true
+        }
+
+        // UTIs cover files whose extension is missing or intentionally
+        // misleading. Use broad system-declared types so subclasses such as
+        // shell scripts and application bundles are included automatically.
+        if let contentType = resourceValues.contentType,
+           unsafeContentTypes.contains(where: { contentType.conforms(to: $0) }) {
+            return true
+        }
+
+        // Finally, reject any regular file the filesystem marks executable,
+        // regardless of its name or detected content type.
+        return resourceValues.isDirectory != true && resourceValues.isExecutable == true
+    }
+
+    static func isUnsafeCharacter(_ scalar: Unicode.Scalar) -> Bool {
+        switch scalar.value {
+        // C0/C1 controls include CR, LF, NEL, and other non-printing bytes.
+        case 0x00...0x1F, 0x7F...0x9F:
+            return true
+
+        // Directional marks and zero-width characters can reorder or conceal
+        // portions of the target without changing what the handler receives.
+        case 0x061C, 0x200B...0x200F, 0x202A...0x202E, 0x2066...0x2069:
+            return true
+
+        // Unicode line/paragraph separators create additional visual lines in
+        // AppKit text even though OSC accepts their UTF-8 bytes.
+        case 0x2028...0x2029:
+            return true
+
+        // Word Joiner and BOM are invisible formatting characters that can be
+        // used as padding or to disguise otherwise identical-looking targets.
+        case 0x2060, 0xFEFF:
+            return true
+
+        default:
+            return false
+        }
+    }
+
+    // Keep the large policy tables after the behavior so the primary type and
+    // its decision flow remain easy to scan.
+    static let unsafePathExtensions: Set<String> = [
+        "action",
+        "app",
+        "applescript",
+        "class",
+        "command",
+        "desktop",
+        "inetloc",
+        "jar",
+        "mobileconfig",
+        "mpkg",
+        "pkg",
+        "scpt",
+        "terminal",
+        "tool",
+        "url",
+        "webloc",
+        "workflow",
+    ]
+
+    static let unsafeContentTypes: [UTType] = [
+        .application,
+        .executable,
+        .script,
+    ]
+}

--- a/Sources/Terminal/GhosttyBridge.swift
+++ b/Sources/Terminal/GhosttyBridge.swift
@@ -423,6 +423,32 @@ class GhosttyBridge {
             // libghostty flips conditional state then asks the embedder to reload.
             GhosttyBridge.shared.reloadConfig(target: target, soft: action.action.reload_config.soft)
             return true
+        case GHOSTTY_ACTION_OPEN_URL:
+            // Cmd+click on a link. OSC 8 targets are producer-controlled and get
+            // the strict policy; a URL matched in the grid is what the user
+            // pointed at, so it opens directly.
+            let open = action.action.open_url
+            guard let raw = decode(open.url, count: Int(open.len)) else { return true }
+            let origin: TerminalLinkOrigin = open.kind == GHOSTTY_ACTION_OPEN_URL_KIND_OSC8
+                ? .hyperlink
+                : .visibleText
+            return TerminalLinkOpener.handle(origin: origin, raw: raw)
+        case GHOSTTY_ACTION_MOUSE_SHAPE:
+            // Drives the cursor: a pointer over a link, a resize arrow in a
+            // mouse-tracking TUI. Without this the pane always shows an arrow,
+            // so a linkable URL looks like plain text.
+            guard let view = station(for: target)?.view else { return true }
+            let shape = action.action.mouse_shape
+            DispatchQueue.main.async { view.setCursorShape(shape) }
+            return true
+        case GHOSTTY_ACTION_MOUSE_OVER_LINK:
+            // Only sent while the link modifier is held, i.e. exactly when the
+            // pane should offer to open what is under the pointer.
+            guard let view = station(for: target)?.view else { return true }
+            let hover = action.action.mouse_over_link
+            let url = decode(hover.url, count: Int(hover.len))
+            DispatchQueue.main.async { view.hoverURL = url }
+            return true
         case GHOSTTY_ACTION_DESKTOP_NOTIFICATION:
             return true
         case GHOSTTY_ACTION_CLOSE_ALL_WINDOWS,
@@ -436,6 +462,15 @@ class GhosttyBridge {
         default:
             return false
         }
+    }
+
+    /// Copy a C string that libghostty passes as pointer + byte length. The
+    /// buffers are not NUL-terminated, so the length is the only safe bound.
+    private static func decode(_ pointer: UnsafePointer<CChar>?, count: Int) -> String? {
+        guard let pointer, count > 0 else { return nil }
+        let bytes = UnsafeRawPointer(pointer).assumingMemoryBound(to: UInt8.self)
+        let text = String(decoding: UnsafeBufferPointer(start: bytes, count: count), as: UTF8.self)
+        return text.isEmpty ? nil : text
     }
 
     private static func readClipboard(userData: UnsafeMutableRawPointer?, clipboard: ghostty_clipboard_e, state: UnsafeMutableRawPointer?) -> Bool {

--- a/Sources/Terminal/GhosttyNSView.swift
+++ b/Sources/Terminal/GhosttyNSView.swift
@@ -22,6 +22,12 @@ class GhosttyNSView: NSView, NSTextInputClient {
     /// Tuple: (owner, repo, prNumber).
     var onRequestPRPreview: ((String, String, Int) -> Void)?
 
+    /// The link libghostty reports under the pointer, or nil when there is none.
+    /// Only sent while the link modifier is held, so this is set exactly when the
+    /// pane is offering to open what the pointer is on. The pane menu prefers it
+    /// over guessing a URL out of the text under the click.
+    var hoverURL: String?
+
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         wantsLayer = true
@@ -581,6 +587,69 @@ class GhosttyNSView: NSView, NSTextInputClient {
 
     // MARK: - Mouse
 
+    /// Latest cursor shape libghostty asked for. AppKit owns the real cursor
+    /// through cursor rects (see `resetCursorRects`), so a change has to
+    /// invalidate them — that is what makes the pointer appear the instant the
+    /// link modifier goes down, with no mouse movement needed.
+    private var cursorShape: ghostty_action_mouse_shape_e = GHOSTTY_MOUSE_SHAPE_DEFAULT
+
+    /// Called on the main thread when libghostty changes the mouse shape.
+    func setCursorShape(_ shape: ghostty_action_mouse_shape_e) {
+        guard shape.rawValue != cursorShape.rawValue else { return }
+        cursorShape = shape
+        window?.invalidateCursorRects(for: self)
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        // One rect covering the grid: Ghostty decides the shape cell by cell and
+        // reports it as an action, not as a region.
+        addCursorRect(bounds, cursor: Self.cursor(for: cursorShape))
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        Self.cursor(for: cursorShape).set()
+    }
+
+    /// Map Ghostty's pointer vocabulary onto the AppKit cursors that exist on
+    /// macOS 14. The zoom shapes have no NSCursor equivalent, so they stay an
+    /// arrow rather than inventing one.
+    private static func cursor(for shape: ghostty_action_mouse_shape_e) -> NSCursor {
+        switch shape.rawValue {
+        case GHOSTTY_MOUSE_SHAPE_TEXT.rawValue, GHOSTTY_MOUSE_SHAPE_VERTICAL_TEXT.rawValue:
+            return .iBeam
+        case GHOSTTY_MOUSE_SHAPE_POINTER.rawValue, GHOSTTY_MOUSE_SHAPE_ALIAS.rawValue:
+            return .pointingHand
+        case GHOSTTY_MOUSE_SHAPE_CONTEXT_MENU.rawValue:
+            return .contextualMenu
+        case GHOSTTY_MOUSE_SHAPE_HELP.rawValue:
+            return .arrow
+        case GHOSTTY_MOUSE_SHAPE_CROSSHAIR.rawValue, GHOSTTY_MOUSE_SHAPE_CELL.rawValue:
+            return .crosshair
+        case GHOSTTY_MOUSE_SHAPE_NOT_ALLOWED.rawValue, GHOSTTY_MOUSE_SHAPE_NO_DROP.rawValue:
+            return .operationNotAllowed
+        case GHOSTTY_MOUSE_SHAPE_GRAB.rawValue, GHOSTTY_MOUSE_SHAPE_ALL_SCROLL.rawValue,
+             GHOSTTY_MOUSE_SHAPE_MOVE.rawValue:
+            return .openHand
+        case GHOSTTY_MOUSE_SHAPE_GRABBING.rawValue:
+            return .closedHand
+        case GHOSTTY_MOUSE_SHAPE_N_RESIZE.rawValue, GHOSTTY_MOUSE_SHAPE_ROW_RESIZE.rawValue:
+            return .resizeUp
+        case GHOSTTY_MOUSE_SHAPE_S_RESIZE.rawValue:
+            return .resizeDown
+        case GHOSTTY_MOUSE_SHAPE_E_RESIZE.rawValue, GHOSTTY_MOUSE_SHAPE_COL_RESIZE.rawValue:
+            return .resizeRight
+        case GHOSTTY_MOUSE_SHAPE_W_RESIZE.rawValue:
+            return .resizeLeft
+        case GHOSTTY_MOUSE_SHAPE_EW_RESIZE.rawValue:
+            return .resizeLeftRight
+        case GHOSTTY_MOUSE_SHAPE_NS_RESIZE.rawValue:
+            return .resizeUpDown
+        default:
+            return .arrow
+        }
+    }
+
     /// Text of the most recent terminal selection, captured on `mouseUp`. The
     /// live selection is often cleared by the time our `rightMouseDown` runs (the
     /// right-button event delivery clears it before we can read it), so we snapshot
@@ -665,6 +734,10 @@ class GhosttyNSView: NSView, NSTextInputClient {
     /// GitHub PR URL captured from the same row, checked after `pendingPreviewURL`
     /// (a PR link is not a file so path resolution won't return it).
     private var pendingPRPreview: (owner: String, repo: String, number: Int)?
+    /// Web link the click resolved to, offered as "Open Link in Browser". A PR
+    /// link gets this *and* the preview item: reading it here and reading it on
+    /// GitHub are separate things to want.
+    private var pendingWebLink: URL?
     /// Several files the click could have meant, offered as a submenu because
     /// nothing in the click says which. Two ways to get here: one line naming
     /// several files that all exist, or a bare name matching several files in
@@ -708,6 +781,10 @@ class GhosttyNSView: NSView, NSTextInputClient {
         } else {
             self.pendingPRPreview = nil
         }
+
+        // A link is its own kind of target: it may sit on a line that also names
+        // files, and opening it is not the same act as previewing one.
+        self.pendingWebLink = webLinkAtClick(selection: selection, tokens: tokens)
         // Focus the right-clicked pane so menu actions target it, then show
         // our pane context menu (split/close/copy/paste).
         if window?.firstResponder !== self {
@@ -715,6 +792,45 @@ class GhosttyNSView: NSView, NSTextInputClient {
         }
         NSMenu.popUpContextMenu(makePaneContextMenu(), with: event, for: self)
     }
+
+    /// Web link under the click, for the menu's link items. An explicit
+    /// selection outranks everything (the user already said what they meant),
+    /// then the link libghostty reported under the pointer, then the nearest
+    /// URL-shaped token.
+    private func webLinkAtClick(selection: String?, tokens: [String]) -> URL? {
+        if let selection, let url = Self.firstWebLink(in: [selection]) { return url }
+        if let hoverURL, let url = URL(string: hoverURL), url.scheme != nil { return url }
+        return Self.firstWebLink(in: tokens)
+    }
+
+    /// The first web link among `candidates`, in the order given — which for a
+    /// click is nearest-first.
+    ///
+    /// Matched with a regex instead of parsing the whole token: terminal output
+    /// frames a URL with whatever the surrounding prose used — `<https://…>`,
+    /// `[#1394](https://…)`, `见 https://…).` — so the token boundary is not the
+    /// URL's boundary. Only http(s) counts: this backs an "open in browser"
+    /// item, and a bare host or a path is not that.
+    static func firstWebLink(in candidates: [String]) -> URL? {
+        for candidate in candidates {
+            let range = NSRange(candidate.startIndex..., in: candidate)
+            guard let match = webLinkRegex?.firstMatch(in: candidate, range: range),
+                  let matchRange = Range(match.range, in: candidate) else { continue }
+            let found = candidate[matchRange]
+                .trimmingCharacters(in: .punctuationCharacters)
+            guard let url = URL(string: found), url.host?.isEmpty == false else { continue }
+            return url
+        }
+        return nil
+    }
+
+    /// Stops at whitespace, at the bracket and quote characters terminal output
+    /// uses to frame a link, and at `)` so a markdown link's tail does not end up
+    /// inside the URL.
+    private static let webLinkRegex = try? NSRegularExpression(
+        pattern: #"https?://[^\s<>"'`\[\]()]+"#,
+        options: .caseInsensitive
+    )
 
     override func rightMouseUp(with event: NSEvent) {
         // Consumed by the context menu in rightMouseDown; nothing to forward.
@@ -752,6 +868,21 @@ class GhosttyNSView: NSView, NSTextInputClient {
             menu.addItem(.separator())
         } else if !pendingPreviewChoices.isEmpty {
             menu.addItem(makeChoicePreviewItem(matches: pendingPreviewChoices))
+            menu.addItem(.separator())
+        }
+
+        if let link = pendingWebLink {
+            let openItem = NSMenuItem(title: "Open Link in Browser", action: #selector(contextOpenLink), keyEquivalent: "")
+            openItem.target = self
+            openItem.representedObject = link
+            openItem.toolTip = link.absoluteString
+            menu.addItem(openItem)
+
+            let copyLinkItem = NSMenuItem(title: "Copy Link", action: #selector(contextCopyLink), keyEquivalent: "")
+            copyLinkItem.target = self
+            copyLinkItem.representedObject = link
+            menu.addItem(copyLinkItem)
+
             menu.addItem(.separator())
         }
 
@@ -1155,6 +1286,18 @@ class GhosttyNSView: NSView, NSTextInputClient {
     @objc private func contextPRPreview(_ sender: NSMenuItem) {
         guard let pr = pendingPRPreview else { return }
         onRequestPRPreview?(pr.owner, pr.repo, pr.number)
+    }
+
+    @objc private func contextOpenLink(_ sender: NSMenuItem) {
+        guard let url = sender.representedObject as? URL else { return }
+        TerminalLinkOpener.open(url)
+    }
+
+    @objc private func contextCopyLink(_ sender: NSMenuItem) {
+        guard let url = sender.representedObject as? URL else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(url.absoluteString, forType: .string)
     }
 
     @objc private func contextSplitHorizontal() { onRequestSplit?(.horizontal) }

--- a/Sources/Terminal/TerminalLinkOpener.swift
+++ b/Sources/Terminal/TerminalLinkOpener.swift
@@ -1,0 +1,72 @@
+import AppKit
+
+/// Carries out the verdict `TerminalLinkPolicy` reaches for a link action, so
+/// nothing else in the app has to re-implement the safety rules or the modal
+/// confirmations behind them.
+enum TerminalLinkOpener {
+    /// Handle the link action libghostty just reported.
+    ///
+    /// Always reported as handled. Returning false makes libghostty fall back to
+    /// its own unrestricted `open` spawn — and on macOS that fallback fails
+    /// closed for OSC 8 targets (`ghostty/src/os/open.zig`), which is how those
+    /// links used to sit there silently doing nothing.
+    @discardableResult
+    static func handle(origin: TerminalLinkOrigin, raw: String) -> Bool {
+        let decision = TerminalLinkPolicy.decide(origin: origin, raw: raw)
+        // Actions arrive on libghostty's thread; NSWorkspace and NSAlert are
+        // main-thread only.
+        DispatchQueue.main.async { perform(decision) }
+        return true
+    }
+
+    /// Open an already-parsed URL the user pointed at, e.g. from the pane's
+    /// context menu.
+    static func open(_ url: URL) {
+        DispatchQueue.main.async {
+            perform(TerminalLinkPolicy.decide(origin: .visibleText, raw: url.absoluteString))
+        }
+    }
+
+    private static func perform(_ decision: TerminalLinkDecision) {
+        switch decision {
+        case .open(let url):
+            guard !NSWorkspace.shared.open(url) else { return }
+            alert(
+                title: "Could not open link",
+                detail: UntrustedURL(url.absoluteString).displayString,
+                buttons: ["OK"]
+            )
+
+        case .confirm(let url):
+            let response = alert(
+                title: "Open this link?",
+                detail: """
+                    \(UntrustedURL(url.absoluteString).displayString)
+
+                    This hands the link to whichever application claims the "\(url.scheme ?? "")" scheme.
+                    """,
+                buttons: ["Open", "Cancel"]
+            )
+            if response == .alertFirstButtonReturn {
+                NSWorkspace.shared.open(url)
+            }
+
+        case .deny(let reason):
+            alert(title: "Link blocked", detail: reason, buttons: ["OK"])
+
+        case .ignore:
+            break
+        }
+    }
+
+    @discardableResult
+    private static func alert(title: String, detail: String, buttons: [String]) -> NSApplication.ModalResponse {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = detail
+        for button in buttons {
+            alert.addButton(withTitle: button)
+        }
+        return alert.runModal()
+    }
+}

--- a/Tests/TerminalLinkPolicyTests.swift
+++ b/Tests/TerminalLinkPolicyTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import seahelm
+
+/// Covers the rules behind "Cmd+click a link in the terminal": what may open,
+/// what has to ask first, and what is refused outright.
+final class TerminalLinkPolicyTests: XCTestCase {
+
+    // MARK: - Visible text (a URL matched in the grid)
+
+    func testVisibleHTTPSOpens() {
+        XCTAssertEqual(
+            TerminalLinkPolicy.decide(origin: .visibleText, raw: "https://github.com/owner/repo/pull/1394"),
+            .open(URL(string: "https://github.com/owner/repo/pull/1394")!)
+        )
+    }
+
+    func testVisibleMailtoOpens() {
+        let decision = TerminalLinkPolicy.decide(origin: .visibleText, raw: "mailto:dev@example.com")
+        guard case .open(let url) = decision else { return XCTFail("expected open, got \(decision)") }
+        XCTAssertEqual(url.scheme, "mailto")
+    }
+
+    func testVisibleTextToleratesSurroundingWhitespace() {
+        XCTAssertEqual(
+            TerminalLinkPolicy.decide(origin: .visibleText, raw: "  https://example.com  "),
+            .open(URL(string: "https://example.com")!)
+        )
+    }
+
+    func testVisibleEmptyIsIgnored() {
+        XCTAssertEqual(TerminalLinkPolicy.decide(origin: .visibleText, raw: "   "), .ignore)
+    }
+
+    /// The default link regex also matches bare paths, so a `.rs` file printed
+    /// by a tool is a link too. libghostty resolves those against the pane's
+    /// working directory first, and one that no longer resolves must not put a
+    /// modal alert in front of the pane.
+    func testVisibleStalePathIsIgnoredQuietly() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-gone-\(UUID().uuidString).rs")
+        XCTAssertEqual(TerminalLinkPolicy.decide(origin: .visibleText, raw: missing.path), .ignore)
+    }
+
+    func testVisibleUnresolvedRelativePathIsIgnoredQuietly() {
+        XCTAssertEqual(
+            TerminalLinkPolicy.decide(origin: .visibleText, raw: "apps/desktop/src/main.rs"),
+            .ignore
+        )
+    }
+
+    /// libghostty resolves a relative path against the pane's cwd before it
+    /// sends the action, so whatever arrives is already absolute.
+    func testVisibleExistingFileOpens() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-link-\(UUID().uuidString).txt")
+        try "hello".write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        guard case .open(let url) = TerminalLinkPolicy.decide(origin: .visibleText, raw: file.path) else {
+            return XCTFail("expected open")
+        }
+        XCTAssertEqual(url.path, file.resolvingSymlinksInPath().path)
+    }
+
+    /// The one visible-text shape that can still execute something.
+    func testVisibleExecutableFileIsRefused() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-link-\(UUID().uuidString).command")
+        try "#!/bin/sh\necho hi\n".write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        guard case .deny = TerminalLinkPolicy.decide(origin: .visibleText, raw: file.path) else {
+            return XCTFail("expected deny for a .command file")
+        }
+    }
+
+    // MARK: - OSC 8 hyperlinks
+
+    func testHyperlinkHTTPSOpens() {
+        XCTAssertEqual(
+            TerminalLinkPolicy.decide(origin: .hyperlink, raw: "https://example.com/a?b=c#d"),
+            .open(URL(string: "https://example.com/a?b=c#d")!)
+        )
+    }
+
+    /// OSC 8 can point anywhere regardless of the text it is drawn under, so a
+    /// malformed target is refused rather than guessed at.
+    func testHyperlinkSchemeLessIsRefused() {
+        guard case .deny = TerminalLinkPolicy.decide(origin: .hyperlink, raw: "example.com/x") else {
+            return XCTFail("expected deny")
+        }
+    }
+
+    func testHyperlinkUnknownSchemeAsksFirst() {
+        guard case .confirm(let url) = TerminalLinkPolicy.decide(origin: .hyperlink, raw: "vscode://file/tmp/x") else {
+            return XCTFail("expected confirm for a custom scheme")
+        }
+        XCTAssertEqual(url.scheme, "vscode")
+    }
+
+    func testHyperlinkExecutableFileIsRefused() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("seahelm-payload-\(UUID().uuidString).command")
+        try "#!/bin/sh\necho pwned\n".write(to: file, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        let target = URL(fileURLWithPath: file.path).absoluteString
+        guard case .deny(let reason) = TerminalLinkPolicy.decide(origin: .hyperlink, raw: target) else {
+            return XCTFail("expected deny for an executable file target")
+        }
+        XCTAssertFalse(reason.isEmpty)
+    }
+
+    func testHyperlinkBidiOverrideIsRefused() {
+        guard case .deny = TerminalLinkPolicy.decide(origin: .hyperlink, raw: "https://example.com/\u{202E}gpj.exe") else {
+            return XCTFail("expected deny for a target with a bidi override")
+        }
+    }
+
+    // MARK: - Context-menu link detection
+
+    func testFirstWebLinkTrimsProseWrappers() {
+        XCTAssertEqual(
+            GhosttyNSView.firstWebLink(in: ["[#1394](https://github.com/o/r/pull/1394)"])?.absoluteString,
+            "https://github.com/o/r/pull/1394"
+        )
+        XCTAssertEqual(
+            GhosttyNSView.firstWebLink(in: ["<https://example.com/x>"])?.absoluteString,
+            "https://example.com/x"
+        )
+        XCTAssertEqual(
+            GhosttyNSView.firstWebLink(in: ["https://example.com/x)."])?.absoluteString,
+            "https://example.com/x"
+        )
+    }
+
+    func testFirstWebLinkSkipsNonLinksAndKeepsOrderOfTheRest() {
+        XCTAssertEqual(
+            GhosttyNSView.firstWebLink(in: ["apps/desktop/src/main.rs", "see", "https://example.com/a", "https://other.example/b"])?.absoluteString,
+            "https://example.com/a"
+        )
+    }
+
+    func testFirstWebLinkRejectsOtherSchemes() {
+        XCTAssertNil(GhosttyNSView.firstWebLink(in: ["mailto:dev@example.com"]))
+        XCTAssertNil(GhosttyNSView.firstWebLink(in: ["file:///tmp/x.txt"]))
+        XCTAssertNil(GhosttyNSView.firstWebLink(in: ["github.com/owner/repo/pull/1"]))
+    }
+}

--- a/seahelm.xcodeproj/project.pbxproj
+++ b/seahelm.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		07CF15A7463B32D0FA558782 /* CoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18A2E8441934257374C57B2 /* CoreTests.swift */; };
 		07D61705F36F11CF9B8CF316 /* ProcessRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA00190FE1317EED4BDFA0D /* ProcessRunner.swift */; };
 		0828C3010E294CFD37CFFE70 /* EventHubTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911314F4B91E512511E3FC21 /* EventHubTests.swift */; };
+		085D40690A4B00AC13036C2D /* TerminalLinkOpener.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5F2FDB1192CD6A1E031DD1 /* TerminalLinkOpener.swift */; };
 		08C794DACF3DFA5DA3086EC5 /* FirstMateActionPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE109A6863FFA98DF4B192C7 /* FirstMateActionPayloadTests.swift */; };
 		09951F094DE67BE6FBB9DF05 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF1E9300BD737DC3B94C1AF3 /* OnboardingTests.swift */; };
 		0ACBFB116D839F9A3BC9DD7C /* TelegramConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78FEF7EF31BF2E3DD44AD5F /* TelegramConfig.swift */; };
@@ -138,6 +139,7 @@
 		4DC9B67D9DB3EE1C96C65503 /* HostGatewayAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C8F047AD222C44B3E5DD1A /* HostGatewayAuthTests.swift */; };
 		4DE34773F233CE9EB7C2B854 /* GlobalKeymap.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86D2BBA33C13BFA224F58D4 /* GlobalKeymap.swift */; };
 		4DEB41D0F7E47035706006E2 /* HostGatewayConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB1ED030DFAE92B65E7E8D1 /* HostGatewayConfig.swift */; };
+		500E2F884A567F587F0E66FA /* UntrustedURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24FA210B040689FDAD15DD71 /* UntrustedURL.swift */; };
 		506F03CBC8DB229C2F20E98F /* EventHub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA02A8188B616E0F6F413FC1 /* EventHub.swift */; };
 		506FABB5322B42EDC75221F8 /* HostGatewayFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0FFC00EE90A3DAECD6396FC /* HostGatewayFrame.swift */; };
 		50C0E2D95435EA0741D4BFE4 /* HostGatewayFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC709BF6C114756E9794146 /* HostGatewayFrameTests.swift */; };
@@ -170,6 +172,7 @@
 		5D6CF18A7384A74B640EFAAC /* WorktreeStatusAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4775959C72857610AC1F12DC /* WorktreeStatusAggregator.swift */; };
 		5E77C3E6AA55F970F5DD877E /* HostGatewayDecisions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399B19A39BB25DDA3D401B60 /* HostGatewayDecisions.swift */; };
 		5F16B6F4A4D85F5E6F515A4E /* WebhookSuggestEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54322E1FB43B65F94D1AAC20 /* WebhookSuggestEventTests.swift */; };
+		5F570733876E3D98C419587D /* TerminalLinkPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B4569535EF5A858CD9D1E70 /* TerminalLinkPolicy.swift */; };
 		5F7CEFC99E339F7621D6509A /* ZmxLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063BC4CAFB28A7B7DEA60474 /* ZmxLocatorTests.swift */; };
 		5FC3252BFA86D110BFDCF34E /* WorktreeReturnRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DA8AD6F8AC7CDE47F86245A /* WorktreeReturnRunnerTests.swift */; };
 		5FC647D840678AE10E2FF5BC /* ShortcutHintBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E664A1C5B1466EF19108D6B8 /* ShortcutHintBar.swift */; };
@@ -234,6 +237,7 @@
 		7D04C2A61105F5AD7BD48E3F /* CommandSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7018E7ABB432ABCFCB9723F /* CommandSpec.swift */; };
 		7D09CC05B794C0D59CA4146B /* WindowChromeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105E0FAF9CFF482771DB785 /* WindowChromeController.swift */; };
 		7DD2666A7F2FE0E895A38F8B /* WorktreeTaskStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF2F9EA56DB31E6555203E06 /* WorktreeTaskStoreTests.swift */; };
+		7E4CF1EE17A0339C8570B80F /* TerminalLinkPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964F34F7086821A02793C06D /* TerminalLinkPolicyTests.swift */; };
 		7E73C1FAA15054E71BDFDEF8 /* GitHubReturnPRClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E584B1D165D21C28521196B /* GitHubReturnPRClient.swift */; };
 		7ED2875B97C74F9DF0DF3F79 /* PaneWorkingDirectory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5DCCDD64708BEB08D20C0A /* PaneWorkingDirectory.swift */; };
 		7F9546C174F5D5E52457F7A8 /* MarkdownRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7558A8D72AFCE237E39E401 /* MarkdownRendererTests.swift */; };
@@ -563,6 +567,7 @@
 		23B112FAA14CF6135A4F7202 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		249CA31487C12997605E1512 /* TaskProgressParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskProgressParserTests.swift; sourceTree = "<group>"; };
 		24BD97D45539400A4E3160E2 /* FirstMateConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstMateConfig.swift; sourceTree = "<group>"; };
+		24FA210B040689FDAD15DD71 /* UntrustedURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UntrustedURL.swift; sourceTree = "<group>"; };
 		25346A39BB85A9E74B496865 /* EditLayoutContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLayoutContainerView.swift; sourceTree = "<group>"; };
 		256BB7C447703DD227B69806 /* IntegrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationCoordinator.swift; sourceTree = "<group>"; };
 		258A1C3E5F11466A79C1CAF3 /* ClaudeUsageSummaryProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeUsageSummaryProvider.swift; sourceTree = "<group>"; };
@@ -780,6 +785,7 @@
 		95C6B4297D134649B185BC65 /* DividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DividerView.swift; sourceTree = "<group>"; };
 		95F52B822BB29970B0615304 /* StackedWorktreeBaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackedWorktreeBaseTests.swift; sourceTree = "<group>"; };
 		9626FD6C7EE99EAEC76D6443 /* PRURLParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRURLParsingTests.swift; sourceTree = "<group>"; };
+		964F34F7086821A02793C06D /* TerminalLinkPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLinkPolicyTests.swift; sourceTree = "<group>"; };
 		968213FDE4B08CF2A98DB961 /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		97096F35E0C4B14D1874C672 /* WorktreeSnapshotterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeSnapshotterTests.swift; sourceTree = "<group>"; };
 		975413D32056A4CFFA39C32C /* HostGatewayVTFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayVTFrame.swift; sourceTree = "<group>"; };
@@ -789,6 +795,7 @@
 		999DBD13511B3A8C4F4D4B8E /* WorktreeAgentTypeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeAgentTypeStore.swift; sourceTree = "<group>"; };
 		99EAA5845DC0E1B3FD6DD1E8 /* CodexUsageSummaryProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexUsageSummaryProviderTests.swift; sourceTree = "<group>"; };
 		9A9E6A0A2CF3F54AA987F20A /* OSC133Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSC133Parser.swift; sourceTree = "<group>"; };
+		9B4569535EF5A858CD9D1E70 /* TerminalLinkPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLinkPolicy.swift; sourceTree = "<group>"; };
 		9B96BFA805FFD64725FFB924 /* NotificationHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHistory.swift; sourceTree = "<group>"; };
 		9D89A6016405AEDB17C3FB5E /* QRCodeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeRenderer.swift; sourceTree = "<group>"; };
 		9DA8AD6F8AC7CDE47F86245A /* WorktreeReturnRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeReturnRunnerTests.swift; sourceTree = "<group>"; };
@@ -988,6 +995,7 @@
 		FE32E46B1123B9F111F2E557 /* SelectedFilePathResolutionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedFilePathResolutionTests.swift; sourceTree = "<group>"; };
 		FEC6CEDF0BAE28FF326D89F9 /* SidebarHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderView.swift; sourceTree = "<group>"; };
 		FF44014C31BB9F7833218FB4 /* AgentRegistryTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRegistryTransitionTests.swift; sourceTree = "<group>"; };
+		FF5F2FDB1192CD6A1E031DD1 /* TerminalLinkOpener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLinkOpener.swift; sourceTree = "<group>"; };
 		FF616B03B16048B3C1157313 /* HostGatewayAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostGatewayAuth.swift; sourceTree = "<group>"; };
 		FF833BDB434AB8F30EE6D6AF /* OSCProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSCProgressTests.swift; sourceTree = "<group>"; };
 		FFBF763CE6B932E7040E0DF7 /* MailHTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailHTMLTests.swift; sourceTree = "<group>"; };
@@ -1137,7 +1145,9 @@
 				AFC635E261560E69EFA29FEE /* TelegramRule.swift */,
 				5C8C29ABAFC62F8A953F2CD9 /* TelegramRuleCoalescer.swift */,
 				3D90518E8BFCA59E2D344513 /* TerminalEnvironment.swift */,
+				9B4569535EF5A858CD9D1E70 /* TerminalLinkPolicy.swift */,
 				77ABED3BE7AAC378B4E6B068 /* TodoStore.swift */,
+				24FA210B040689FDAD15DD71 /* UntrustedURL.swift */,
 				D01D0EBCC80C1AA901CA8E5B /* VTEvent.swift */,
 				F0982B809334A31181947736 /* WatchFeed.swift */,
 				B07FF7C768D8C4871A88AA48 /* WorkspaceManager.swift */,
@@ -1580,6 +1590,7 @@
 				0BC6460413988FF775BDA1B3 /* TelegramRuleTests.swift */,
 				DCE458A11E72A34C3556092F /* TerminalCoordinatorTests.swift */,
 				472ACEFBD0F23747FC60EB0D /* TerminalHeaderViewTests.swift */,
+				964F34F7086821A02793C06D /* TerminalLinkPolicyTests.swift */,
 				3F67CBC84404085C3483C910 /* TestViewHelpers.swift */,
 				DBC2859D1D589D68F33F0552 /* TodoStoreTests.swift */,
 				574B7FE2D9B877BB71343689 /* UsageReadoutTests.swift */,
@@ -1660,6 +1671,7 @@
 				5D7FF8E6F2D2E5EC4963C627 /* SplitNode.swift */,
 				849C6707188E7E90997D691A /* SplitTree.swift */,
 				40CAD3E9929AC9E5E32EBA9F /* Station.swift */,
+				FF5F2FDB1192CD6A1E031DD1 /* TerminalLinkOpener.swift */,
 				B767FA4381095CD7B0F537CF /* ZmxSessionRecovery.swift */,
 			);
 			path = Terminal;
@@ -2143,6 +2155,7 @@
 				47229EE74F8F3BEA93AB0B6A /* TelegramRuleTests.swift in Sources */,
 				B2D3C5CCB2735F1895E271BE /* TerminalCoordinatorTests.swift in Sources */,
 				9C35BEC65A084B6F21FF11DB /* TerminalHeaderViewTests.swift in Sources */,
+				7E4CF1EE17A0339C8570B80F /* TerminalLinkPolicyTests.swift in Sources */,
 				FA7FE7F8722B6916762E68E3 /* TestViewHelpers.swift in Sources */,
 				62FF9B7688CD065BE7DEBF35 /* TodoStoreTests.swift in Sources */,
 				67534BADE19F84A44C2CE74E /* UsageReadoutTests.swift in Sources */,
@@ -2429,9 +2442,12 @@
 				0658FAE09BDFAD7932B01617 /* TerminalCoordinator.swift in Sources */,
 				913DBD2B1D15867351B0DEE0 /* TerminalEnvironment.swift in Sources */,
 				AD608FF60D293BA96BCB01B8 /* TerminalHeaderView.swift in Sources */,
+				085D40690A4B00AC13036C2D /* TerminalLinkOpener.swift in Sources */,
+				5F570733876E3D98C419587D /* TerminalLinkPolicy.swift in Sources */,
 				CBB8B4ECA774CBFE1EF1A070 /* Theme.swift in Sources */,
 				964D05E6C8C5D093CB6633E2 /* ThemedBackgroundView.swift in Sources */,
 				A3C6B5F047EBF420EA393C13 /* TodoStore.swift in Sources */,
+				500E2F884A567F587F0E66FA /* UntrustedURL.swift in Sources */,
 				53CB2A1C620681FD4477E378 /* UpdateBanner.swift in Sources */,
 				3228A013E381D520EE386C05 /* UpdateCoordinator.swift in Sources */,
 				2016934685236AC44DC4F54F /* UpdateDriver.swift in Sources */,


### PR DESCRIPTION
## What the user sees

Cmd+clicking a URL in a pane did nothing — including the `https://github.com/…/pull/1394` an agent prints at the end of a run. No pointer cursor, no feedback, no browser. OSC 8 hyperlinks (`ls --hyperlink`, several agent CLIs) were dead in every case.

## Why

`GhosttyBridge.handleAction` claimed `SET_TITLE`, `PWD`, `PROGRESS_REPORT`, `RELOAD_CONFIG` and the close/notification actions, and returned `false` for everything else — including the three that make a link a link:

- **`GHOSTTY_ACTION_OPEN_URL`** — unclaimed, so libghostty fell back to its own `open` spawn. On macOS that fallback *fails closed* for OSC 8 targets (`ghostty/src/os/open.zig` returns `error.UnsafeOSC8Link`), so those were silently inert by construction. Regex-matched URLs only "worked" when `spawn("open", …)` happened to succeed, with no error surfaced anywhere.
- **`GHOSTTY_ACTION_MOUSE_SHAPE`** — unclaimed, so the pane always showed an arrow. A linkable URL looked exactly like the text around it.
- **`GHOSTTY_ACTION_MOUSE_OVER_LINK`** — unclaimed, so the pane never knew what was under the pointer.

## The change

### `Sources/Core/TerminalLinkPolicy.swift` + `Sources/Core/UntrustedURL.swift` (new, no AppKit — unit-testable)

`UntrustedURL` is ported from Ghostty's own macOS apprt (`macos/Sources/Helpers/UntrustedURL.swift`), so the pane applies the same allow/confirm/deny policy the upstream app does: scheme allowlist, invisible/bidi character rejection, and file targets classified by their *canonical* object (a `.command`, or any executable-bit file, is never handed to Launch Services).

`TerminalLinkPolicy` turns one link action into one verdict:

| verdict | when |
| --- | --- |
| `open` | http(s)/mailto, an existing non-executable file, or any custom scheme coming from **visible text** |
| `confirm` | a custom scheme coming from an **OSC 8** target — its display text can differ from its destination, so the target is shown first |
| `deny` | an OSC 8 target that could execute, or one carrying invisible characters — and it says why |
| `ignore` | a path that no longer resolves: clicking a stale path is a no-op in every other terminal, and a modal for it would read as a bug |

That last one is why the two origins are distinguished at all. The default link regex also matches **bare paths**, and libghostty resolves a relative one against the pane's cwd *only when the file is there* — so a path that still arrives relative names nothing reachable.

### `Sources/Terminal/TerminalLinkOpener.swift` (new)

Carries the verdict out on the main thread. `handle` always reports the action as handled, because returning `false` is exactly what used to hand control back to the unrestricted fallback.

### `Sources/Terminal/GhosttyBridge.swift`

Claims the three actions, with its own pointer+length decoder (those buffers are not NUL-terminated). OSC 8 arrives as `.hyperlink`, everything else as `.visibleText`.

### `Sources/Terminal/GhosttyNSView.swift`

- Maps the mouse shape onto a cursor **rect**, so the pointer appears the instant Cmd goes down rather than on the next mouse move — `invalidateCursorRects` is what re-applies it while the pointer sits still.
- Remembers the hovered link and offers **Open Link in Browser** / **Copy Link** in the pane menu for the URL under the click, beside the existing Preview / Preview PR items. The URL is matched out of the clicked token with a regex, so terminal prose framing (`<https://…>`, `[#1394](https://…)`, `https://…).`) does not end up inside the target.

## Validation

- `xcodebuild -project seahelm.xcodeproj -scheme seahelm -destination 'platform=macOS' -only-testing:seahelmTests test` → **1973 tests, 0 failures** (2 skipped), including 16 new tests in `Tests/TerminalLinkPolicyTests.swift` covering both origins, all four verdicts, `.command`/executable refusal, bidi-override refusal, stale-path silence, and the prose wrappers terminal output puts around a URL.
- `ProcessProbeTests.testArgvIsStableWhenABufferIsReusedAcrossProcesses` is flaky in this environment; it fails identically on a clean `main` and passed in the final run.

Not covered by automation: the cursor and the menu need a live surface. Manual pass — Cmd+click a plain URL → browser; Cmd+click an OSC 8 link → browser; right-click a URL → Open Link in Browser; `Cmd+Shift`+click inside a mouse-capturing TUI (Shift is Ghostty's existing escape from mouse capture); a `file:///…/x.command` target → refused with a reason.
